### PR TITLE
Deflake the FILE-publication staging test and cut the fast tier from 2m06s to 1m17s

### DIFF
--- a/swath-cli/src/test/java/io/varve/swath/cli/FilePublicationOrderingCharacterizationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/FilePublicationOrderingCharacterizationTest.java
@@ -48,7 +48,18 @@ final class FilePublicationOrderingCharacterizationTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /** One filesystem observation taken from inside a page fetch, i.e. mid-run. */
-    private record MidRunView(boolean destinationExists, int tempSiblings, long tempBytes) { }
+    private record MidRunView(int page, boolean destinationExists, int tempSiblings, long tempBytes) { }
+
+    /**
+     * Key count for the streaming observation. Sized well past the point where staging must be
+     * visible mid-run rather than only at close: rows reach the sink per COMMITTED RANGE (I1
+     * commit-before-emit), and the text writer buffers ~8 KiB, so a small run can legitimately
+     * finish every fetch before the first byte lands on disk. At this size many ranges commit and
+     * flush while pages are still being served, on any machine speed. (An observation must never
+     * WAIT for those bytes: every mid-run observation runs on a fetch thread, so blocking them all
+     * stops the ranges from ever completing — the writer starves and the wait deadlocks itself.)
+     */
+    private static final int STREAMING_KEYS = 20_000;
 
     // ---- ordering: stage → write → publish ---------------------------------------------------
 
@@ -65,10 +76,10 @@ final class FilePublicationOrderingCharacterizationTest {
         List<MidRunView> views = Collections.synchronizedList(new ArrayList<>());
 
         MockPageFetcher fetcher = MockPageFetcher.builder()
-                .keys(keys(500))
-                .maxKeysCap(50)   // many pages, so mid-run observations exist and the buffer flushes
+                .keys(keys(STREAMING_KEYS))
+                .maxKeysCap(100)   // many pages, so mid-run observations exist and the buffer flushes
                 .interceptor((req, idx, page) -> {
-                    views.add(observe(dir, out));
+                    views.add(observe(dir, out, idx));
                     return page;
                 })
                 .build();
@@ -82,15 +93,14 @@ final class FilePublicationOrderingCharacterizationTest {
         assertThat(views).as("the real destination path is NEVER observable mid-run — no partial, "
                         + "no zero-length placeholder: publication is a single rename at the end")
                 .noneMatch(MidRunView::destinationExists);
-        MidRunView last = views.get(views.size() - 1);
-        assertThat(last.tempSiblings())
-                .as("exactly one hidden temp sibling stages the run while it is in flight")
-                .isEqualTo(1);
-        assertThat(last.tempBytes())
+        assertThat(views)
+                .as("at most one hidden temp sibling stages the run at any moment")
+                .allMatch(view -> view.tempSiblings() <= 1);
+        assertThat(views)
                 .as("listing data is written into the STAGED file, not the destination, before publish")
-                .isGreaterThan(0L);
+                .anyMatch(view -> view.tempSiblings() == 1 && view.tempBytes() > 0L);
 
-        assertThat(Files.readAllLines(out)).hasSize(500);
+        assertThat(Files.readAllLines(out)).hasSize(STREAMING_KEYS);
         assertThat(stagingSiblings(dir, out)).as("the rename consumes the temp sibling").isEmpty();
     }
 
@@ -189,11 +199,12 @@ final class FilePublicationOrderingCharacterizationTest {
 
     // ---- helpers ------------------------------------------------------------------------------
 
-    private static MidRunView observe(Path dir, Path out) {
+    /** Takes one non-blocking mid-run observation from the fetch thread serving {@code page}. */
+    private static MidRunView observe(Path dir, Path out, int page) {
         try {
             List<Path> siblings = stagingSiblings(dir, out);
             long bytes = siblings.isEmpty() ? 0L : Files.size(siblings.get(0));
-            return new MidRunView(Files.exists(out), siblings.size(), bytes);
+            return new MidRunView(page, Files.exists(out), siblings.size(), bytes);
         } catch (Exception e) {
             throw new IllegalStateException("mid-run observation failed", e);
         }

--- a/swath-cli/src/test/java/io/varve/swath/cli/LiveProgressRecordTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/LiveProgressRecordTest.java
@@ -139,13 +139,25 @@ final class LiveProgressRecordTest {
         return captured.toString(StandardCharsets.UTF_8).lines().toList();
     }
 
+    /**
+     * How long the run is held open, on its FIRST fetch only. What earns a frame is the run's
+     * elapsed wall clock, not the number of slow pages: the reporter's first frame lands at
+     * {@code min(activation delay, cadence)} — 1s under the explicit {@link #FASTEST_CADENCE}, 2s
+     * for {@link #runVerbose}, which deliberately keeps the default cadence — so one hold past the
+     * later of those two is what every case here needs. Sleeping on every page instead multiplies
+     * that by the fetch count (~10 for this keyspace, seed probes included) and buys nothing.
+     */
+    private static final long FIRST_PAGE_HOLD_MS = 3_500L;
+
     /** A checkpoint-free run over a mock keyspace, slowed so at least one frame is due. */
     private static ListCommand slowListCommand(Path out) {
         MockPageFetcher fetcher = MockPageFetcher.builder()
                 .keys(List.of("data/a".getBytes(StandardCharsets.UTF_8),
                         "data/b".getBytes(StandardCharsets.UTF_8)))
                 .interceptor((req, idx, page) -> {
-                    TimeUnit.MILLISECONDS.sleep(1_600L);
+                    if (idx == 0) {
+                        TimeUnit.MILLISECONDS.sleep(FIRST_PAGE_HOLD_MS);
+                    }
                     return page;
                 })
                 .build();

--- a/swath-cli/src/test/java/io/varve/swath/cli/RunSummaryBlockTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/RunSummaryBlockTest.java
@@ -78,8 +78,12 @@ final class RunSummaryBlockTest {
         swathLogger.setLevel(originalLevel);
     }
 
-    /** Long enough to clear {@link SummaryRenderer#AUTO_MIN_ELAPSED} without a flag forcing it. */
-    private static final long OVER_THRESHOLD_MS = 1_800L;
+    /**
+     * Long enough to clear {@link SummaryRenderer#AUTO_MIN_ELAPSED} without a flag forcing it.
+     * Held on the FIRST fetch only: what earns the summary is the run's session wall clock, so one
+     * hold past the threshold is enough — holding every page multiplies it by the fetch count.
+     */
+    private static final long OVER_THRESHOLD_MS = 2_500L;
 
     @Test
     void everyFdCombinationGetsIdenticalContentButOnlyATtyStderrColors(@TempDir Path dir) throws Exception {
@@ -343,7 +347,9 @@ final class RunSummaryBlockTest {
                         "data/b".getBytes(StandardCharsets.UTF_8)));
         if (firstPageDelayMs > 0) {
             fetcher.interceptor((req, idx, page) -> {
-                TimeUnit.MILLISECONDS.sleep(firstPageDelayMs);
+                if (idx == 0) {
+                    TimeUnit.MILLISECONDS.sleep(firstPageDelayMs);
+                }
                 return page;
             });
         }


### PR DESCRIPTION
## What & why

Two fast-tier problems, both in swath-cli tests. No product code changes.

**1. A flaky test.** `FilePublicationOrderingCharacterizationTest#dataStreamsIntoATempSiblingAndTheDestinationAppearsOnlyAfterTheRun` failed a local `just build-fast`. It asserted that the *last* mid-run observation already saw bytes in the staged temp file — a race against the writer, not a property of the code. Rows reach the sink per committed range (I1 commit-before-emit) and the text writer buffers ~8 KiB, while the run was 500 keys / 75 KB (7.5 KB a page), so every fetch can legitimately finish before the first flush lands. Reproduced 1-in-3 with the box loaded, which is what a full build does to itself — swath-core runs 4 test forks while swath-cli runs.

Fixed by sizing the run past the race (20,000 keys at 100/page) and asserting over the whole observation set instead of one arbitrarily-ordered element — the observations are appended from concurrent fetch threads, so "last in the list" was never a well-defined position. The load-bearing pin (the destination path is never observable mid-run) is unchanged and now sampled ~200 times instead of ~10.

Waiting for the bytes inside the observation is *not* the fix, and the commit records why: the observations run on the fetch threads, so blocking them stops ranges from completing and the writer starves — the wait deadlocks itself (4/4 failures).

**2. The fast tier was 2m06s**, and `:swath-cli:test` was its longest task at 92.8s — 83s of which was four tests sleeping on purpose. Both fixtures slept on *every* page fetch when what they need is for the run to cross a threshold once; the fetch count (~10, seed probes plus a two-key listing) is incidental.

A progress frame is earned by elapsed wall clock — the first frame lands at `min(ACTIVATION_DELAY, cadence)`, 1s under the explicit cadence and 2s in `runVerbose`, which deliberately keeps the default. One 3.5s hold clears the later of the two with 1.5s of margin, more headroom than the old per-fetch sleep had. Likewise the summary block is earned by `SummaryRenderer#AUTO_MIN_ELAPSED` (1.5s) against the session clock, so one 2.5s hold clears it with 1s of margin instead of 0.3s per page. `RunSummaryBlockTest`'s helper was already named `firstPageDelayMs`; it just wasn't behaving that way.

| | before | after |
|---|---|---|
| `LiveProgressRecordTest` | 64.1s | 15.0s |
| `RunSummaryBlockTest` | 18.6s | 3.7s |
| `:swath-cli:test` | 92.8s | 30.1s |
| `build -PnoIntegration` | 2m06s | **1m17s** |

The critical path is now `:swath-core:test` at 60s (4 forks over 192s of test time), with `:swath-replay-server:test` at 49.8s underneath it — so raising `maxParallelForks` on the other modules would no longer move the wall clock. swath-core's own tail is `ByteKeysPropertyTest` at 39.3s for 6 property tests, which is the next target if the tier needs to go below ~1m10s.

## How it was tested

- Fast tier: `./gradlew build -PnoIntegration --rerun-tasks` — green, 73/73 tasks executed, 1m17s (the failing run had 53 executed with 7 cached, so the comparison is conservative).
- Flake reproduction and fix: `FilePublicationOrderingCharacterizationTest` under 8-way CPU load — 1/3 failed before, 5/5 green after.
- Sleep changes: `LiveProgressRecordTest` and `RunSummaryBlockTest` under the same 8-way load, 6/6 green, so the reduced margins are exercised against contention rather than an idle box.
- Not run: the Docker/LocalStack integration tier and `-Pdeep`/`-Pperf`. Nothing here touches them.

## Checklist

- [x] Commits are signed off (`git commit -s`, DCO)
- [x] `./gradlew build` passes — fast tier (`-PnoIntegration`); integration tier not run
- [x] Added or updated tests where it makes sense — test-only change
- [x] Updated docs if behavior or the CLI changed — no behavior or CLI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded filesystem streaming coverage to validate staging behavior throughout large transfers.
  * Improved progress and summary rendering test stability with configurable first-page delays.
  * Updated timing thresholds to better verify automatic elapsed-time summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->