### PR TITLE
Deflake res4_killAfterRotation: await the first finalized part before injecting the kill

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/runtime/ResumeParquetTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/ResumeParquetTest.java
@@ -7,6 +7,7 @@ package io.varve.swath.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import io.varve.swath.checkpoint.Node;
 import io.varve.swath.checkpoint.NodeSpec;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -155,15 +157,6 @@ final class ResumeParquetTest {
         Path dir = tmp.resolve("out");
         Files.createDirectories(dir);
 
-        // Small part target ⇒ parts rotate (finalize) mid-run, advancing durable_cursor;
-        // crash on the 9th fetch leaves earlier finalized parts durable + an open part to discard.
-        MockPageFetcher faulty = MockPageFetcher.builder().keys(all).maxKeysCap(5)
-                .interceptor((req, idx, page) -> {
-                    if (idx == 9) {
-                        throw new ListingException("injected late kill");
-                    }
-                    return page;
-                }).build();
         MockPageFetcher clean2 = MockPageFetcher.builder().keys(all).maxKeysCap(5).build();
         RunContext ctx = RunContext.create();
 
@@ -171,6 +164,27 @@ final class ResumeParquetTest {
             RunMeta run = store.openRun(runKey(), false, false);
             store.insertNode(NodeSpec.rootRange(run.id()));
             Node node = store.loadResumable(run.id(), true).getFirst();
+
+            // Small part target ⇒ parts rotate (finalize) mid-run, advancing durable_cursor;
+            // crash on the 9th fetch leaves earlier finalized parts durable + an open part to discard.
+            // Finalization runs on the ParquetWriterPool's own writer-lane thread
+            // (ParquetWriterPool#runLane, forked in the constructor), decoupled from this fetch
+            // thread — so on a slow/contended runner the abort at fetch idx 9 can win the race
+            // against the first part's finalize+record (ParquetWriterPool#finalizeCurrent), leaving
+            // zero finalized parts (#36). Force the ordering the precondition below depends on
+            // instead of hoping for it: block THIS fetch thread on the designated kill fetch until
+            // the store itself reports a finalized part, then throw. This cannot deadlock — the
+            // writer lane drains its already-submitted batches on its own thread regardless of
+            // whether the producer ever reaches fetch idx 9.
+            MockPageFetcher faulty = MockPageFetcher.builder().keys(all).maxKeysCap(5)
+                    .interceptor((req, idx, page) -> {
+                        if (idx == 9) {
+                            await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(20))
+                                    .until(() -> !store.finalizedParts(run.id()).isEmpty());
+                            throw new ListingException("injected late kill");
+                        }
+                        return page;
+                    }).build();
 
             assertThatThrownBy(() -> new ListRunner().runToParquetCheckpointed(
                     ctx, faulty, dir, spec(256), store, run.id(), node, List.of()))


### PR DESCRIPTION
## Race explanation

`ParquetWriterPool#finalizeCurrent` (the part-finalize + manifest-commit path, invoked from `#writeBatch`/`#runLane`) runs on the pool's own writer-lane thread, forked in the constructor and decoupled from the fetch/producer thread the test's interceptor runs on. `CheckpointedScanProducer#produce` submits each fetched page to the pool's bounded lane queue and immediately fetches the next page — it never waits for that page's rotation/finalize to land. On a slow or contended runner, the lane thread can still be behind (or not yet scheduled at all) when the producer reaches the designated kill fetch (idx 9), so the injected `ListingException` aborts the run before any part has finalized, leaving `finalizedParts()` empty — exactly the "Expecting actual not to be empty" failure from CI runs 30221683041 and 30222830689.

## Fix

The interceptor, on fetch idx 9, first awaits (Awaitility, bounded 10s, polling every 20ms) until `store.finalizedParts(runId)` is non-empty, then throws. This forces the "kill strictly AFTER >=1 part rotated and finalized" ordering the test's precondition already asserts, instead of hoping the scheduler cooperates. No deadlock risk: the writer lane drains its already-submitted batches independently of whether the producer thread ever reaches fetch idx 9, so blocking the producer here only waits on progress that does not depend on it.

Test-only change — zero `src/main` diff.

## Evidence

1. **Reproduced the exact CI symptom** against the ORIGINAL (unmodified) test by temporarily adding `Thread.sleep(2000)` at the top of `ParquetWriterPool#runLane` (simulating a writer lane slow to be scheduled). The original test failed deterministically:
   ```
   java.lang.AssertionError: [a part rotated + finalized before the kill]
   Expecting actual not to be empty
       at io.varve.swath.runtime.ResumeParquetTest.res4_killAfterRotation_finalizedPartsSurvive_tailReListed(ResumeParquetTest.java:181)
   ```
   — the same assertion and message CI reported.

2. With the same temporary 2s delay still in place, the **fixed test passed**: `res4_killAfterRotation_finalizedPartsSurvive_tailReListed(Path) PASSED`. The temporary source change was then fully reverted (`git diff --stat` confirms zero `swath-core/src/main` changes going into this PR).

3. Ran the fixed test method **30 times in a loop** (`./gradlew :swath-core:test --tests ...res4_killAfterRotation_finalizedPartsSurvive_tailReListed --rerun`, without the induced delay): 30/30 green.

Also ran the full `ResumeParquetTest` class once (4/4 green) and `:swath-core:spotlessCheck` (clean).

Fixes #36