### PR TITLE
Get the deep tier green: re-baseline the probe-timeout fixtures against the strict steal bound

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
@@ -54,9 +54,8 @@ import org.junit.jupiter.api.Timeout;
  *
  * <p>The comparison ({@link #off}/{@link #control1}/{@link #control2}) isolates what latency reveals:
  * <ul>
- *   <li><b>OFF + latency</b> — the collapse: low avg-in-flight / high serial_frac, {@code
- *       attempt_timeout_probe} > 0 — and byte-exact correct output (the collapse is a PERF failure,
- *       not a correctness one).</li>
+ *   <li><b>OFF + latency</b> — the collapse: low avg-in-flight / high serial_frac — and byte-exact
+ *       correct output (the collapse is a PERF failure, not a correctness one).</li>
  *   <li><b>CONTROL 1 — OFF, zero latency</b> — the blind spot: the SAME keyspace/toggle run with a
  *       zero-latency, fault-free harness produces ZERO probe timeouts and ZERO sheds. The whole
  *       spiral is invisible offline without a latency fixture. (Note: {@code cursor_passed_pivot}
@@ -78,9 +77,16 @@ import org.junit.jupiter.api.Timeout;
  * now issues exactly ONE probe, deterministically (1/1 across 8 runs). The volume thresholds this arm
  * used to assert (>15 timeouts, >5 cursor races) were therefore measuring the OLD steal policy, not
  * the collapse: they cannot be restored by re-tuning the fixture, because the pressure they counted is
- * precisely what the bound removed. What remains — and is asserted — is the collapse's structural
- * signature (a ~2-range seed, serial_frac at 1.0, avg-in-flight far below W) plus the latency-only
- * fact that a cold probe times out at all where the zero-latency control cannot.
+ * precisely what the bound removed.
+ *
+ * <p>Nor can a weaker "&gt;= 1 probe timeout" stand in: whether the tail issues ANY probe before it
+ * drains is machine-dependent — 1 on an 8-core dev box (8/8 runs), 0 on the 4-core CI runner. So this
+ * class no longer asserts on probe timeouts in either arm. What it asserts is what is deterministic:
+ * the collapse's structural signature (a ~2-range seed against 50 tiled, serial_frac at 1.0,
+ * avg-in-flight far below W, byte-exact output), and the latency-only discriminator in the SHED
+ * dimension — {@link #offStorm} fires a sustained-timeout shed that {@link #control1} never can,
+ * driven by the workers' own cold first-page reads, which need no steal slot and so are untouched by
+ * the bound.
  *
  * <p>The sustained-timeout SHED is proven in a dedicated cold-start-storm arm ({@link #offStorm}), because
  * it cannot coexist with the sustained-probe signature in ONE bounded run — see {@link
@@ -185,15 +191,11 @@ final class DenseShapeCollapseSignatureTest {
                 .as("OFF sustains only a low average in-flight (a couple of drainers, not W)")
                 .isLessThan(WORKERS / 4.0);
 
-        // Probe attempt-timeouts: a cold split-probe exceeds the scaled attempt-timeout budget and
-        // faults. The VOLUME is no longer a signature -- see the class javadoc: the fleet-wide
-        // one-attempt-in-flight bound serializes probes, so this collapsed tail issues exactly one
-        // in a 1.7s run (measured 1/1 across 8 runs) where the pre-bound engine issued dozens. What
-        // survives as the latency-only signal is that a cold probe times out AT ALL, which the
-        // zero-latency control (0, always) never does -- control1 asserts that delta.
-        assertThat(off.probeTimeouts)
-                .as("OFF: a cold split-probe exceeds the attempt-timeout budget (attempt_timeout_probe)")
-                .isGreaterThanOrEqualTo(1L);
+        // NO probe-timeout assertion -- see the class javadoc. Under the fleet-wide
+        // one-attempt-in-flight bound, whether this collapsed tail issues ANY steal probe before it
+        // drains is machine-dependent: 1 every time on an 8-core dev box, 0 on the 4-core CI runner.
+        // The latency-only discriminator the class exists to prove now lives in the shed dimension
+        // (offStorm vs control1), which fires by construction rather than by timing.
     }
 
     // ---- CONTROL 1: the zero-latency harness is blind to the spiral ---------------------------------
@@ -213,13 +215,11 @@ final class DenseShapeCollapseSignatureTest {
                 .as("zero latency: no timeout storm -> the sustained-timeout shed never fires")
                 .isZero();
 
-        // The blind spot as a delta: the fixture reveals probe-timeout pressure the zero-latency
-        // harness cannot. The delta is now 1 vs 0 rather than dozens vs 0 -- the strict steal bound
-        // caps the volume, not the visibility, and zero is exactly what the zero-latency harness can
-        // never rise above (a probe that costs nothing cannot exceed a budget).
-        assertThat(off.probeTimeouts)
-                .as("the latency fixture reveals probe-timeout pressure invisible to the zero-latency harness")
-                .isGreaterThan(control1.probeTimeouts);
+        // The blind spot as a delta, in the one dimension that survives the strict steal bound: the
+        // SHED. The probe-timeout delta is gone -- the OFF arm's probe count is machine-dependent
+        // (1 here, 0 on the 4-core CI runner), so it can no longer carry this claim. The storm arm's
+        // shed does, and by construction: its leading cold-start burst is the workers' OWN first-page
+        // reads, which need no steal slot and so are untouched by the bound.
         assertThat(offStorm.sheds)
                 .as("the latency fixture reveals shed storms invisible to the zero-latency harness")
                 .isGreaterThan(control1.sheds);
@@ -334,9 +334,11 @@ final class DenseShapeCollapseSignatureTest {
      *
      * <ul>
      *   <li><b>Sustained tail</b> (both modes): ~1-in-8 cold split-PROBE attempts ({@code maxKeys <= 1})
-     *       time out ({@code attempt_timeout_probe} >> 0), while the other ~7-in-8 cold probes SLOW-succeed
+     *       time out ({@code attempt_timeout_probe}), while the other ~7-in-8 cold probes SLOW-succeed
      *       so the owner's fast warm cursor races past the far-ahead pivot during the slow probe
-     *       ({@code cursor_passed_pivot}). Worker BULK pages ({@code maxKeys > 1}) are never faulted here —
+     *       ({@code cursor_passed_pivot}). Both counts are now incidental rather than asserted: the
+     *       strict steal bound means only a handful of probes — often none at all — are issued in a
+     *       run this short. Worker BULK pages ({@code maxKeys > 1}) are never faulted here —
      *       they must complete for the run to stay byte-exact.</li>
      *   <li><b>STORM only</b>: a leading cold-start burst — the first {@link #STARTUP_TIMEOUT_BURST}
      *       COLD reads (the workers' own first-page fetches into the unwarmed keyspace) time out before any

--- a/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
@@ -72,16 +72,25 @@ import org.junit.jupiter.api.Timeout;
  * <p><b>What the strict steal bound changed here.</b> This fixture was written against an engine
  * whose speculative steal probes ran concurrently fleet-wide, so probe-timeout pressure scaled with
  * the number of idle thieves and the OFF arm produced dozens of {@code attempt_timeout_probe} faults.
- * Making that bound strict (one attempt in flight fleet-wide) serializes the probes, and a
- * non-productive attempt then paces the next one out to the backoff cap — so this 1.7s collapsed tail
- * now issues exactly ONE probe, deterministically (1/1 across 8 runs). The volume thresholds this arm
- * used to assert (>15 timeouts, >5 cursor races) were therefore measuring the OLD steal policy, not
- * the collapse: they cannot be restored by re-tuning the fixture, because the pressure they counted is
- * precisely what the bound removed.
+ * Making that bound strict (one attempt in flight fleet-wide) SERIALIZES the probes: the single slot
+ * is occupied for essentially the whole tail by back-to-back 90-160ms cold probes, so probe volume is
+ * capped at roughly one per probe-latency rather than scaling with W. The counters say so directly —
+ * measured on this arm, denials split ~6000 {@code IDLE_SLOT.in_flight} against ~275
+ * {@code IDLE_SLOT.paced}, i.e. workers are refused because the slot is BUSY, not because the backoff
+ * is holding them off (pacing barely bites here: {@code IdleStealBackoff#reset} is called by unrelated
+ * workers on every ordinary claim and every non-empty page commit, and the two drainers commit warm
+ * 1ms pages continuously). The volume thresholds this arm used to assert (>15 timeouts, >5 cursor
+ * races) were therefore measuring the OLD steal policy, not the collapse, and cannot be restored by
+ * re-tuning the fixture: the pressure they counted is precisely what the bound removed.
  *
- * <p>Nor can a weaker "&gt;= 1 probe timeout" stand in: whether the tail issues ANY probe before it
- * drains is machine-dependent — 1 on an 8-core dev box (8/8 runs), 0 on the 4-core CI runner. So this
- * class no longer asserts on probe timeouts in either arm. What it asserts is what is deterministic:
+ * <p>Nor can a weaker "&gt;= 1 probe timeout" stand in — but NOT because the engine stops probing.
+ * Steal attempts flow identically on both machine shapes ({@code STEAL.attempted} = 6 on an 8-core dev
+ * box and on 4 pinned cores; most die at {@code NO_VICTIM.no_splittable_victim}, 5 of 6, or lose the
+ * cursor race, exactly the collapse this fixture characterizes). What is a coin flip is whether one of
+ * that handful of probe fetches lands on the interceptor's fault pattern, which fires on
+ * {@code callIndex % 8} over the GLOBAL call index — a stream dominated by warm bulk pages. Hence 1
+ * timeout locally and 0 on the CI runner from the same six attempts. So this class no longer asserts
+ * on probe timeouts in either arm. What it asserts is what is deterministic:
  * the collapse's structural signature (a ~2-range seed against 50 tiled, serial_frac at 1.0,
  * avg-in-flight far below W, byte-exact output), and the latency-only discriminator in the SHED
  * dimension — {@link #offStorm} fires a sustained-timeout shed that {@link #control1} never can,
@@ -191,11 +200,12 @@ final class DenseShapeCollapseSignatureTest {
                 .as("OFF sustains only a low average in-flight (a couple of drainers, not W)")
                 .isLessThan(WORKERS / 4.0);
 
-        // NO probe-timeout assertion -- see the class javadoc. Under the fleet-wide
-        // one-attempt-in-flight bound, whether this collapsed tail issues ANY steal probe before it
-        // drains is machine-dependent: 1 every time on an 8-core dev box, 0 on the 4-core CI runner.
-        // The latency-only discriminator the class exists to prove now lives in the shed dimension
-        // (offStorm vs control1), which fires by construction rather than by timing.
+        // NO probe-timeout assertion -- see the class javadoc. The tail still probes (6 attempts on
+        // both an 8-core box and 4 pinned cores), but the strict bound serializes them, and whether
+        // one of that handful lands on the interceptor's global-callIndex fault pattern is a
+        // scheduling coin flip: 1 timeout locally, 0 on the CI runner. The latency-only discriminator
+        // the class exists to prove now lives in the shed dimension (offStorm vs control1), which
+        // fires by construction rather than by timing.
     }
 
     // ---- CONTROL 1: the zero-latency harness is blind to the spiral ---------------------------------
@@ -216,8 +226,9 @@ final class DenseShapeCollapseSignatureTest {
                 .isZero();
 
         // The blind spot as a delta, in the one dimension that survives the strict steal bound: the
-        // SHED. The probe-timeout delta is gone -- the OFF arm's probe count is machine-dependent
-        // (1 here, 0 on the 4-core CI runner), so it can no longer carry this claim. The storm arm's
+        // SHED. The probe-timeout delta is gone -- with probes serialized, the OFF arm's timeout
+        // count rides on whether a probe coincides with the fixture's fault pattern (1 here, 0 on the
+        // 4-core CI runner), so it can no longer carry this claim. The storm arm's
         // shed does, and by construction: its leading cold-start burst is the workers' OWN first-page
         // reads, which need no steal slot and so are untouched by the bound.
         assertThat(offStorm.sheds)
@@ -336,9 +347,10 @@ final class DenseShapeCollapseSignatureTest {
      *   <li><b>Sustained tail</b> (both modes): ~1-in-8 cold split-PROBE attempts ({@code maxKeys <= 1})
      *       time out ({@code attempt_timeout_probe}), while the other ~7-in-8 cold probes SLOW-succeed
      *       so the owner's fast warm cursor races past the far-ahead pivot during the slow probe
-     *       ({@code cursor_passed_pivot}). Both counts are now incidental rather than asserted: the
-     *       strict steal bound means only a handful of probes — often none at all — are issued in a
-     *       run this short. Worker BULK pages ({@code maxKeys > 1}) are never faulted here —
+     *       ({@code cursor_passed_pivot}). Both counts are now incidental rather than asserted: with
+     *       probes serialized by the strict steal bound only a handful are issued per run, and this
+     *       predicate keys on the GLOBAL call index — so whether any probe coincides with it is a
+     *       scheduling accident. Worker BULK pages ({@code maxKeys > 1}) are never faulted here —
      *       they must complete for the run to stay byte-exact.</li>
      *   <li><b>STORM only</b>: a leading cold-start burst — the first {@link #STARTUP_TIMEOUT_BURST}
      *       COLD reads (the workers' own first-page fetches into the unwarmed keyspace) time out before any

--- a/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/DenseShapeCollapseSignatureTest.java
@@ -54,20 +54,35 @@ import org.junit.jupiter.api.Timeout;
  *
  * <p>The comparison ({@link #off}/{@link #control1}/{@link #control2}) isolates what latency reveals:
  * <ul>
- *   <li><b>OFF + latency</b> — the collapse: low avg-in-flight / high serial_frac, elevated {@code
- *       cursor_passed_pivot}, {@code attempt_timeout_probe} >> 0 — and byte-exact correct output (the
- *       collapse is a PERF failure, not a correctness one).</li>
+ *   <li><b>OFF + latency</b> — the collapse: low avg-in-flight / high serial_frac, {@code
+ *       attempt_timeout_probe} > 0 — and byte-exact correct output (the collapse is a PERF failure,
+ *       not a correctness one).</li>
  *   <li><b>CONTROL 1 — OFF, zero latency</b> — the blind spot: the SAME keyspace/toggle run with a
  *       zero-latency, fault-free harness produces ZERO probe timeouts and ZERO sheds. The whole
  *       spiral is invisible offline without a latency fixture. (Note: {@code cursor_passed_pivot}
  *       is NOT a clean latency discriminator — a collapsed seed makes 48 thieves contend over ~2 ranges,
  *       and the instant owner drains fast, so scheduling races occur even at zero latency; the true
- *       latency-only signals are the probe timeouts and the shed.)</li>
+ *       latency-only signals are the probe timeouts and the shed. Since the strict steal bound it is
+ *       INVERTED — measured 10 at zero latency against 1 with latency, because instant probes recycle
+ *       the one attempt slot while a 90-160ms cold probe holds it — so this arm no longer asserts on
+ *       it at all.)</li>
  *   <li><b>CONTROL 2 — ON + latency</b> — {@code fanout_tiling} ON ties the story together: the SAME
  *       hostile latency largely defuses the collapse (seed tiles pre-empt the probe race), dropping
  *       serial_frac and raising avg-in-flight materially.</li>
  * </ul>
- * The sustained-timeout SHED is proven in a dedicated cold-start-storm arm ({@link #offStorm}), because
+ * <p><b>What the strict steal bound changed here.</b> This fixture was written against an engine
+ * whose speculative steal probes ran concurrently fleet-wide, so probe-timeout pressure scaled with
+ * the number of idle thieves and the OFF arm produced dozens of {@code attempt_timeout_probe} faults.
+ * Making that bound strict (one attempt in flight fleet-wide) serializes the probes, and a
+ * non-productive attempt then paces the next one out to the backoff cap — so this 1.7s collapsed tail
+ * now issues exactly ONE probe, deterministically (1/1 across 8 runs). The volume thresholds this arm
+ * used to assert (>15 timeouts, >5 cursor races) were therefore measuring the OLD steal policy, not
+ * the collapse: they cannot be restored by re-tuning the fixture, because the pressure they counted is
+ * precisely what the bound removed. What remains — and is asserted — is the collapse's structural
+ * signature (a ~2-range seed, serial_frac at 1.0, avg-in-flight far below W) plus the latency-only
+ * fact that a cold probe times out at all where the zero-latency control cannot.
+ *
+ * <p>The sustained-timeout SHED is proven in a dedicated cold-start-storm arm ({@link #offStorm}), because
  * it cannot coexist with the sustained-probe signature in ONE bounded run — see {@link
  * #STARTUP_TIMEOUT_BURST} and {@link #offStorm_coldStartStormFiresTheShedSpiral} for why (a harness
  * limitation).
@@ -170,16 +185,15 @@ final class DenseShapeCollapseSignatureTest {
                 .as("OFF sustains only a low average in-flight (a couple of drainers, not W)")
                 .isLessThan(WORKERS / 4.0);
 
-        // Elevated cursor_passed_pivot: slow cold probes let the owner's fast warm cursor race past the
-        // thief's pivot before the split commits (the ~100:1 structural race, scaled).
-        assertThat(off.cursorPassedPivot)
-                .as("OFF loses the cursor_passed_pivot race repeatedly under slow cold probes")
-                .isGreaterThan(5L);
-
-        // Probe attempt-timeouts >> 0: cold split-probes exceed the scaled attempt-timeout budget and fault.
+        // Probe attempt-timeouts: a cold split-probe exceeds the scaled attempt-timeout budget and
+        // faults. The VOLUME is no longer a signature -- see the class javadoc: the fleet-wide
+        // one-attempt-in-flight bound serializes probes, so this collapsed tail issues exactly one
+        // in a 1.7s run (measured 1/1 across 8 runs) where the pre-bound engine issued dozens. What
+        // survives as the latency-only signal is that a cold probe times out AT ALL, which the
+        // zero-latency control (0, always) never does -- control1 asserts that delta.
         assertThat(off.probeTimeouts)
-                .as("OFF: cold split-probes time out en masse (attempt_timeout_probe)")
-                .isGreaterThan(15L);
+                .as("OFF: a cold split-probe exceeds the attempt-timeout budget (attempt_timeout_probe)")
+                .isGreaterThanOrEqualTo(1L);
     }
 
     // ---- CONTROL 1: the zero-latency harness is blind to the spiral ---------------------------------
@@ -199,10 +213,13 @@ final class DenseShapeCollapseSignatureTest {
                 .as("zero latency: no timeout storm -> the sustained-timeout shed never fires")
                 .isZero();
 
-        // The blind spot as a delta: the fixture reveals probe-timeout pressure the zero-latency harness cannot.
+        // The blind spot as a delta: the fixture reveals probe-timeout pressure the zero-latency
+        // harness cannot. The delta is now 1 vs 0 rather than dozens vs 0 -- the strict steal bound
+        // caps the volume, not the visibility, and zero is exactly what the zero-latency harness can
+        // never rise above (a probe that costs nothing cannot exceed a budget).
         assertThat(off.probeTimeouts)
                 .as("the latency fixture reveals probe-timeout pressure invisible to the zero-latency harness")
-                .isGreaterThan(control1.probeTimeouts + 15L);
+                .isGreaterThan(control1.probeTimeouts);
         assertThat(offStorm.sheds)
                 .as("the latency fixture reveals shed storms invisible to the zero-latency harness")
                 .isGreaterThan(control1.sheds);

--- a/swath-core/src/test/java/io/varve/swath/engine/TimeoutShedGateReopenTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/TimeoutShedGateReopenTest.java
@@ -45,9 +45,11 @@ import org.junit.jupiter.api.io.TempDir;
  * is WORKER-fed — the cold-start burst is the workers' own first-page reads into unwarmed
  * keyspace (a thief probe cannot precede any worker success, so it can never satisfy the shed's
  * starvation gate at t=0). This test asserts that the shed is worker-fed ({@code
- * timeout_storm_worker_fed} carries it) and that concurrent probe-class timeout pressure was observed
- * and attributed ({@code TRANSIENT.attempt_timeout_probe} &gt; 0) — probe timeouts still feed the
- * {@code timeout_storm_probe_fed} VISIBILITY split but do NOT gate the shed. The deterministic RED
+ * timeout_storm_worker_fed} carries it). It no longer asserts on coexisting probe-class timeout
+ * pressure: the shed pauses stealing, and since the fleet-wide steal-attempt bound became strict a
+ * short post-shed window can reach quiescence with no probe issued at all ({@code
+ * TRANSIENT.attempt_timeout_probe} measured 0) — probe timeouts still feed the {@code
+ * timeout_storm_probe_fed} VISIBILITY split but do NOT gate the shed. The deterministic RED
  * guard for "probe timeouts never gate the shed decision" lives at the gauge level in {@link
  * ConcurrencyGaugeShedCallClassMixTest} (an engine-level probe-fed shed is not reproducible offline:
  * the starvation gate closes as soon as healthy workers make progress, and probes cannot precede
@@ -122,11 +124,12 @@ final class TimeoutShedGateReopenTest {
                         + "gates the shed decision (probe timeouts feed the probe_fed VISIBILITY split only)")
                 .isGreaterThanOrEqualTo(1L);
 
-        // Probe-class timeout pressure was observed and attributed -- present
-        // and non-zero, yet it did NOT itself cause the shed above.
-        assertThat(r.steal("TRANSIENT.attempt_timeout_probe"))
-                .as("cold split-probes time out and are attributed to the probe call class")
-                .isGreaterThan(0L);
+        // No assertion on probe-class timeout volume: the shed pauses stealing, and under the
+        // fleet-wide one-attempt-in-flight bound the run can legitimately reach quiescence without
+        // issuing a single probe after the gate reopens (measured 0). That was incidental colour
+        // here in any case -- the probes-do-not-gate-the-shed bite is guarded deterministically at
+        // the gauge level by ConcurrencyGaugeShedCallClassMixTest, and the shed's own worker-fed
+        // attribution is asserted above.
 
         // RECOVERY — the seam's whole point: the demand/steal gate REOPENED (compressed clean window) and
         // T climbed back off the floor, rather than collapsing permanently.

--- a/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
@@ -252,12 +252,17 @@ final class ShapeRegressionCorpusTest {
      * where sleeping threads don't consume a core and so aren't core-bound. A fixed {@code workers / 4}
      * floor (4 at {@code W=16}) is unreachable on a 2-core runner, even though the seed-time structural
      * signal above (radix bands fired, {@code specs.size() > 8}) is unaffected by core count and stays
-     * green throughout. The floor is therefore capped at the runner's own {@code availableProcessors()}
-     * ({@code min(4, 2) = 2} on a 2-core runner; unchanged at {@code min(4, 8) = 4} on an 8+-core dev
-     * box, the original literal threshold): {@code peak_in_flight} is fundamentally a
-     * runtime-achieved-concurrency reading, not a placement/structure fact, and the zero-latency
-     * CPU-bound physics genuinely caps it at core count — the structural signal cannot substitute for
-     * it.
+     * green throughout. The floor is therefore capped at the runner's own core count, LESS ONE:
+     * capping at the bare count still demanded that every core be inside a fetch at the same sampled
+     * instant, which a shared 4-core CI runner does not owe anyone — the GC, the sampler and the JIT
+     * compete for exactly the cores the assertion is counting, and it read {@code peak_in_flight = 3}
+     * against a floor of 4 on the standard GitHub runner. One core of headroom keeps the guard
+     * meaningful without asserting perfect occupancy ({@code min(4, 3) = 3} on a 4-core runner;
+     * unchanged at {@code min(4, 7) = 4} on an 8+-core dev box, the original literal threshold):
+     * {@code peak_in_flight} is fundamentally a runtime-achieved-concurrency reading, not a
+     * placement/structure fact, and the zero-latency CPU-bound physics genuinely caps it at core
+     * count — the structural signal cannot substitute for it. The ablated shape still reads far
+     * below this floor (one un-banded range), so the guard keeps its bite.
      *
      * <p><b>Guard sharpness.</b> Ablating {@code radix_bands} (via {@link EngineToggles#parse}) leaves
      * the dense flat root as ONE un-subdivided seed range ({@code seedCount == 1}) instead of the
@@ -289,8 +294,10 @@ final class ShapeRegressionCorpusTest {
         Run run = scan(dir, "radix-band", keyspace, workers, 1000, Duration.ZERO, EngineToggles.DEFAULT);
         assertExactlyOnce(run.emitted, keyspace);
         // peak_in_flight at zero injected latency is CPU-bound, so it cannot exceed the actual
-        // core count the runner schedules on — cap the floor accordingly (see javadoc).
-        int concurrencyFloor = Math.min(workers / 4, Math.max(1, Runtime.getRuntime().availableProcessors()));
+        // core count the runner schedules on — cap the floor accordingly, keeping one core of
+        // headroom so the assertion never demands perfect occupancy (see javadoc).
+        int concurrencyFloor =
+                Math.min(workers / 4, Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
         assertThat(run.peakInFlight)
                 .as("no collapse: banded root reaches a healthy fraction of W, capped by the runner's "
                         + "actual core count at zero injected latency")


### PR DESCRIPTION
## What & why

Gets the `deep-tests` job green on `main`. It has been red since `ba2942e`, and the four failures are all pre-existing — they were introduced by `ba2942e` and `c85f082`, not by the test-speed PR (#10) merged after them. Test-only change; no product code.

**The process gap that let this land:** `deep-tests` runs on `main` and on the nightly cron, not on PRs. Both offending PRs were green on their own checks and went red after merge. Worth deciding separately whether the deep job should also run on PRs that touch swath-core — it costs ~3 min. I have not changed CI here.

### 1. Three probe-timeout fixtures vs. the strict steal bound

`DenseShapeCollapseSignatureTest` (×2) and `TimeoutShedGateReopenTest` were written against an engine whose speculative steal probes ran concurrently fleet-wide, so probe-timeout pressure scaled with the number of idle thieves. `c85f082` made that bound strict — one attempt in flight fleet-wide — which serializes probes and paces the next one out to the backoff cap after a non-productive attempt. The pressure these fixtures counted no longer exists to be counted.

Measured on the OFF arm, 8 consecutive runs on an 8-core dev box, identical every time:

| metric | asserted | measured |
|---|---|---|
| `probeTimeouts` | > 15 | **1** |
| `cursorPassedPivot` | > 5 | **1** |
| `serialFrac` | > 0.5 | 1.0 ✅ |
| `avgInFlight` | < W/4 | 0.39 ✅ |

One probe, deterministically, in a 1.7s collapsed tail. Those volume thresholds were measuring the *old steal policy*, not the collapse, and can't be recovered by re-tuning: at the backoff cap a second probe needs seconds of extra tail, and the pressure they counted is exactly what the bound removed.

**Nor does a weakened `>= 1` stand up.** My first attempt kept exactly that, fitted to those 8 runs — and a dispatched CI run on this branch failed it with **0** probe timeouts on the 4-core runner. So neither arm asserts on probe timeouts now.

**Why, precisely** — a frontier-tier consult challenged my first explanation and it was wrong, so the counters were measured on both machine shapes:

| counter (OFF arm) | 8-core | 4 pinned cores |
|---|---|---|
| `IDLE_SLOT.in_flight` denials | 6046 | 6026 |
| `IDLE_SLOT.paced` denials | 272 | 280 |
| `STEAL.attempted` | 6 | 6 |
| `NO_VICTIM.no_splittable_victim` | 5 | 5 |
| `attempt_timeout_probe` | 1 | 1 (0 on CI) |

The bound **serializes** probes — the slot is busy essentially the whole tail — it does not pace them out: `IdleStealBackoff#reset` clears pacing on every ordinary claim and every non-empty commit, and the two drainers commit warm 1ms pages continuously. And the tail probes *identically* on both shapes; what differs is whether one of that handful of probes coincides with the fixture's fault predicate, which fires on `callIndex % 8` over the **global** call index in a stream dominated by warm bulk pages. Same six attempts, 1 timeout locally, 0 on CI.

This matters beyond accuracy: "the bound paces probes out to the cap" describes an over-suppressive engine that does not exist, and this javadoc is what an eventual #3 N-permit revisit will read. The measured picture is an engine running flat out at the serialization ceiling, with attempts dying on **victim eligibility** (5 of 6) rather than on the slot — an argument about per-victim reservations, not permit count.

What the class asserts is what is deterministic on both machines: the collapse's structural signature (~2-range seed against 50 tiled, `serial_frac` 1.0, avg-in-flight far below W, byte-exact output), `control1`'s zeros, and the latency-only discriminator moved to the **shed** dimension — `offStorm` fires a sustained-timeout shed `control1` never can, and it fires *by construction*: its cold-start burst is the workers' own first-page reads, which need no steal slot and so are untouched by the bound. That is why the shed claim is safe where the probe claim was not — it doesn't depend on a thief winning a slot inside a 1.7s window.

`cursor_passed_pivot` is **dropped** from the OFF arm rather than re-tuned. The class javadoc already warned it wasn't a clean latency discriminator; under the strict bound it is *inverted* — 10 at zero latency against 1 with latency, because instant probes recycle the one attempt slot while a 90–160 ms cold probe holds it. An assertion whose signal points the wrong way is worse than none.

`TimeoutShedGateReopenTest` loses only its probe-volume line, which was incidental colour — the shed pauses stealing, so a short post-shed window can legitimately reach quiescence with no probe issued (measured 0). Its real invariant (shed fires, is worker-fed, the gate reopens, T climbs off the floor, byte-exact) is untouched, and the probes-don't-gate-the-shed bite is guarded deterministically at the gauge level by `ConcurrencyGaugeShedCallClassMixTest`, as its own javadoc says.

### 2. `radixBandedFlatRoot_…` — a floor that demanded perfect core occupancy

At zero injected latency a page fetch is pure CPU work, so `peak_in_flight` is capped by the cores actually scheduling workers — which the floor already handled by capping at `availableProcessors()`. On a box with exactly 4 cores that cap relieves nothing: `min(16/4, 4)` is still 4, so it demanded every core be inside a fetch at the same sampled instant, on a shared runner where the GC, JIT and sampler compete for the very cores being counted. It read 3.

The floor now keeps one core of headroom — `min(4, cores-1)` — 3 on a 4-core runner, unchanged at 4 on an 8+-core dev box. The guard keeps its bite: the ablated shape (`radix_bands` off) leaves one un-banded seed range and reads far below either floor.

## How it was tested

- **Verified on real CI, not just locally**: `workflow_dispatch` on this branch runs the jobs a PR skips — `deep-tests`, `fast-tests` and `integration-tests` all green ([run 30176719662](https://github.com/varveio/swath/actions/runs/30176719662)). This is what caught my first re-baseline being fitted to an 8-core box; local green was not sufficient evidence and shouldn't have been treated as such.
- Full deep tier locally: `./gradlew test -Pdeep` — green, 3m25s. It was red on `main` at HEAD before these commits.
- Bisected the three probe fixtures in a worktree: green at `ba2942e`, red at `c85f082`.
- Bisected the CI failure cause the same way: the dispatched run is the only place these tests execute before merge.
- Fast tier: `./gradlew build -PnoIntegration` — green.
- **Honest gap:** I could not produce a local red for #2. Pinned to 4 cores with 3 CPU burners on the same cores, the unfixed assertion still passed 3/3 — `peak_in_flight` counts fetches *entered* and not yet returned, not threads running, so descheduling a worker mid-fetch doesn't lower it. The CI reading is the evidence and the fix is sized to it; the ablation check is what keeps the guard honest.
- Integration tier not run locally (Docker); unaffected by these files.

## One thing I did not touch

The first dispatched run also failed `MaxDurationNoProgressTest.maxDurationWithProgress_staysPlainMaxDuration` in the **fast** tier — "this run made real progress before the cancel", 0 objects emitted. The identical commit passed fast-tests on the PR run and on `main`, so it is a pre-existing latent flake (a slow runner lets the max-duration cancel land before the first page commits), not something this branch introduced. Happy to file it.

## Checklist

- [x] Commits are signed off (`git commit -s`, DCO)
- [x] `./gradlew build` passes — fast tier and full deep tier; integration tier not run
- [x] Added or updated tests where it makes sense — test-only change
- [x] Updated docs if behavior or the CLI changed — no behavior change; fixture javadocs updated to match the new regime
