### PR TITLE
Deflake finalizeFailureRecordsFinalizeFailed: arm the fault with a row trigger, not a clock race

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
@@ -115,21 +115,29 @@ class ParquetWriterPoolMetricsTest {
         // own already-open output-stream handle is unaffected (POSIX permission checks apply only
         // at open() time, not to already-open descriptors), so the write itself still lands; only
         // the SECOND, explicit open for fsync (the one finalizeCurrent's IOException catch guards)
-        // fails. This is the same time-trigger clock-seam pattern as timeTriggerRotationRecordsTimeReason.
+        // fails.
+        //
+        // A ROW-COUNT trigger -- not the clock-driven time trigger this test used to arm the fault
+        // with -- makes the fault window deterministic. Whether rotation fires is then a pure
+        // function of how many rows THIS lane thread has itself written from the ordered queue;
+        // nothing the test thread does (revoking permissions, submitting the next batch) can move
+        // that number. The old clock-based design raced: under full-suite load, the lane thread
+        // could still be evaluating the FIRST (under-threshold) batch's rotationReason() by the
+        // time the test thread had already bumped the injected clock and revoked permissions -- so
+        // the FIRST batch's own rotation check (now reading the already-bumped clock) could fire
+        // the fault before the SECOND, intended batch ever ran, recording the failure into the
+        // pool's shared state before the test's own second submit() call -- which then threw the
+        // already-recorded failure straight out of `pool.submit()` (via `checkFailure()`) instead
+        // of surfacing where this test asserts it (#37).
         RunContext ctx = RunContext.create();
-        AtomicLong clock = new AtomicLong(0);
-        long intervalNanos = Duration.ofSeconds(10).toNanos();
         var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "hash", 1, Long.MAX_VALUE, 8,
-                ParquetWriterPoolConfig.DEFAULT.withRotationIntervalNanos(intervalNanos).withMetrics(ctx.metrics()),
-                clock::get);
+                ParquetWriterPoolConfig.DEFAULT.withRotationMaxRows(5L).withMetrics(ctx.metrics()));
         Path partPath = DatasetLayout.of(dir).dataFile("part-w0-00000.parquet");
 
-        pool.submit(batch(0, 0, 0, 10));   // opens part-w0-00000 (partOpenedAtNanos captured at clock=0)
+        pool.submit(batch(0, 0, 0, 3));   // opens part-w0-00000; 3 rows < maxRows(5) -> never rotates on its own
         await().atMost(Duration.ofSeconds(5)).until(() -> Files.exists(partPath));
-        Thread.sleep(50);   // let writeBatch()'s rotationReason() check (still reading clock=0) finish too
         Files.setPosixFilePermissions(partPath, Set.of());   // revoke access for any NEW open() of this file
-        clock.addAndGet(intervalNanos + 1);
-        pool.submit(batch(0, 1, 10, 11));   // next write's rotationReason() fires the time trigger -> finalizeCurrent -> close() fails
+        pool.submit(batch(0, 1, 3, 6));   // cumulative rows=6 >= maxRows(5) -> rotationReason() fires ROWS -> finalizeCurrent() -> close() fails
 
         try {
             MeterRegistry registry = ctx.meterRegistry();


### PR DESCRIPTION
## Diagnosis

The test armed its induced finalize failure with the time-based rotation trigger, using an injected `AtomicLong` clock the TEST thread bumps externally and a `Thread.sleep(50)` meant to let the writer lane's `rotationReason()` check for the FIRST (under-threshold) batch finish reading the clock before it changes. That sleep is a race, not a guarantee: under full-suite load, the writer lane thread (`ParquetWriterPool#runLane`, its own forked thread, decoupled from the test thread) can still be mid-flight on the FIRST batch's `writeBatch`/`rotationReason()` check (`ParquetWriterPool.java:269-311`) when the test thread has already bumped the clock and revoked the part's permissions. That check then reads the already-bumped clock, fires the TIME trigger on the wrong (first) batch, and `finalizeCurrent` (`ParquetWriterPool.java:320-374`) fails and records the failure into the pool's shared `failure` atomic BEFORE the test's own second `submit()` call runs. That second `submit()`'s own `checkFailure()` (`ParquetWriterPool.java` ~184/205) then throws the already-recorded `OutputException` straight out of `submit()` -- an uncaught exception outside the test's `try` block -- instead of the fault surfacing where the test asserts it, inside the awaited counter check (#37).

## Fix

Drive the fault with a ROW-COUNT trigger (`rotationMaxRows`) instead of the clock-driven time trigger. Whether rotation fires is then a pure function of how many rows the lane thread has itself written from the ordered queue -- nothing the test thread does (revoking permissions, submitting the next batch) can move that number, so there is no external state for the first batch's rotation check to race against. The first batch (3 rows) can never reach `maxRows(5)` regardless of scheduling; only the second batch's own write pushes the cumulative count over the threshold and triggers its own rotation.

Test-only change -- zero `src/main` diff.

## Evidence

1. **Reproduced the exact CI symptom** against the ORIGINAL (unmodified) test by temporarily adding a `Thread.sleep(200)` in `ParquetWriterPool#writeBatch` right before the `rotationReason()` check (simulating a writer lane slow to reach that check), plus a temporary `Thread.sleep(300)` in the test between the clock bump and the second `submit()` call (widening the window so the scheduler doesn't have to get lucky to hit it). The original test failed with the exact reported shape:
   ```
   io.varve.swath.error.OutputException: parquet writer failed
       at ParquetWriterPool.checkFailure(ParquetWriterPool.java:205)
       at ParquetWriterPool.submit(ParquetWriterPool.java:184)
       at ParquetWriterPoolMetricsTest.finalizeFailureRecordsFinalizeFailedAndNeitherFinalizedNorDiscarded(...:133)
   ```
   caused by the revoked-permission `AccessDeniedException` surfacing through `writeBatch -> finalizeCurrent`, i.e. escaping via `submit()`/`checkFailure()` exactly as #37 describes.

2. Reverted the temporary test-side sleep and, with the temporary `ParquetWriterPool#writeBatch` `sleep(200)` still in place, ran the **fixed test** (this PR's row-trigger version): PASSED.

3. Reverted the temporary source change entirely (`git diff --stat` confirmed zero `swath-core/src/main` changes going into this PR), then ran the fixed test method **30 times in a loop** (`./gradlew :swath-core:test --tests ...finalizeFailureRecordsFinalizeFailedAndNeitherFinalizedNorDiscarded --rerun`, with no induced delay): 30/30 green.

Also ran the full `ParquetWriterPoolMetricsTest` class once (6/6 green) and `:swath-core:spotlessCheck` (clean).

Fixes #37