### PR TITLE
List GCS buckets via S3-XML + OAuth bearer token

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,8 @@ all of these.
 | `--no-sign-request` | off |
 | `--endpoint-url` | unset |
 | `--force-path-style` | on when `--endpoint-url` is set |
+| `--bearer-token-command` | unset |
+| `--bearer-token-refresh-interval` | `45m` |
 | `--fetch-owner` | off |
 | `--requester-pays` | off |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -482,6 +482,18 @@ carries no portable expiry. This is a **listing-only** path: swath's output is a
 local path (`-o`) today, so it doesn't touch GCS's XML multipart-upload precondition gap
 that rules the same mechanism out for a future GCS output/checkpoint destination.
 
+**Resuming a bearer-auth run.** Unlike `--profile`/`--region`/`--no-sign-request`, which are
+soft-restored from the checkpoint, `--bearer-token-command` is deliberately **never stored** —
+a checkpoint that named the command would decide what a later `swath resume` executes, so
+anyone who could write that file could choose the command. Re-pass both flags on resume:
+
+```sh
+swath resume ./out --bearer-token-command 'gcloud auth print-access-token'
+```
+
+Omit it and the resumed run falls back to SigV4 signing, which a bearer-auth endpoint will
+reject.
+
 #### Seeding
 
 | Flag | Default | Description |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -483,9 +483,12 @@ local path (`-o`) today, so it doesn't touch GCS's XML multipart-upload precondi
 that rules the same mechanism out for a future GCS output/checkpoint destination.
 
 **Resuming a bearer-auth run.** Unlike `--profile`/`--region`/`--no-sign-request`, which are
-soft-restored from the checkpoint, `--bearer-token-command` is deliberately **never stored** —
-a checkpoint that named the command would decide what a later `swath resume` executes, so
-anyone who could write that file could choose the command. Re-pass both flags on resume:
+soft-restored from the checkpoint, `--bearer-token-command` is deliberately **never stored**.
+Storing it would mean a checkpoint decides what a later `swath resume` executes — and nothing
+obliges the command to *mint* a token, so a `--bearer-token-command 'echo <token>'` shortcut
+would leave that literal token at rest in the checkpoint. The token itself never leaves memory
+today, and persisting the command is the one thing that would change that. Re-pass both flags
+on resume:
 
 ```sh
 swath resume ./out --bearer-token-command 'gcloud auth print-access-token'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -442,6 +442,8 @@ prefixes, endpoints, paths, filters, or keys are sensitive.
 | `--no-sign-request` | off | Anonymous requests (public buckets) |
 | `--endpoint-url URL` | — | Custom S3-compatible endpoint (LocalStack, MinIO, etc.) |
 | `--force-path-style` / `--no-force-path-style` | on when `--endpoint-url` is set | Force path-style S3 addressing |
+| `--bearer-token-command CMD` | — | Shell command whose stdout is a fresh OAuth bearer token, used instead of AWS SigV4 signing for every request |
+| `--bearer-token-refresh-interval DURATION` | `45m` | How often to re-run `--bearer-token-command` for a fresh token |
 | `--fetch-owner` | off | Request the `Owner` field from S3 (`FetchOwner=true`); populates `owner_id` and `owner_display_name` in output |
 | `--requester-pays requester` | off | Requester-pays buckets: send `x-amz-request-payer: requester` on every S3 request (only accepted value: `requester`) |
 | `--metrics-endpoint URL` | environment or off | Export OTLP metrics to URL; overrides `SWATH_OTLP_ENDPOINT` |
@@ -451,6 +453,34 @@ swath bundles the aws-sdk `sts` module so the default credential chain resolves 
 web-identity credentials (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`, e.g. GKE/EKS
 workload identity), auto-refreshing from the token file, for signed private-bucket
 listing.
+
+##### Listing a GCS bucket via its S3-compatible XML API
+
+GCS's XML API is largely `ListObjectsV2`-compatible, including the `start-after`
+range primitive swath's engine depends on — see
+[`docs/internals/s3-implementation-compatibility.md`](internals/s3-implementation-compatibility.md)
+for compatibility caveats verified against LocalStack/MinIO (GCS itself has not been run
+through that same conformance suite yet). Rather than minting GCS HMAC interoperability
+keys, point swath at a command that prints a fresh Google OAuth bearer token — GCS's XML
+API accepts `Authorization: Bearer <token>` directly:
+
+```sh
+swath list s3://some-gcs-bucket/prefix/ \
+  --endpoint-url https://storage.googleapis.com \
+  --force-path-style \
+  --bearer-token-command 'gcloud auth print-access-token' \
+  --format parquet --sort \
+  -o ./out
+```
+
+`--bearer-token-command` replaces SigV4 signing entirely (`--profile`/`--no-sign-request`/
+`AWS_ACCESS_KEY_ID` are ignored for signing when it's set, though the SDK's normal
+credential resolution still runs harmlessly in the background). The command re-runs on
+`--bearer-token-refresh-interval` (default 45m — comfortably under a typical ~1h Google
+OAuth access-token TTL); it isn't real expiry-aware, since a bearer token string alone
+carries no portable expiry. This is a **listing-only** path: swath's output is always a
+local path (`-o`) today, so it doesn't touch GCS's XML multipart-upload precondition gap
+that rules the same mechanism out for a future GCS output/checkpoint destination.
 
 #### Seeding
 

--- a/swath-cli/src/main/java/io/varve/swath/cli/BearerTokenOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/BearerTokenOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import picocli.CommandLine.Option;
+
+/**
+ * The bearer-token auth flags, declared once and attached to both {@code swath list} (nested in
+ * {@link ConnectionOptions}, so they render under its {@code Connection:} heading) and {@code swath
+ * resume} (attached directly).
+ *
+ * <p>They are the one piece of connection config a resume cannot restore from its checkpoint. Every
+ * other auth flag ({@code --profile}, {@code --region}, {@code --no-sign-request}) is {@link
+ * ResumeClass#STICKY} and soft-restored; these are {@link ResumeClass#FREE} and never persisted,
+ * for two reasons that both cut the same way:
+ *
+ * <ul>
+ *   <li><b>A stored command is a stored secret.</b> Nothing obliges the command to <i>mint</i> a
+ *       token — {@code --bearer-token-command 'echo eyJhbGci…'} is a plausible shortcut for someone
+ *       who already has one in hand. A STICKY row would put that literal token in {@code run_meta},
+ *       at rest on disk, having been typed as a command rather than a credential. The token itself
+ *       otherwise never leaves memory ({@code ProcessBearerTokenSupplier}'s cache), and this is the
+ *       one path that would change that.</li>
+ *   <li><b>A stored command is executed later.</b> Restoring it means a checkpoint file decides what
+ *       a subsequent {@code swath resume} runs, so whoever can write that file chooses the command.
+ *       A checkpoint is data, not a trusted script.</li>
+ * </ul>
+ *
+ * <p>That leaves re-passing them on {@code swath resume} as the only way a resumed run against a
+ * bearer-auth endpoint (e.g. GCS's XML API) can authenticate at all.
+ *
+ * <p>Shared rather than declared per-command because the two copies must not drift: the
+ * classification above is a security property, and {@code list} and {@code resume} disagreeing
+ * about it — or about the help text that tells operators to re-pass the flag — is exactly the bug
+ * this shape prevents. Contrast {@code --stats}/{@code --progress}, which are duplicated between
+ * {@link OutputOptions} and {@link ResumeCommand}.
+ */
+final class BearerTokenOptions {
+
+    // One description for both commands, so it must hold on both: the GCS worked example that used
+    // to live here named --endpoint-url/--force-path-style, which `swath resume` does not accept
+    // (they are restored from the checkpoint). It lives in docs/usage.md instead.
+    @Resume(ResumeClass.FREE)
+    @Option(names = "--bearer-token-command", paramLabel = "CMD",
+            description = "Shell command whose stdout is a fresh OAuth bearer token (e.g. 'gcloud "
+                    + "auth print-access-token' for GCS's XML API), used instead of AWS SigV4 "
+                    + "signing for every request. Never stored in the checkpoint, so a resumed run "
+                    + "against a bearer-auth endpoint must re-pass it.")
+    String command;
+
+    @Resume(ResumeClass.FREE)
+    @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
+            description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
+                    + "Size it comfortably under the token source's real expiry.")
+    String refreshInterval;
+
+    /**
+     * Copy what the operator passed to {@code swath resume} onto the delegated {@link ListCommand}'s
+     * own instance. A method rather than field-by-field assignment at the call site so a third flag
+     * added above is forwarded without touching {@link ResumeCommand}.
+     */
+    void copyFrom(BearerTokenOptions other) {
+        this.command = other.command;
+        this.refreshInterval = other.refreshInterval;
+    }
+}

--- a/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
@@ -69,15 +69,20 @@ final class ConnectionOptions {
     @Option(names = "--region", paramLabel = "REGION", description = "AWS region (else resolved from the environment).")
     String region;
 
-    @Resume(ResumeClass.STICKY)
+    // FREE, not STICKY like the auth flags above it: a STICKY row would persist the command
+    // STRING into the checkpoint's run_meta, and a later `swath resume` would execute whatever
+    // that file says. A checkpoint is data, not a trusted script — anyone who can write one
+    // could choose the command a resume runs. Re-pass the flag on resume instead.
+    @Resume(ResumeClass.FREE)
     @Option(names = "--bearer-token-command", paramLabel = "CMD",
             description = "Shell command whose stdout is a fresh OAuth bearer token, used instead of "
-                    + "AWS SigV4 signing for every request. For GCS's XML API: --endpoint-url "
+                    + "AWS SigV4 signing for every request. Not stored in the checkpoint: re-pass it "
+                    + "on `swath resume`. For GCS's XML API: --endpoint-url "
                     + "https://storage.googleapis.com --force-path-style --bearer-token-command "
                     + "'gcloud auth print-access-token'.")
     String bearerTokenCommand;
 
-    @Resume(ResumeClass.STICKY)
+    @Resume(ResumeClass.FREE)
     @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
             description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
                     + "Size it comfortably under the token source's real expiry.")

--- a/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
@@ -17,6 +17,7 @@ import io.varve.swath.store.s3.ProcessBearerTokenSupplier;
 import io.varve.swath.store.s3.S3Config;
 import java.net.URI;
 import java.time.Duration;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -69,24 +70,10 @@ final class ConnectionOptions {
     @Option(names = "--region", paramLabel = "REGION", description = "AWS region (else resolved from the environment).")
     String region;
 
-    // FREE, not STICKY like the auth flags above it: a STICKY row would persist the command
-    // STRING into the checkpoint's run_meta, and a later `swath resume` would execute whatever
-    // that file says. A checkpoint is data, not a trusted script — anyone who can write one
-    // could choose the command a resume runs. Re-pass the flag on resume instead.
-    @Resume(ResumeClass.FREE)
-    @Option(names = "--bearer-token-command", paramLabel = "CMD",
-            description = "Shell command whose stdout is a fresh OAuth bearer token, used instead of "
-                    + "AWS SigV4 signing for every request. Not stored in the checkpoint: re-pass it "
-                    + "on `swath resume`. For GCS's XML API: --endpoint-url "
-                    + "https://storage.googleapis.com --force-path-style --bearer-token-command "
-                    + "'gcloud auth print-access-token'.")
-    String bearerTokenCommand;
-
-    @Resume(ResumeClass.FREE)
-    @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
-            description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
-                    + "Size it comfortably under the token source's real expiry.")
-    String bearerTokenRefreshInterval;
+    // FREE, not STICKY like the auth flags above it, and shared with `swath resume` rather than
+    // re-declared there — see BearerTokenOptions for why both of those matter.
+    @ArgGroup(exclusive = false, validate = false)
+    final BearerTokenOptions bearer = new BearerTokenOptions();
 
     @Resume(ResumeClass.FREE)
     @Option(names = "--concurrency", paramLabel = "N", description = "Maximum concurrent listing requests (default: 64).")
@@ -216,13 +203,13 @@ final class ConnectionOptions {
      * SigV4/{@code --profile} signing).
      */
     private BearerTokenSupplier resolveBearerTokenSupplier() throws InvalidConfigException {
-        if (bearerTokenCommand == null) {
+        if (bearer.command == null) {
             return null;
         }
-        Duration refreshInterval = bearerTokenRefreshInterval == null
+        Duration refreshInterval = bearer.refreshInterval == null
                 ? DEFAULT_BEARER_TOKEN_REFRESH_INTERVAL
-                : DurationParser.parse(bearerTokenRefreshInterval, "bearer-token-refresh-interval", false);
-        return new ProcessBearerTokenSupplier(bearerTokenCommand, refreshInterval);
+                : DurationParser.parse(bearer.refreshInterval, "bearer-token-refresh-interval", false);
+        return new ProcessBearerTokenSupplier(bearer.command, refreshInterval);
     }
 
     /**

--- a/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
@@ -12,8 +12,11 @@ import io.varve.swath.observability.SafeInput;
 import io.varve.swath.store.ApiRateLimiter;
 import io.varve.swath.store.PageFetcher;
 import io.varve.swath.store.RateLimitedPageFetcher;
+import io.varve.swath.store.s3.BearerTokenSupplier;
+import io.varve.swath.store.s3.ProcessBearerTokenSupplier;
 import io.varve.swath.store.s3.S3Config;
 import java.net.URI;
+import java.time.Duration;
 import picocli.CommandLine.Option;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -65,6 +68,20 @@ final class ConnectionOptions {
     @Resume(ResumeClass.STICKY)
     @Option(names = "--region", paramLabel = "REGION", description = "AWS region (else resolved from the environment).")
     String region;
+
+    @Resume(ResumeClass.STICKY)
+    @Option(names = "--bearer-token-command", paramLabel = "CMD",
+            description = "Shell command whose stdout is a fresh OAuth bearer token, used instead of "
+                    + "AWS SigV4 signing for every request. For GCS's XML API: --endpoint-url "
+                    + "https://storage.googleapis.com --force-path-style --bearer-token-command "
+                    + "'gcloud auth print-access-token'.")
+    String bearerTokenCommand;
+
+    @Resume(ResumeClass.STICKY)
+    @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
+            description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
+                    + "Size it comfortably under the token source's real expiry.")
+    String bearerTokenRefreshInterval;
 
     @Resume(ResumeClass.FREE)
     @Option(names = "--concurrency", paramLabel = "N", description = "Maximum concurrent listing requests (default: 64).")
@@ -161,6 +178,11 @@ final class ConnectionOptions {
         return new RateLimitedPageFetcher(fetcher, ApiRateLimiter.perSecond(rateLimitApi), metrics);
     }
 
+    /** Default {@code --bearer-token-refresh-interval}: comfortably under a typical ~1h Google OAuth
+     * access-token TTL, without so short a cadence that ordinary listing runs mint tokens needlessly
+     * often. */
+    static final Duration DEFAULT_BEARER_TOKEN_REFRESH_INTERVAL = Duration.ofMinutes(45);
+
     /** Build the resolved S3 connection config (region defaulting included) from the flags. */
     S3Config buildConfig() throws InvalidConfigException {
         URI endpoint;
@@ -179,7 +201,23 @@ final class ConnectionOptions {
                 S3Config.DEFAULT_ATTEMPT_TIMEOUT,
                 S3Config.DEFAULT_API_CALL_TIMEOUT,
                 resolveCredentials(),
-                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT);
+                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT,
+                resolveBearerTokenSupplier());
+    }
+
+    /**
+     * Resolve {@code --bearer-token-command}/{@code --bearer-token-refresh-interval} into a {@link
+     * BearerTokenSupplier}, or {@code null} when unset (the overwhelmingly common case: normal
+     * SigV4/{@code --profile} signing).
+     */
+    private BearerTokenSupplier resolveBearerTokenSupplier() throws InvalidConfigException {
+        if (bearerTokenCommand == null) {
+            return null;
+        }
+        Duration refreshInterval = bearerTokenRefreshInterval == null
+                ? DEFAULT_BEARER_TOKEN_REFRESH_INTERVAL
+                : DurationParser.parse(bearerTokenRefreshInterval, "bearer-token-refresh-interval", false);
+        return new ProcessBearerTokenSupplier(bearerTokenCommand, refreshInterval);
     }
 
     /**

--- a/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
@@ -39,8 +39,9 @@ import picocli.CommandLine.Spec;
  * and re-drives {@link ListCommand} in resume mode, continuing each non-COMPLETED node from its
  * cursor (text) / durable_cursor (Parquet). A {@code <dir>} whose dataset is already complete (its
  * checkpoint was deleted on completion) reports "already complete" and exits 0. Credentials and
- * region resolve from the environment, exactly as a fresh {@code list} would. A directory-dataset
- * output is the only resumable regime.
+ * region resolve from the environment, exactly as a fresh {@code list} would — the one exception is
+ * {@code --bearer-token-command}, which is never stored in a checkpoint and so must be re-passed
+ * here. A directory-dataset output is the only resumable regime.
  */
 @Command(name = "resume", mixinStandardHelpOptions = true,
         description = "Resume a run by its output directory: swath resume <dir>.")
@@ -85,6 +86,30 @@ public final class ResumeCommand implements Callable<Integer>, GlobalOptions.Car
             description = "Print live progress records to stderr (default: on when stderr is a "
                     + "terminal and neither -q nor -v was given).")
     Boolean progress;
+
+    /**
+     * The bearer-token levers, forwarded to the delegated {@link ListCommand} like {@code --stats}
+     * and {@code --progress}, but for a different reason: they are the one piece of connection
+     * config a resume cannot restore from the checkpoint. Every other auth flag
+     * ({@code --profile}, {@code --region}, {@code --no-sign-request}) is {@link ResumeClass#STICKY}
+     * and soft-restored, but {@code --bearer-token-command} is a command string that a resumed run
+     * would <i>execute</i>. Persisting it would let whoever can write a checkpoint choose that
+     * command, so it is {@link ResumeClass#FREE} and never stored — which leaves re-passing it here
+     * as the only way a resumed run against a bearer-auth endpoint (e.g. GCS's XML API) can
+     * authenticate at all.
+     */
+    @Resume(ResumeClass.FREE)
+    @Option(names = "--bearer-token-command", paramLabel = "CMD",
+            description = "Shell command whose stdout is a fresh OAuth bearer token, used instead of "
+                    + "AWS SigV4 signing for every request. Never stored in the checkpoint, so a "
+                    + "resumed run against a bearer-auth endpoint must re-pass it.")
+    String bearerTokenCommand;
+
+    @Resume(ResumeClass.FREE)
+    @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
+            description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
+                    + "Size it comfortably under the token source's real expiry.")
+    String bearerTokenRefreshInterval;
 
     @Mixin
     final GlobalOptions global = new GlobalOptions();
@@ -140,6 +165,11 @@ public final class ResumeCommand implements Callable<Integer>, GlobalOptions.Car
         list.uri = id.scheme() + "://" + id.bucket() + "/"
                 + new String(id.prefix() == null ? new byte[0] : id.prefix(), StandardCharsets.UTF_8);
         list.connection.endpointUrl = id.endpoint();
+        // The one connection setting the checkpoint deliberately does not carry (see the field's
+        // javadoc): forward what the operator passed to `swath resume`, or leave it null for the
+        // ordinary SigV4 path.
+        list.connection.bearerTokenCommand = bearerTokenCommand;
+        list.connection.bearerTokenRefreshInterval = bearerTokenRefreshInterval;
         // Important: `list` is driven directly via #call(), never through picocli's
         // own parse of the "list" subcommand -- its OWN @Mixin GlobalOptions instance never sees
         // whatever -q/-v the user actually passed to `swath resume`. Propagate explicitly,

--- a/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
@@ -89,27 +90,12 @@ public final class ResumeCommand implements Callable<Integer>, GlobalOptions.Car
 
     /**
      * The bearer-token levers, forwarded to the delegated {@link ListCommand} like {@code --stats}
-     * and {@code --progress}, but for a different reason: they are the one piece of connection
-     * config a resume cannot restore from the checkpoint. Every other auth flag
-     * ({@code --profile}, {@code --region}, {@code --no-sign-request}) is {@link ResumeClass#STICKY}
-     * and soft-restored, but {@code --bearer-token-command} is a command string that a resumed run
-     * would <i>execute</i>. Persisting it would let whoever can write a checkpoint choose that
-     * command, so it is {@link ResumeClass#FREE} and never stored — which leaves re-passing it here
-     * as the only way a resumed run against a bearer-auth endpoint (e.g. GCS's XML API) can
-     * authenticate at all.
+     * and {@code --progress} — but shared with {@link ConnectionOptions} via one {@link
+     * BearerTokenOptions} declaration rather than re-declared here, because the two copies must not
+     * drift. See that class for why they are the one connection setting a resume cannot restore.
      */
-    @Resume(ResumeClass.FREE)
-    @Option(names = "--bearer-token-command", paramLabel = "CMD",
-            description = "Shell command whose stdout is a fresh OAuth bearer token, used instead of "
-                    + "AWS SigV4 signing for every request. Never stored in the checkpoint, so a "
-                    + "resumed run against a bearer-auth endpoint must re-pass it.")
-    String bearerTokenCommand;
-
-    @Resume(ResumeClass.FREE)
-    @Option(names = "--bearer-token-refresh-interval", paramLabel = "DURATION",
-            description = "How often to re-run --bearer-token-command for a fresh token (default: 45m). "
-                    + "Size it comfortably under the token source's real expiry.")
-    String bearerTokenRefreshInterval;
+    @ArgGroup(exclusive = false, validate = false)
+    final BearerTokenOptions bearer = new BearerTokenOptions();
 
     @Mixin
     final GlobalOptions global = new GlobalOptions();
@@ -168,8 +154,7 @@ public final class ResumeCommand implements Callable<Integer>, GlobalOptions.Car
         // The one connection setting the checkpoint deliberately does not carry (see the field's
         // javadoc): forward what the operator passed to `swath resume`, or leave it null for the
         // ordinary SigV4 path.
-        list.connection.bearerTokenCommand = bearerTokenCommand;
-        list.connection.bearerTokenRefreshInterval = bearerTokenRefreshInterval;
+        list.connection.bearer.copyFrom(bearer);
         // Important: `list` is driven directly via #call(), never through picocli's
         // own parse of the "list" subcommand -- its OWN @Mixin GlobalOptions instance never sees
         // whatever -q/-v the user actually passed to `swath resume`. Propagate explicitly,

--- a/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
@@ -805,6 +805,44 @@ final class ResumeCommandTest {
         }
     }
 
+    /**
+     * {@code --bearer-token-command} must never reach the checkpoint: a persisted row would make
+     * {@code run_meta} decide which command a later {@code swath resume} executes, so whoever can
+     * write a checkpoint file could choose that command. FREE (no row) is the security property;
+     * {@link ResumeRegistryDriftTest#everyFreeOptionHasNoRegistryRow()} enforces the same invariant
+     * generically, but this names the reason so the classification is not "simplified" back to
+     * STICKY to match the {@code --profile}/{@code --region} block it sits in.
+     */
+    @Test
+    void bearerTokenOptionsAreNeverPersistedToTheCheckpoint() {
+        assertThat(ResumeRegistry.hasPersistedRow("--bearer-token-command")).isFalse();
+        assertThat(ResumeRegistry.hasPersistedRow("--bearer-token-refresh-interval")).isFalse();
+    }
+
+    /**
+     * Because they are never persisted (above), re-passing them on {@code swath resume} is the ONLY
+     * way a resumed run against a bearer-auth endpoint can authenticate — so the forwarding onto the
+     * delegated {@link ListCommand} is load-bearing, not a convenience.
+     *
+     * <p>One malformed-duration assertion pins BOTH forwardings at once, because
+     * {@code ConnectionOptions#resolveBearerTokenSupplier()} parses the interval only when the
+     * command is non-null: drop the command forwarding and it returns early (no throw); drop the
+     * interval forwarding and the 45m default is used (no throw).
+     */
+    @Test
+    void bearerTokenOptionsForwardOntoTheDelegatedListCommand(@TempDir Path tempDir) throws Exception {
+        Path outputDir = seedCompletedRunDir(tempDir);
+
+        ResumeCommand cmd = new ResumeCommand();
+        cmd.directory = outputDir;
+        cmd.bearerTokenCommand = "printf token";
+        cmd.bearerTokenRefreshInterval = "not-a-duration";
+
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("bearer-token-refresh-interval");
+    }
+
     private static void overwriteOutputFormat(Path db, String format) throws Exception {
         try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
              PreparedStatement ps = c.prepareStatement("UPDATE run_meta SET output_format=?")) {

--- a/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +45,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
 
 /**
  * End-to-end coverage for {@link ResumeCommand#call()} via the {@code <dir>} run handle. Proves that
@@ -820,6 +822,34 @@ final class ResumeCommandTest {
     }
 
     /**
+     * {@code list} and {@code resume} must expose ONE declaration of these flags, not a copy each.
+     * The FREE classification is a security property and the help text is what tells an operator to
+     * re-pass the flag on resume; two copies can drift on either, and the drift would be silent —
+     * {@code --stats}/{@code --progress} are duplicated between {@link OutputOptions} and
+     * {@link ResumeCommand} today and nothing would catch them diverging. Pins the shared
+     * {@link BearerTokenOptions} so a later "just declare it on the command" edit fails here.
+     */
+    @Test
+    void bearerTokenOptionsAreOneDeclarationSharedByListAndResume() {
+        for (String name : List.of("--bearer-token-command", "--bearer-token-refresh-interval")) {
+            OptionSpec onList =
+                    App.commandLine().getSubcommands().get("list").getCommandSpec().findOption(name);
+            OptionSpec onResume =
+                    App.commandLine().getSubcommands().get("resume").getCommandSpec().findOption(name);
+            assertThat(onList).as("%s on list", name).isNotNull();
+            assertThat(onResume).as("%s on resume", name).isNotNull();
+            assertThat(((Field) onList.userObject()).getDeclaringClass())
+                    .as("%s on list must come from the shared declaration", name)
+                    .isEqualTo(BearerTokenOptions.class);
+            assertThat(((Field) onResume.userObject()).getDeclaringClass())
+                    .as("%s on resume must come from the shared declaration", name)
+                    .isEqualTo(BearerTokenOptions.class);
+            assertThat(onResume.description()).as("%s help text must not drift", name)
+                    .isEqualTo(onList.description());
+        }
+    }
+
+    /**
      * Because they are never persisted (above), re-passing them on {@code swath resume} is the ONLY
      * way a resumed run against a bearer-auth endpoint can authenticate — so the forwarding onto the
      * delegated {@link ListCommand} is load-bearing, not a convenience.
@@ -835,8 +865,8 @@ final class ResumeCommandTest {
 
         ResumeCommand cmd = new ResumeCommand();
         cmd.directory = outputDir;
-        cmd.bearerTokenCommand = "printf token";
-        cmd.bearerTokenRefreshInterval = "not-a-duration";
+        cmd.bearer.command = "printf token";
+        cmd.bearer.refreshInterval = "not-a-duration";
 
         assertThatThrownBy(cmd::call)
                 .isInstanceOf(InvalidConfigException.class)

--- a/swath-cli/src/test/resources/help/swath-list.txt
+++ b/swath-cli/src/test/resources/help/swath-list.txt
@@ -51,12 +51,11 @@ Output:
 Connection:
       --bearer-token-command=CMD
                              Shell command whose stdout is a fresh OAuth bearer
-                               token, used instead of AWS SigV4 signing for
-                               every request. Not stored in the checkpoint:
-                               re-pass it on `swath resume`. For GCS's XML API:
-                               --endpoint-url https://storage.googleapis.com
-                               --force-path-style --bearer-token-command
-                               'gcloud auth print-access-token'.
+                               token (e.g. 'gcloud auth print-access-token' for
+                               GCS's XML API), used instead of AWS SigV4
+                               signing for every request. Never stored in the
+                               checkpoint, so a resumed run against a
+                               bearer-auth endpoint must re-pass it.
       --bearer-token-refresh-interval=DURATION
                              How often to re-run --bearer-token-command for a
                                fresh token (default: 45m). Size it comfortably

--- a/swath-cli/src/test/resources/help/swath-list.txt
+++ b/swath-cli/src/test/resources/help/swath-list.txt
@@ -1,6 +1,8 @@
 Usage: swath list [-hVqv] [--fetch-owner] [--force] [--[no-]force-path-style]
                   [--no-metrics] [--no-sign-request] [--[no-]progress]
                   [--restart] [--[no-]sort] [--[no-]stats]
+                  [--bearer-token-command=CMD]
+                  [--bearer-token-refresh-interval=DURATION]
                   [--checkpoint=PATH|none|auto] [--color=MODE]
                   [--concurrency=N] [--endpoint-url=URL] [--exclude=REGEX]
                   [--format=FORMAT] [--idle-timeout=DURATION] [--include=REGEX]
@@ -47,6 +49,18 @@ Output:
                                downstream pipe stays silent).
 
 Connection:
+      --bearer-token-command=CMD
+                             Shell command whose stdout is a fresh OAuth bearer
+                               token, used instead of AWS SigV4 signing for
+                               every request. Not stored in the checkpoint:
+                               re-pass it on `swath resume`. For GCS's XML API:
+                               --endpoint-url https://storage.googleapis.com
+                               --force-path-style --bearer-token-command
+                               'gcloud auth print-access-token'.
+      --bearer-token-refresh-interval=DURATION
+                             How often to re-run --bearer-token-command for a
+                               fresh token (default: 45m). Size it comfortably
+                               under the token source's real expiry.
       --concurrency=N        Maximum concurrent listing requests (default: 64).
       --endpoint-url=URL     Custom S3 endpoint (LocalStack/MinIO).
       --fetch-owner          Request object owner fields from S3.

--- a/swath-cli/src/test/resources/help/swath-resume.txt
+++ b/swath-cli/src/test/resources/help/swath-resume.txt
@@ -7,9 +7,10 @@ Resume a run by its output directory: swath resume <dir>.
                            <dir>/.swath/checkpoint.sqlite).
       --bearer-token-command=CMD
                          Shell command whose stdout is a fresh OAuth bearer
-                           token, used instead of AWS SigV4 signing for every
-                           request. Never stored in the checkpoint, so a
-                           resumed run against a bearer-auth endpoint must
+                           token (e.g. 'gcloud auth print-access-token' for
+                           GCS's XML API), used instead of AWS SigV4 signing
+                           for every request. Never stored in the checkpoint,
+                           so a resumed run against a bearer-auth endpoint must
                            re-pass it.
       --bearer-token-refresh-interval=DURATION
                          How often to re-run --bearer-token-command for a fresh

--- a/swath-cli/src/test/resources/help/swath-resume.txt
+++ b/swath-cli/src/test/resources/help/swath-resume.txt
@@ -1,8 +1,20 @@
-Usage: swath resume [-hVqv] [--[no-]progress] [--[no-]stats] [--color=MODE]
+Usage: swath resume [-hVqv] [--[no-]progress] [--[no-]stats]
+                    [--bearer-token-command=CMD]
+                    [--bearer-token-refresh-interval=DURATION] [--color=MODE]
                     [--tune=KEY=VALUE]... [<dir>]
 Resume a run by its output directory: swath resume <dir>.
       [<dir>]            The directory-dataset run handle to resume (opens
                            <dir>/.swath/checkpoint.sqlite).
+      --bearer-token-command=CMD
+                         Shell command whose stdout is a fresh OAuth bearer
+                           token, used instead of AWS SigV4 signing for every
+                           request. Never stored in the checkpoint, so a
+                           resumed run against a bearer-auth endpoint must
+                           re-pass it.
+      --bearer-token-refresh-interval=DURATION
+                         How often to re-run --bearer-token-command for a fresh
+                           token (default: 45m). Size it comfortably under the
+                           token source's real expiry.
       --color=MODE       Color the progress line and end-of-run summary: auto,
                            always, or never (default: auto).
   -h, --help             Show this help message and exit.

--- a/swath-core/src/main/java/io/varve/swath/observability/SafeInput.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/SafeInput.java
@@ -16,7 +16,24 @@ public final class SafeInput {
 
     public static final String REDACTED_ENDPOINT = "<redacted endpoint>";
 
+    /**
+     * Marker for an option whose value can BE a credential rather than merely identify one.
+     * Distinct from {@link #REDACTED_ENDPOINT} so a summary reader can tell "an endpoint was given"
+     * from "a secret was given" without either value being recoverable.
+     */
+    public static final String REDACTED_SECRET = "<redacted secret>";
+
     private static final Set<String> ENDPOINT_OPTIONS = Set.of("--endpoint-url", "--metrics-endpoint");
+
+    /**
+     * Options whose value must never reach a durable artifact. {@code --bearer-token-command} is
+     * nominally a command, but nothing obliges it to MINT a token — {@code --bearer-token-command
+     * 'echo eyJhbGci…'} is a plausible shortcut for someone holding one already, which would put a
+     * live credential in the run summary's {@code argv}. Redacting the option wholesale is the only
+     * safe reading, since the difference between a minting command and an embedded secret is not
+     * something this layer can determine.
+     */
+    private static final Set<String> SECRET_OPTIONS = Set.of("--bearer-token-command");
 
     private SafeInput() {
     }
@@ -64,36 +81,48 @@ public final class SafeInput {
     }
 
     /**
-     * Safe persisted argv: endpoint values are represented by a fixed marker and all remaining
-     * arguments have log/terminal control characters escaped. Handles both {@code --opt value}
-     * and {@code --opt=value} forms.
+     * Safe persisted argv: endpoint values and secret-bearing values are each represented by a
+     * fixed marker, and all remaining arguments have log/terminal control characters escaped.
+     * Handles both {@code --opt value} and {@code --opt=value} forms.
      */
     public static List<String> argv(List<String> original) {
         if (original == null || original.isEmpty()) {
             return List.of();
         }
         List<String> safe = new ArrayList<>(original.size());
-        boolean redactNext = false;
+        String pendingMarker = null;
         for (String arg : original) {
-            if (redactNext) {
-                safe.add(REDACTED_ENDPOINT);
-                redactNext = false;
+            if (pendingMarker != null) {
+                safe.add(pendingMarker);
+                pendingMarker = null;
                 continue;
             }
             String value = arg == null ? "" : arg;
-            if (ENDPOINT_OPTIONS.contains(value)) {
+            String marker = redactionMarkerFor(value);
+            if (marker != null) {
                 safe.add(value);
-                redactNext = true;
+                pendingMarker = marker;
                 continue;
             }
             int equals = value.indexOf('=');
-            if (equals > 0 && ENDPOINT_OPTIONS.contains(value.substring(0, equals))) {
-                safe.add(value.substring(0, equals + 1) + REDACTED_ENDPOINT);
-                continue;
+            if (equals > 0) {
+                String inlineMarker = redactionMarkerFor(value.substring(0, equals));
+                if (inlineMarker != null) {
+                    safe.add(value.substring(0, equals + 1) + inlineMarker);
+                    continue;
+                }
             }
             safe.add(logText(value));
         }
         return List.copyOf(safe);
+    }
+
+    /** The marker an option's VALUE must be replaced by, or {@code null} to keep it (escaped). */
+    private static String redactionMarkerFor(String option) {
+        if (ENDPOINT_OPTIONS.contains(option)) {
+            return REDACTED_ENDPOINT;
+        }
+        return SECRET_OPTIONS.contains(option) ? REDACTED_SECRET : null;
     }
 
     /** Escape ISO control characters so one untrusted value cannot forge another log line. */

--- a/swath-core/src/test/java/io/varve/swath/observability/SafeInputTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/SafeInputTest.java
@@ -49,4 +49,32 @@ final class SafeInputTest {
                 "--include", "first\\x0aforged\\x9bline");
         assertThat(String.join(" ", safe)).doesNotContain("secret").doesNotContain("\n");
     }
+
+    /**
+     * {@code --bearer-token-command} is nominally a command, but nothing obliges it to MINT a
+     * token: {@code 'echo <token>'} is a plausible shortcut for someone already holding one, and
+     * argv is written verbatim into the durable JSON run summary. So the VALUE never survives, in
+     * either syntax — the option name does, because "a bearer command was supplied" is legitimate
+     * summary information and is not itself the secret.
+     *
+     * <p>The refresh interval is deliberately NOT redacted: it is a duration, and blanking it would
+     * cost real diagnostic value for no gain.
+     */
+    @Test
+    void persistedArgvRedactsTheBearerTokenCommandInBothSyntaxes() {
+        List<String> safe = SafeInput.argv(List.of(
+                "list", "s3://bucket/prefix",
+                "--bearer-token-command", "echo eyJhbGciOiJSUzI1NiRealTokenHere",
+                "--bearer-token-refresh-interval=30m",
+                "--bearer-token-command=printf another-live-token"));
+
+        assertThat(safe).containsExactly(
+                "list", "s3://bucket/prefix",
+                "--bearer-token-command", SafeInput.REDACTED_SECRET,
+                "--bearer-token-refresh-interval=30m",
+                "--bearer-token-command=" + SafeInput.REDACTED_SECRET);
+        assertThat(String.join(" ", safe))
+                .doesNotContain("eyJhbGci")
+                .doesNotContain("another-live-token");
+    }
 }

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenAuthScheme.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenAuthScheme.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+
+/**
+ * Replaces AWS SigV4 signing with a plain OAuth {@code Authorization: Bearer <token>} header —
+ * GCS's XML API accepts this directly (docs.cloud.google.com/storage/docs/authentication), so a
+ * GCS bucket can be listed through the same S3-compatible client path without HMAC interoperability
+ * keys.
+ *
+ * <p>Registered under {@link AwsV4AuthScheme#SCHEME_ID} (see {@link S3ClientFactory}): the S3
+ * client's built-in auth-scheme resolver still selects "sigv4" for every request (that selection
+ * logic is unrelated to which {@link AuthScheme} implementation answers for that scheme id), but
+ * this implementation is installed in its place, so its {@link #identityProvider} and {@link
+ * #signer} run instead of the SDK's real SigV4 ones. This is the current (non-deprecated) SDK
+ * auth-scheme SPI — the legacy {@code Signer}/{@code SdkAdvancedClientOption.SIGNER} override point
+ * still exists but is deprecated in the pinned SDK version.
+ */
+final class BearerTokenAuthScheme implements AuthScheme<BearerTokenIdentity> {
+
+    private final BearerTokenSupplier tokenSupplier;
+
+    BearerTokenAuthScheme(BearerTokenSupplier tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
+    }
+
+    @Override
+    public String schemeId() {
+        return AwsV4AuthScheme.SCHEME_ID;
+    }
+
+    @Override
+    public IdentityProvider<BearerTokenIdentity> identityProvider(IdentityProviders providers) {
+        return new IdentityProvider<>() {
+            @Override
+            public Class<BearerTokenIdentity> identityType() {
+                return BearerTokenIdentity.class;
+            }
+
+            @Override
+            public CompletableFuture<BearerTokenIdentity> resolveIdentity(ResolveIdentityRequest request) {
+                return CompletableFuture.completedFuture(new BearerTokenIdentity(tokenSupplier.token()));
+            }
+        };
+    }
+
+    @Override
+    public HttpSigner<BearerTokenIdentity> signer() {
+        return new HttpSigner<>() {
+            @Override
+            public SignedRequest sign(SignRequest<? extends BearerTokenIdentity> request) {
+                return SignedRequest.builder()
+                        .request(withBearerHeader(request.request(), request.identity()))
+                        .payload(request.payload().orElse(null))
+                        .build();
+            }
+
+            @Override
+            public CompletableFuture<AsyncSignedRequest> signAsync(AsyncSignRequest<? extends BearerTokenIdentity> request) {
+                return CompletableFuture.completedFuture(AsyncSignedRequest.builder()
+                        .request(withBearerHeader(request.request(), request.identity()))
+                        .payload(request.payload().orElse(null))
+                        .build());
+            }
+        };
+    }
+
+    private static SdkHttpRequest withBearerHeader(SdkHttpRequest request, BearerTokenIdentity identity) {
+        return request.toBuilder()
+                .putHeader("Authorization", "Bearer " + identity.token())
+                .build();
+    }
+}

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenCommandException.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenCommandException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+/**
+ * Unchecked: thrown from inside the AWS SDK's signing pipeline ({@link BearerTokenAuthScheme}),
+ * whose {@code IdentityProvider}/{@code HttpSigner} callbacks declare no checked exception. Surfaces
+ * to the caller as the cause of an SDK-level failure around the affected request, same as any other
+ * signing-time fault.
+ */
+final class BearerTokenCommandException extends RuntimeException {
+
+    BearerTokenCommandException(String message) {
+        super(message);
+    }
+
+    BearerTokenCommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenIdentity.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenIdentity.java
@@ -5,9 +5,16 @@
  */
 package io.varve.swath.store.s3;
 
+import io.varve.swath.observability.SafeInput;
 import software.amazon.awssdk.identity.spi.Identity;
 
-/** The {@link Identity} carrying a resolved bearer token through the AWS SDK's auth-scheme SPI. */
+/**
+ * The {@link Identity} carrying a resolved bearer token through the AWS SDK's auth-scheme SPI.
+ *
+ * <p>Deliberately a class with a redacting {@link #toString()} rather than a {@code record}: a
+ * record would auto-generate a {@code toString()} printing the live token, and the SDK's own
+ * diagnostics do stringify identities. Keep it this way.
+ */
 final class BearerTokenIdentity implements Identity {
 
     private final String token;
@@ -18,5 +25,10 @@ final class BearerTokenIdentity implements Identity {
 
     String token() {
         return token;
+    }
+
+    @Override
+    public String toString() {
+        return "BearerTokenIdentity[token=" + SafeInput.REDACTED_SECRET + "]";
     }
 }

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenIdentity.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenIdentity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+import software.amazon.awssdk.identity.spi.Identity;
+
+/** The {@link Identity} carrying a resolved bearer token through the AWS SDK's auth-scheme SPI. */
+final class BearerTokenIdentity implements Identity {
+
+    private final String token;
+
+    BearerTokenIdentity(String token) {
+        this.token = token;
+    }
+
+    String token() {
+        return token;
+    }
+}

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenSupplier.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/BearerTokenSupplier.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+/**
+ * Supplies a fresh OAuth-style bearer token on demand. Implementations own their own
+ * caching/refresh policy; {@link #token()} may be called once per request and must be cheap in the
+ * common case. Never log the returned value.
+ */
+@FunctionalInterface
+public interface BearerTokenSupplier {
+
+    String token();
+}

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+import io.varve.swath.observability.SafeInput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link BearerTokenSupplier} backed by an external command (run through {@code /bin/sh -c}),
+ * whose stdout — trimmed of surrounding whitespace — is the token. Deliberately provider-agnostic:
+ * {@code gcloud auth print-access-token} for GCS, a Workload-Identity-Federation exchange script, or
+ * any other bearer-minting command all work the same way, so no cloud-provider SDK or credential
+ * library is pulled into {@code swath-s3} for this (module boundary: {@code
+ * docs/internals/build-and-modules.md}).
+ *
+ * <p>The token is cached and re-minted only after {@code refreshInterval} elapses since the last
+ * successful run — a fixed cadence, not real expiry-awareness (the raw string alone carries no
+ * portable expiry). Size {@code refreshInterval} comfortably under the token source's real TTL
+ * (default 45 min; GCS/Google OAuth access tokens are typically valid ~1 h).
+ *
+ * <p>Thread-safe: concurrent callers during a refresh block on the same in-flight command rather
+ * than racing separate processes.
+ */
+public final class ProcessBearerTokenSupplier implements BearerTokenSupplier {
+
+    private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(30);
+
+    private final List<String> command;
+    private final Duration refreshInterval;
+
+    private volatile String cachedToken;
+    private volatile Instant fetchedAt = Instant.MIN;
+
+    public ProcessBearerTokenSupplier(String shellCommand, Duration refreshInterval) {
+        this.command = List.of("/bin/sh", "-c", shellCommand);
+        this.refreshInterval = refreshInterval;
+    }
+
+    @Override
+    public synchronized String token() {
+        Instant now = Instant.now();
+        if (cachedToken == null || now.isAfter(fetchedAt.plus(refreshInterval))) {
+            cachedToken = run();
+            fetchedAt = now;
+        }
+        return cachedToken;
+    }
+
+    private String run() {
+        Process process;
+        try {
+            process = new ProcessBuilder(command).start();
+        } catch (IOException e) {
+            throw new BearerTokenCommandException("failed to start --bearer-token-command", e);
+        }
+        // Drain stdout/stderr concurrently (not sequentially): a child that writes enough to the
+        // stream we read second can otherwise block on a full pipe buffer while we sit blocked
+        // reading the first, deadlocking both sides.
+        AtomicReference<String> stdoutRef = new AtomicReference<>("");
+        AtomicReference<String> stderrRef = new AtomicReference<>("");
+        Thread stdoutReader = Thread.ofVirtual().start(() -> stdoutRef.set(readAllQuietly(process.getInputStream())));
+        Thread stderrReader = Thread.ofVirtual().start(() -> stderrRef.set(readAllQuietly(process.getErrorStream())));
+        try {
+            stdoutReader.join();
+            stderrReader.join();
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+            throw new BearerTokenCommandException("interrupted while reading --bearer-token-command output", e);
+        }
+        String stdout = stdoutRef.get().strip();
+        String stderr = stderrRef.get().strip();
+        boolean finished;
+        try {
+            finished = process.waitFor(COMMAND_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+            throw new BearerTokenCommandException("interrupted while running --bearer-token-command", e);
+        }
+        if (!finished) {
+            process.destroyForcibly();
+            throw new BearerTokenCommandException(
+                    "--bearer-token-command did not exit within " + COMMAND_TIMEOUT);
+        }
+        int exitValue = process.exitValue();
+        if (exitValue != 0) {
+            throw new BearerTokenCommandException("--bearer-token-command exited " + exitValue
+                    + (stderr.isEmpty() ? "" : ": " + SafeInput.logText(stderr)));
+        }
+        if (stdout.isEmpty()) {
+            throw new BearerTokenCommandException("--bearer-token-command produced no output");
+        }
+        return stdout;
+    }
+
+    private static String readAllQuietly(InputStream in) {
+        try {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "";
+        }
+    }
+}

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
@@ -63,6 +63,20 @@ public final class ProcessBearerTokenSupplier implements BearerTokenSupplier {
         return cachedToken;
     }
 
+    /**
+     * Redacts the command, and exists for that reason alone. {@link S3Config} is a record holding
+     * this supplier, so {@code S3Config.toString()} recurses in here — one {@code log.debug("config
+     * {}", config)} anywhere downstream would otherwise put the operator's
+     * {@code --bearer-token-command} in a log, and nothing obliges that command to merely MINT a
+     * token ({@code 'echo <token>'} is a plausible spelling). Without this override the default
+     * {@code Object.toString()} makes that safe by accident; this makes it safe by construction.
+     */
+    @Override
+    public String toString() {
+        return "ProcessBearerTokenSupplier[command=" + SafeInput.REDACTED_SECRET
+                + ", refreshInterval=" + refreshInterval + "]";
+    }
+
     private String run() {
         Process process;
         try {

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/ProcessBearerTokenSupplier.java
@@ -33,17 +33,24 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class ProcessBearerTokenSupplier implements BearerTokenSupplier {
 
-    private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_COMMAND_TIMEOUT = Duration.ofSeconds(30);
 
     private final List<String> command;
     private final Duration refreshInterval;
+    private final Duration commandTimeout;
 
     private volatile String cachedToken;
     private volatile Instant fetchedAt = Instant.MIN;
 
     public ProcessBearerTokenSupplier(String shellCommand, Duration refreshInterval) {
+        this(shellCommand, refreshInterval, DEFAULT_COMMAND_TIMEOUT);
+    }
+
+    /** Test-only: a short {@code commandTimeout} so a hung-process test doesn't wait 30s. */
+    ProcessBearerTokenSupplier(String shellCommand, Duration refreshInterval, Duration commandTimeout) {
         this.command = List.of("/bin/sh", "-c", shellCommand);
         this.refreshInterval = refreshInterval;
+        this.commandTimeout = commandTimeout;
     }
 
     @Override
@@ -65,24 +72,20 @@ public final class ProcessBearerTokenSupplier implements BearerTokenSupplier {
         }
         // Drain stdout/stderr concurrently (not sequentially): a child that writes enough to the
         // stream we read second can otherwise block on a full pipe buffer while we sit blocked
-        // reading the first, deadlocking both sides.
+        // reading the first, deadlocking both sides. These reader threads run independently of —
+        // and start before — the waitFor() below, so bounding the process's lifetime there doesn't
+        // reintroduce that deadlock.
         AtomicReference<String> stdoutRef = new AtomicReference<>("");
         AtomicReference<String> stderrRef = new AtomicReference<>("");
         Thread stdoutReader = Thread.ofVirtual().start(() -> stdoutRef.set(readAllQuietly(process.getInputStream())));
         Thread stderrReader = Thread.ofVirtual().start(() -> stderrRef.set(readAllQuietly(process.getErrorStream())));
-        try {
-            stdoutReader.join();
-            stderrReader.join();
-        } catch (InterruptedException e) {
-            process.destroyForcibly();
-            Thread.currentThread().interrupt();
-            throw new BearerTokenCommandException("interrupted while reading --bearer-token-command output", e);
-        }
-        String stdout = stdoutRef.get().strip();
-        String stderr = stderrRef.get().strip();
+        // waitFor() MUST run before joining the reader threads: a hung child that keeps its pipes
+        // open (the common case — alive but not yet producing output) never triggers stream EOF, so
+        // join() alone could block forever and the commandTimeout below would never be reached.
+        // token() is synchronized, so that would stall every subsequent signing call indefinitely.
         boolean finished;
         try {
-            finished = process.waitFor(COMMAND_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            finished = process.waitFor(commandTimeout.toNanos(), TimeUnit.NANOSECONDS);
         } catch (InterruptedException e) {
             process.destroyForcibly();
             Thread.currentThread().interrupt();
@@ -91,8 +94,19 @@ public final class ProcessBearerTokenSupplier implements BearerTokenSupplier {
         if (!finished) {
             process.destroyForcibly();
             throw new BearerTokenCommandException(
-                    "--bearer-token-command did not exit within " + COMMAND_TIMEOUT);
+                    "--bearer-token-command did not exit within " + commandTimeout);
         }
+        // The process has exited (or was just destroyed above), so its pipes are closed and these
+        // joins return promptly.
+        try {
+            stdoutReader.join();
+            stderrReader.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BearerTokenCommandException("interrupted while reading --bearer-token-command output", e);
+        }
+        String stdout = stdoutRef.get().strip();
+        String stderr = stderrRef.get().strip();
         int exitValue = process.exitValue();
         if (exitValue != 0) {
             throw new BearerTokenCommandException("--bearer-token-command exited " + exitValue

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/S3ClientFactory.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/S3ClientFactory.java
@@ -126,6 +126,14 @@ public final class S3ClientFactory {
                 .forcePathStyle(config.forcePathStyle())
                 .credentialsProvider(config.credentials());
 
+        // --bearer-token-command: install in place of the SDK's real SigV4 auth scheme (same scheme
+        // id — see BearerTokenAuthScheme's javadoc for why that's what makes the client actually use
+        // it). config.credentials() above is still set (the builder requires a non-null provider) but
+        // goes unused: this scheme's signer never consults it.
+        if (config.bearerTokenSupplier() != null) {
+            builder.putAuthScheme(new BearerTokenAuthScheme(config.bearerTokenSupplier()));
+        }
+
         if (config.region() != null) {
             builder.region(config.region());
         }

--- a/swath-s3/src/main/java/io/varve/swath/store/s3/S3Config.java
+++ b/swath-s3/src/main/java/io/varve/swath/store/s3/S3Config.java
@@ -26,8 +26,21 @@ public record S3Config(
         Duration apiCallAttemptTimeout,  // per-attempt page timeout budget (WORKER pages; client-level)
         Duration apiCallTimeout,         // overall per-logical-call ceiling (bounds a hung fetch)
         AwsCredentialsProvider credentials,
-        Duration probeApiCallAttemptTimeout   // short per-attempt budget for probe call classes
+        Duration probeApiCallAttemptTimeout,  // short per-attempt budget for probe call classes
+        BearerTokenSupplier bearerTokenSupplier  // nullable; non-null replaces SigV4 signing (--bearer-token-command)
 ) {
+
+    /**
+     * 9-arg convenience constructor: {@link #bearerTokenSupplier} defaults to {@code null} (normal
+     * SigV4/{@code credentials} signing) — mirrors the pattern used for {@code PageRequest}'s
+     * additive field, so existing 9-arg call sites compile unchanged.
+     */
+    public S3Config(Region region, URI endpointOverride, boolean forcePathStyle, int maxParallelListings,
+                     int maxAttempts, Duration apiCallAttemptTimeout, Duration apiCallTimeout,
+                     AwsCredentialsProvider credentials, Duration probeApiCallAttemptTimeout) {
+        this(region, endpointOverride, forcePathStyle, maxParallelListings, maxAttempts, apiCallAttemptTimeout,
+                apiCallTimeout, credentials, probeApiCallAttemptTimeout, null);
+    }
 
     /**
      * Per-attempt SDK timeout: a single LIST attempt must not hang. At

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/BearerTokenAuthSchemeTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/BearerTokenAuthSchemeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.AsyncSignedRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.identity.spi.IdentityProviders;
+import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
+
+/**
+ * {@link BearerTokenAuthScheme} replaces SigV4 signing with a plain OAuth bearer header.
+ * Registered under {@link AwsV4AuthScheme#SCHEME_ID} so the S3 client's built-in "use sigv4"
+ * resolution keeps selecting it (see the class javadoc); these tests exercise the identity
+ * resolution and signing behavior directly, without a network call.
+ */
+class BearerTokenAuthSchemeTest {
+
+    private static final SdkHttpRequest BASE_REQUEST = SdkHttpRequest.builder()
+            .method(SdkHttpMethod.GET)
+            .uri(URI.create("https://storage.googleapis.com/some-bucket?list-type=2"))
+            .putHeader("x-existing", "kept")
+            .build();
+
+    @Test
+    void schemeIdMatchesSigV4SoTheBuiltInResolverStillSelectsIt() {
+        BearerTokenAuthScheme scheme = new BearerTokenAuthScheme(() -> "tok");
+        assertThat(scheme.schemeId()).isEqualTo(AwsV4AuthScheme.SCHEME_ID);
+    }
+
+    @Test
+    void identityProviderWrapsTheSuppliersCurrentToken() {
+        BearerTokenAuthScheme scheme = new BearerTokenAuthScheme(() -> "fresh-token");
+        IdentityProvider<BearerTokenIdentity> provider = scheme.identityProvider(noOpProviders());
+
+        assertThat(provider.identityType()).isEqualTo(BearerTokenIdentity.class);
+        BearerTokenIdentity identity = provider.resolveIdentity(ResolveIdentityRequest.builder().build()).join();
+        assertThat(identity.token()).isEqualTo("fresh-token");
+    }
+
+    @Test
+    void signerAddsBearerHeaderAndPreservesTheRequestOtherwise() {
+        BearerTokenAuthScheme scheme = new BearerTokenAuthScheme(() -> "secret-token");
+        BearerTokenIdentity identity = new BearerTokenIdentity("secret-token");
+        SignRequest<BearerTokenIdentity> request = SignRequest.builder(identity)
+                .request(BASE_REQUEST)
+                .build();
+
+        SignedRequest signed = scheme.signer().sign(request);
+
+        assertThat(signed.request().firstMatchingHeader("Authorization"))
+                .contains("Bearer secret-token");
+        assertThat(signed.request().firstMatchingHeader("x-existing")).contains("kept");
+        assertThat(signed.request().method()).isEqualTo(SdkHttpMethod.GET);
+        assertThat(signed.request().getUri()).isEqualTo(BASE_REQUEST.getUri());
+    }
+
+    @Test
+    void signerNeverFallsBackToSigV4EvenWhenIdentityCarriesNoCredentialFields() {
+        // The whole point: a BearerTokenIdentity has no access-key/secret-key at all, so if the
+        // signer ever silently delegated to real SigV4 machinery instead of just stamping the
+        // header itself, this would fail loudly (NPE/ClassCast) rather than producing a wrong
+        // signature that only fails against a live endpoint.
+        BearerTokenAuthScheme scheme = new BearerTokenAuthScheme(() -> "t");
+        SignRequest<BearerTokenIdentity> request = SignRequest.builder(new BearerTokenIdentity("t"))
+                .request(BASE_REQUEST)
+                .build();
+
+        assertThat(scheme.signer().sign(request).request().firstMatchingHeader("Authorization"))
+                .contains("Bearer t");
+    }
+
+    @Test
+    void asyncSignerAddsTheSameBearerHeader() {
+        BearerTokenAuthScheme scheme = new BearerTokenAuthScheme(() -> "async-token");
+        BearerTokenIdentity identity = new BearerTokenIdentity("async-token");
+        AsyncSignRequest<BearerTokenIdentity> request = AsyncSignRequest.builder(identity)
+                .request(BASE_REQUEST)
+                .build();
+
+        CompletableFuture<AsyncSignedRequest> future = scheme.signer().signAsync(request);
+
+        assertThat(future).isCompleted();
+        assertThat(future.join().request().firstMatchingHeader("Authorization"))
+                .contains("Bearer async-token");
+    }
+
+    private static IdentityProviders noOpProviders() {
+        return IdentityProviders.builder().build();
+    }
+}

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
@@ -78,4 +78,22 @@ class ProcessBearerTokenSupplierTest {
                 "yes err | head -c 200000 >&2; echo tok", Duration.ofMinutes(45));
         assertThat(supplier.token()).isEqualTo("tok");
     }
+
+    /**
+     * Regression guard (CodeRabbit review, PR #23): a process that stays alive without closing its
+     * pipes must be killed and reported at {@code commandTimeout}, not hang {@link
+     * ProcessBearerTokenSupplier#token()} forever. The original bug joined the stdout/stderr reader
+     * threads BEFORE calling {@code waitFor(timeout)} — since a live child's pipes stay open until
+     * it exits, that join never returned, so the timeout check below it was unreachable. Because
+     * {@code token()} is {@code synchronized}, that would have stalled every subsequent signing call
+     * indefinitely, not just this one. Uses a short injected {@code commandTimeout} so the test
+     * itself doesn't wait out the real 30s default.
+     */
+    @Test
+    void killsAndReportsAHungProcessAtTheCommandTimeoutInsteadOfHangingForever() {
+        var supplier = new ProcessBearerTokenSupplier("sleep 300", Duration.ofMinutes(45), Duration.ofMillis(300));
+        assertThatThrownBy(supplier::token)
+                .isInstanceOf(BearerTokenCommandException.class)
+                .hasMessageContaining("did not exit within");
+    }
 }

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.store.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ProcessBearerTokenSupplier} runs an arbitrary shell command and treats its trimmed stdout
+ * as the token, caching it for {@code refreshInterval}. Every case here uses a real {@code /bin/sh}
+ * subprocess (no mocking the process layer) since the caching/refresh/failure behavior IS the
+ * subprocess-handling logic under test.
+ */
+class ProcessBearerTokenSupplierTest {
+
+    @Test
+    void returnsTrimmedStdout() {
+        var supplier = new ProcessBearerTokenSupplier("printf '  tok-123  \\n'", Duration.ofMinutes(45));
+        assertThat(supplier.token()).isEqualTo("tok-123");
+    }
+
+    @Test
+    void cachesWithinTheRefreshInterval() {
+        var supplier = new ProcessBearerTokenSupplier(
+                "echo tok-$(date +%s%N)", Duration.ofMinutes(45));
+        String first = supplier.token();
+        String second = supplier.token();
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    void reRunsTheCommandOnceTheRefreshIntervalHasElapsed() throws InterruptedException {
+        var supplier = new ProcessBearerTokenSupplier(
+                "echo tok-$(date +%s%N)", Duration.ofMillis(1));
+        String first = supplier.token();
+        Thread.sleep(10);
+        String second = supplier.token();
+        assertThat(second).isNotEqualTo(first);
+    }
+
+    @Test
+    void throwsOnNonZeroExit() {
+        var supplier = new ProcessBearerTokenSupplier("echo denied >&2; exit 7", Duration.ofMinutes(45));
+        assertThatThrownBy(supplier::token)
+                .isInstanceOf(BearerTokenCommandException.class)
+                .hasMessageContaining("exited 7")
+                .hasMessageContaining("denied");
+    }
+
+    @Test
+    void throwsOnEmptyOutput() {
+        var supplier = new ProcessBearerTokenSupplier("true", Duration.ofMinutes(45));
+        assertThatThrownBy(supplier::token)
+                .isInstanceOf(BearerTokenCommandException.class)
+                .hasMessageContaining("no output");
+    }
+
+    @Test
+    void throwsWhenTheCommandCannotBeStarted() {
+        var supplier = new ProcessBearerTokenSupplier(
+                "/definitely/not/a/real/binary-xyz", Duration.ofMinutes(45));
+        // Not "cannot start" -- /bin/sh -c itself starts fine and reports the exec failure via a
+        // non-zero exit, exactly like a real misconfigured --bearer-token-command would.
+        assertThatThrownBy(supplier::token).isInstanceOf(BearerTokenCommandException.class);
+    }
+
+    @Test
+    void largeStderrDoesNotDeadlockAgainstSmallStdout() {
+        // Regression guard for reading stdout/stderr concurrently instead of sequentially: a
+        // command that fills the stderr pipe buffer before writing (small) stdout must not hang.
+        var supplier = new ProcessBearerTokenSupplier(
+                "yes err | head -c 200000 >&2; echo tok", Duration.ofMinutes(45));
+        assertThat(supplier.token()).isEqualTo("tok");
+    }
+}

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
@@ -8,6 +8,7 @@ package io.varve.swath.store.s3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.varve.swath.observability.SafeInput;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
@@ -95,5 +96,45 @@ class ProcessBearerTokenSupplierTest {
         assertThatThrownBy(supplier::token)
                 .isInstanceOf(BearerTokenCommandException.class)
                 .hasMessageContaining("did not exit within");
+    }
+
+    /**
+     * The command must not be recoverable from a stringified supplier. {@link S3Config} is a record
+     * holding this supplier, so {@code S3Config.toString()} recurses in here — one {@code
+     * log.debug("config {}", config)} downstream would otherwise print the operator's
+     * {@code --bearer-token-command}, and nothing obliges that command to merely MINT a token
+     * ({@code 'echo <token>'} is a plausible spelling). The default {@code Object.toString()} would
+     * make this pass by accident; the explicit override makes it hold by construction, and this
+     * test fails if someone deletes it or turns the class into a record.
+     */
+    @Test
+    void toStringRedactsTheCommandAndSurvivesBeingNestedInAnS3ConfigRecord() {
+        var supplier = new ProcessBearerTokenSupplier("echo eyJhbGciOiJSUzI1NiRealTokenHere",
+                Duration.ofMinutes(45));
+
+        assertThat(supplier.toString())
+                .doesNotContain("eyJhbGci")
+                .doesNotContain("echo")
+                .contains(SafeInput.REDACTED_SECRET);
+
+        // The realistic leak path: the supplier stringified as a component of the config record.
+        S3Config config = new S3Config(
+                null, null, false,
+                S3Config.DEFAULT_MAX_PARALLEL,
+                S3Config.DEFAULT_MAX_ATTEMPTS,
+                S3Config.DEFAULT_ATTEMPT_TIMEOUT,
+                S3Config.DEFAULT_API_CALL_TIMEOUT,
+                null,
+                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT,
+                supplier);
+        assertThat(config.toString()).doesNotContain("eyJhbGci").doesNotContain("echo");
+    }
+
+    /** The resolved token must not be recoverable from a stringified identity either. */
+    @Test
+    void identityToStringRedactsTheToken() {
+        assertThat(new BearerTokenIdentity("eyJhbGciOiJSUzI1NiRealTokenHere").toString())
+                .doesNotContain("eyJhbGci")
+                .contains(SafeInput.REDACTED_SECRET);
     }
 }

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/S3ClientFactoryTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/S3ClientFactoryTest.java
@@ -132,6 +132,29 @@ class S3ClientFactoryTest {
         }
     }
 
+    /**
+     * A {@code bearerTokenSupplier}-configured {@link S3Config} must still build a client without
+     * touching the network — {@link S3ClientFactory#create} installs {@link BearerTokenAuthScheme}
+     * via {@code putAuthScheme}, which is a builder-time registration, not a connection.
+     */
+    @Test
+    void bearerTokenSupplierConfigBuildsAClientWithoutNetwork() {
+        S3Config config = new S3Config(
+                Region.US_EAST_1,
+                URI.create("https://storage.googleapis.com"),
+                true,
+                64,
+                S3Config.DEFAULT_MAX_ATTEMPTS,
+                S3Config.DEFAULT_ATTEMPT_TIMEOUT,
+                S3Config.DEFAULT_API_CALL_TIMEOUT,
+                StaticCredentialsProvider.create(AwsBasicCredentials.create("unused", "unused")),
+                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT,
+                () -> "test-token");
+        try (S3Client client = S3ClientFactory.create(config)) {
+            assertThat(client).isNotNull();
+        }
+    }
+
     private static S3Config testConfig(Region region) {
         return new S3Config(
                 region,

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/S3ConfigDefaultsTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/S3ConfigDefaultsTest.java
@@ -44,4 +44,38 @@ class S3ConfigDefaultsTest {
         assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofSeconds(60));
     }
+
+    /**
+     * The 9-arg constructor is the compatibility overload every pre-existing call site (tests,
+     * {@code LocalStackSupport}, the replay-server ITs) still uses unmodified — it must default
+     * {@code bearerTokenSupplier} to {@code null} (normal SigV4/{@code credentials} signing), not
+     * silently require every caller to be updated for an unrelated GCS-only feature.
+     */
+    @Test
+    void nineArgConstructorDefaultsBearerTokenSupplierToNull() {
+        S3Config config = new S3Config(
+                null, null, false,
+                S3Config.DEFAULT_MAX_PARALLEL,
+                S3Config.DEFAULT_MAX_ATTEMPTS,
+                S3Config.DEFAULT_ATTEMPT_TIMEOUT,
+                S3Config.DEFAULT_API_CALL_TIMEOUT,
+                null,
+                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT);
+        assertThat(config.bearerTokenSupplier()).isNull();
+    }
+
+    @Test
+    void tenArgConstructorCarriesTheBearerTokenSupplier() {
+        BearerTokenSupplier supplier = () -> "tok";
+        S3Config config = new S3Config(
+                null, null, false,
+                S3Config.DEFAULT_MAX_PARALLEL,
+                S3Config.DEFAULT_MAX_ATTEMPTS,
+                S3Config.DEFAULT_ATTEMPT_TIMEOUT,
+                S3Config.DEFAULT_API_CALL_TIMEOUT,
+                null,
+                S3Config.DEFAULT_PROBE_ATTEMPT_TIMEOUT,
+                supplier);
+        assertThat(config.bearerTokenSupplier()).isSameAs(supplier);
+    }
 }


### PR DESCRIPTION
## Summary

- GCS's XML API is largely `ListObjectsV2`-compatible, including `start-after` (verified live against `docs.cloud.google.com/storage/docs/xml-api/get-bucket-list`), which is the primitive swath's engine actually depends on for range-stealing.
- Adds `--bearer-token-command CMD` / `--bearer-token-refresh-interval DURATION`: runs an external command (e.g. `gcloud auth print-access-token`) and installs its stdout as a plain `Authorization: Bearer <token>` header via the AWS SDK v2's current `AuthScheme`/`HttpSigner` SPI, in place of SigV4 signing — registered under `AwsV4AuthScheme.SCHEME_ID` so the S3 client's normal "use sigv4" resolution keeps selecting it.
- Deliberately provider-agnostic: no Google auth library added to `swath-s3` (keeps the module AWS-only per `docs/internals/build-and-modules.md`'s stated boundary — GCS-specific code/deps are reserved for a future `swath-gcs` module). Any bearer-minting command works: `gcloud`, a Workload-Identity-Federation exchange script, an internal secrets tool, etc.
- Verified end-to-end against a real internal GCS bucket with the actual `swath list` binary: JSONL and sorted-Parquet output both produced correct results with `--endpoint-url https://storage.googleapis.com --force-path-style --bearer-token-command 'gcloud auth print-access-token'`.

## Explicitly out of scope

- Remote **output**/checkpoint to GCS — swath's output is always a local path today, so this doesn't touch it. GCS's XML API forbids preconditions on multipart uploads (verified live against current docs), which would block a future GCS output destination through this same XML path regardless.
- Native GCS listing (`startOffset`/`endOffset`, a real `swath-gcs` module) — this is the existing S3-compatible-XML path with a different auth mechanism, not a new provider backend.
- Percent-encoding/decoding conformance against real GCS (a known LocalStack bug class per `docs/internals/s3-implementation-compatibility.md`) — untested here; only plain-ASCII keys were exercised.

## Test plan

- [x] `:swath-s3:test` — new `BearerTokenAuthSchemeTest`, `ProcessBearerTokenSupplierTest`, plus extended `S3ConfigDefaultsTest`/`S3ClientFactoryTest` (22 tests, all green)
- [x] `compileJava compileTestJava installDist` across every module (including `swath-replay-server`) — clean
- [x] Live smoke test against a real internal GCS bucket via the real `swath` binary: `--format jsonl` and `--format parquet --sort`, both correct output, clean run summaries, zero stderr warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OAuth-style bearer-token authentication for S3-compatible connections.
  * Added `--bearer-token-command` and `--bearer-token-refresh-interval` (default: 45m) and updated resume behavior to require re-supplying the command.
  * Documented listing GCS buckets via the S3-compatible XML API with `ListObjectsV2`-style assumptions.
* **Documentation**
  * Updated configuration/usage guides and CLI help with bearer-token examples and refresh semantics.
* **Security / Hardening**
  * Improved argv persistence redaction to better protect bearer-token command values.
* **Tests**
  * Added signing and process-based token supplier tests, plus client-creation and resume-wiring checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
