### PR TITLE
docs: rewrite the README lede and correct the start-after constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ without their credentials or their bill, testing your own tooling against a
 listing that would otherwise cost money to enumerate every run, and pinning
 listing behaviour in regression tests.
 
+It also works as a **listing cache**. A listing you have already paid to produce
+can be served back through the same API your tools already speak: list the bucket
+once with swath, then point everything that would otherwise re-list it at the
+replay server instead — local speed, no per-request S3 charge, and no load on the
+real bucket. Two things to weigh first. It serves a **point-in-time snapshot**,
+not live bucket state, so it fits workloads that can tolerate a listing as fresh
+as its last capture. And it has **no authentication**, so it belongs inside a
+trust boundary you already control. The operational surface is still being
+smoothed — see the scope note below.
+
 Scope: path-style `ListObjectsV2` over an existing listing fixture — no object
 data, no authentication, not a general S3 emulator. It is built by this repo but
 is not part of the swath CLI distribution. See

--- a/README.md
+++ b/README.md
@@ -108,17 +108,21 @@ included, and swath will tell you so rather than pretend otherwise.
 
 ## Replay server
 
-This repo also builds `swath-replay-server`, a development tool. It serves a
-captured swath listing back as an S3-compatible `ListObjectsV2` endpoint, so you
-can point a lister at a deterministic, zero-cost bucket whose key distribution you
-already know — including the pathological shapes that are expensive to find and
-slow to list. It can inject per-request latency keyed on the shape of the request,
-which is how swath's own hard cases get reproduced without going back to the real
-bucket.
+`swath-replay-server` serves a captured swath listing back as an S3-compatible
+`ListObjectsV2` endpoint. Point a lister at it and you get a deterministic,
+zero-cost bucket whose key distribution you already know — including the
+pathological shapes that are expensive to find and slow to list. It can inject
+per-request latency keyed on the shape of the request, so a bucket that only
+misbehaves under a particular latency profile can be reproduced on a laptop.
 
-It is not a general S3 emulator and not part of the release: path-style
-`ListObjectsV2` over an existing listing fixture, no object data, no
-authentication. See
+That makes it useful beyond swath itself: reproducing someone's bucket shape
+without their credentials or their bill, testing your own tooling against a
+listing that would otherwise cost money to enumerate every run, and pinning
+listing behaviour in regression tests.
+
+Scope: path-style `ListObjectsV2` over an existing listing fixture — no object
+data, no authentication, not a general S3 emulator. It is built by this repo but
+is not part of the swath CLI distribution. See
 [`docs/swath-replay-server.md`](docs/swath-replay-server.md).
 
 ## Comparisons

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
+[![CI](https://github.com/varveio/swath/actions/workflows/ci.yml/badge.svg)](https://github.com/varveio/swath/actions/workflows/ci.yml)
+
 # swath
 
-A fast, resumable object-store lister for the buckets other tools choke on.
+**Lists very large S3 buckets in parallel, working out how to split the keyspace
+while it lists.**
 
-We kept running into very large S3 buckets that made every lister we tried slow
-to a crawl or fall over — deep prefix trees, totally flat random-key spaces,
-badly skewed distributions — so we built swath. It is a **Java 25** CLI
-distributed as a self-contained jar and an installable launcher, designed for
-very large listings. On supported general-purpose S3 buckets, it discovers how
-to partition an opaque keyspace *while* it lists it, using demand-driven
-range-stealing across a fixed pool of workers, adapting to backpressure so it
-degrades instead of failing. The name fits the method: the keyspace is tiled
-into adjacent ranges and swept in parallel, like mown swaths, covering every
-object exactly once with no gaps and no overlap.
+S3 lists a bucket one page at a time: 1000 keys per request, strictly in
+lexicographic order. You can start anywhere by handing it a `start-after` token,
+and that token doesn't have to be a key that exists — but nothing tells you how
+many keys sit between two tokens. So parallelism is a guessing problem. Splitting
+the keyspace is free; knowing whether the split was balanced costs a listing.
+
+swath guesses disjoint ranges blind, starts workers on the guesses, and corrects
+them as real keys come back — stealing work across a fixed pool when a range turns
+out denser or emptier than the guess assumed. No prefix hints, no pre-pass, no
+prior knowledge of how the keys are laid out. The name fits the method: the
+keyspace is tiled into adjacent ranges and swept in parallel, like mown swaths.
+
+swath is built and maintained by [Varve](https://varve.io/) — we catalog the
+datasets inside object storage from listing structure alone, never object
+contents. swath is the listing layer underneath it, and we wanted it inspectable
+by the people who would have to trust it.
+
+It is a **Java 25** CLI for general-purpose S3 buckets (directory buckets are not
+supported), distributed as a self-contained jar and an installable launcher.
 
 **Status: pre-1.0.** The `list` and `resume` commands are built and tested,
 including globally sorted Parquet output and crash-safe checkpoint/resume. Still
@@ -33,13 +45,37 @@ export PATH="$PWD/swath-cli/build/install/swath/bin:$PATH"
 swath list s3://my-bucket/prefix/ --no-sign-request --format parquet -o out/
 ```
 
+Every object becomes one row. The columns you will use most:
+
+```text
+key              BINARY       raw key bytes, byte-exact, never UTF-8 coerced
+size             INT64        object size in bytes
+last_modified    TIMESTAMP    micros, UTC
+etag             UTF8         quotes stripped, multipart ETags kept verbatim
+storage_class    UTF8         STANDARD, GLACIER, ...
+row_type         UTF8         OBJECT | COMMON_PREFIX (DELETE_MARKER reserved)
+```
+
+Owner, checksum, and versioning columns are always present too, reserved for
+versioned listing rather than populated by it. The full schema is in
+[`docs/usage.md`](docs/usage.md).
+
 Resume an interrupted run from its output directory:
 
 ```bash
 swath resume out/
 ```
 
-## What it does
+## When not to use it
+
+swath reads listings, never objects. It is **LIST-only** by design, and it exists
+for buckets where a precomputed listing (AWS S3 Inventory or S3 Metadata tables)
+isn't an option — not enabled, too stale, or on a bucket you don't own. If you
+already have a fresh Inventory or Metadata table you can query, use that: reading a
+precomputed listing is strictly cheaper than any live `ListObjectsV2` lister, swath
+included, and swath will tell you so rather than pretend otherwise.
+
+## Behaviour and limits
 
 - **Handles varied general-purpose S3 key distributions** — deep prefix trees,
   flat random keys, heavy skew — with no manual partitioning step, discovering
@@ -48,8 +84,16 @@ swath resume out/
 - **Is designed for very large listings** without accumulating object rows in
   heap. Active pipeline buffers are configuration-bounded; Parquet output also
   retains metadata proportional to finalized part count, and `--sort` retains
-  metadata proportional to staging-segment count. The current public heap gate
-  covers 100,000 keys; larger-scale measurements are pending.
+  metadata proportional to staging-segment count.
+- **Published scale evidence is still thin.** The CI gate pins heap behaviour at
+  100,000 keys — a regression guard, not a scale measurement. Larger runs are in
+  progress; their figures, and a throughput number, will land in
+  [`docs/performance.md`](docs/performance.md).
+- **Costs one LIST request per 1000 keys.** A billion-key bucket is roughly 1M
+  requests — about $5 at a $0.005-per-1000-requests reference rate — before probe
+  and retry overhead, and before egress if you run it outside the bucket's region.
+  Verify current pricing for your region; every run reports its actual
+  `cost.api_calls`. See [`docs/operating.md`](docs/operating.md).
 - **Resumes managed Parquet directory datasets** after Ctrl+C or a crash.
   Finalized parts stay durable; swath discards an unfinalized tail and re-lists
   it from `durable_cursor`. Stdout and FILE-kind destinations are one-shot and
@@ -62,21 +106,35 @@ swath resume out/
 - **Writes Parquet, JSONL, TSV, or an aligned table**, with optional globally
   sorted Parquet output.
 
-## When not to use it
+## Replay server
 
-swath is **LIST-only**. It exists for buckets where a precomputed listing (AWS S3
-Inventory or S3 Metadata tables) isn't an option — not enabled, too stale, or on
-a bucket you don't own. If you already have a fresh Inventory or Metadata table
-you can query, use that: reading a precomputed listing is strictly cheaper than
-any live `ListObjectsV2` lister, swath included, and swath will tell you so rather
-than pretend otherwise.
+This repo also builds `swath-replay-server`, a development tool. It serves a
+captured swath listing back as an S3-compatible `ListObjectsV2` endpoint, so you
+can point a lister at a deterministic, zero-cost bucket whose key distribution you
+already know — including the pathological shapes that are expensive to find and
+slow to list. It can inject per-request latency keyed on the shape of the request,
+which is how swath's own hard cases get reproduced without going back to the real
+bucket.
 
-For how swath compares to other S3-listing tools, the head-to-head benchmarks
-and the tool-by-tool mechanism notes belong to a separate
-[S3-listing comparison study](https://github.com/varveio/s3-listing-study), so
-this repo describes swath rather than grading it against rivals. That study has
-committed its methodology and tool roster; the comparative runs have not started
-yet.
+It is not a general S3 emulator and not part of the release: path-style
+`ListObjectsV2` over an existing listing fixture, no object data, no
+authentication. See
+[`docs/swath-replay-server.md`](docs/swath-replay-server.md).
+
+## Comparisons
+
+The head-to-head benchmarks and tool-by-tool mechanism notes belong to a separate
+repo, the [S3-listing comparison study](https://github.com/varveio/s3-listing-study),
+which Varve also maintains. Its methodology and tool roster were committed before
+any comparative runs began, so the results can be checked against a plan that
+predates them. Those runs have not started yet.
+
+## Have a bucket that breaks it
+
+That is the interesting case. Open an issue with the shape — key distribution,
+rough object count, what went wrong — or mail oss@varve.io if the shape isn't
+something you can post publicly. Bucket names and keys aren't needed; the
+distribution is.
 
 ## Documentation
 
@@ -98,8 +156,3 @@ Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md) · Security:
 
 [Apache-2.0](LICENSE). Bundled third-party dependencies and their licenses are
 listed in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
-
-## About
-
-swath is built and maintained by [Varve](https://varve.io/); we wrote it because
-our own object-storage work kept running into buckets no existing tool could list.

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -21,16 +21,19 @@ The engine is one `WorkStealingScan` over `KeyBytes` ranges on JDK 25.
 Listing a large S3 bucket is hard for one reason: S3 only lets you page through a
 bucket sequentially. One `ListObjectsV2` call returns up to 1000 keys in sorted
 order plus a continuation token for the next 1000, and the only way to start
-somewhere other than the beginning is `start_after=<key>` — "give me the keys
+somewhere other than the beginning is `start_after=<token>` — "give me the keys
 after this one." There is no "give me keys 50,000–51,000" and no "how many keys
 are under this prefix." The key distribution inside a bucket is opaque until you
 list some of it.
 
-That makes parallel listing a guessing problem. To hand a second worker a useful
-starting point you need a real key from the middle of the bucket, and the only way
-to learn one is to list up to it. So swath does not divide a known range into equal
-pieces; it **guesses disjoint key ranges blind, starts workers on the guesses, and
-corrects them as real keys come back.**
+That makes parallel listing a guessing problem — though not because the split
+points are hard to name. `start_after` accepts any byte string, and it need not be
+a key that exists ([`algorithms.md`](algorithms.md) §1.2), so the
+keyspace can be carved wherever you like for free. What no request will tell you is
+how many keys sit between two split points; the only way to find out is to list
+them. So swath does not divide a known range into equal pieces; it **guesses
+disjoint key ranges blind, starts workers on the guesses, and corrects them as real
+keys come back.**
 
 The properties swath targets on supported general-purpose S3 buckets, with no
 preconfiguration:

--- a/docs/swath-replay-server.md
+++ b/docs/swath-replay-server.md
@@ -1,9 +1,10 @@
 # swath replay server
 
-> **Developer tool, not a release artifact.** `swath-replay-server` is built by this repository's
-> Gradle project for fixture and conformance work, but is not part of the supported `swath` CLI
-> distribution or public release surface. Its operational CLI behavior (including diagnostics and
-> JVM launcher settings) is therefore not a v0.1 user contract.
+> **Built here, but not part of the `swath` CLI distribution.** `swath-replay-server` is built by
+> this repository's Gradle project and is a supported thing to use; it is simply shipped separately
+> from the `swath` CLI rather than inside it. Its wire behavior — what it serves for a given fixture
+> — is stable and conformance-tested. Its *operational* surface (diagnostics, logging destinations,
+> JVM launcher settings) is still being smoothed and is not yet a v0.1 user contract.
 
 The swath replay server serves a swath Parquet listing as an HTTP endpoint
 that looks like S3 `ListObjectsV2` — the only wire protocol it speaks today;


### PR DESCRIPTION
Documentation only — no product code changes.

## The correction that matters

The README's opening claimed the only way to start a listing somewhere other than the beginning was to name a key you had already seen, and that a second worker needed a real key from the middle of the bucket. That is wrong, and the paragraph immediately after it described swath doing the thing the claim ruled out.

`start-after` accepts any byte string. `docs/internals/algorithms.md` §1.2 *relies* on synthetic, non-existent boundary keys — that is exactly what makes an adjacent-range boundary gap-free without a coordination step. The real constraint is density: carving the keyspace costs nothing, but nothing tells you how many keys sit between two split points without listing them.

`docs/internals/overview.md` carried the same error — it is where the README's phrasing came from — and is corrected the same way.

## Other README changes

- Scope "resumable" to managed Parquet directory datasets; stdout and FILE-kind output are one-shot
- Move the "when not to use it" answer above the fold, and frame LIST-only as a design stance rather than a limitation
- Note that Varve also maintains the S3-listing comparison study, so its results are not mistaken for third-party validation
- State the cost arithmetic — one LIST request per 1000 keys — consistent with `docs/operating.md`
- Describe the 100,000-key CI gate as the regression guard it is, rather than as a scale measurement
- Add the Parquet output schema, and a way to report buckets that break it

## Replay server

The README and `docs/swath-replay-server.md` both opened by calling it a developer tool, which undersold it. It serves a captured listing back as an S3-compatible `ListObjectsV2` endpoint, which makes it useful as a listing cache as well as a test fixture. Its wire behaviour is conformance-tested; its operational surface — diagnostics, logging, launcher settings — is still being smoothed, and both docs now say so.