### PR TITLE
Deflake radixBandedFlatRoot: inject page latency so peak_in_flight isn't CPU-bound

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
@@ -240,29 +240,26 @@ final class ShapeRegressionCorpusTest {
 
     /**
      * Rationale: a dense flat root (no {@code CommonPrefixes}) must radix-band at seed time
-     * ({@code dense_root_radix_banded} present in {@code decisions[]}) and — at zero latency, no
-     * timing dependency needed for this shape — must not collapse to a couple of ranges (peak
-     * in-flight reaches a healthy fraction of {@code W}).
+     * ({@code dense_root_radix_banded} present in {@code decisions[]}) and must not collapse to a
+     * couple of ranges (peak in-flight reaches a healthy fraction of {@code W}).
      *
-     * <p><b>CI-core constraint on the {@code peak_in_flight} floor.</b> At zero injected page
-     * latency, a "page fetch" is pure CPU work (an in-memory scan/compare, no {@code Thread.sleep}),
-     * so the number of REALLY-overlapping fetches {@code peak_in_flight} can observe is hard-capped by
-     * the number of physical cores actually scheduling worker threads at once — unlike the
-     * latency-injected corpus tests (e.g. {@link #healthyNestedFanoutControl_seedBandHighAvgInFlightCheapApi})
-     * where sleeping threads don't consume a core and so aren't core-bound. A fixed {@code workers / 4}
-     * floor (4 at {@code W=16}) is unreachable on a 2-core runner, even though the seed-time structural
-     * signal above (radix bands fired, {@code specs.size() > 8}) is unaffected by core count and stays
-     * green throughout. The floor is therefore capped at the runner's own core count, LESS ONE:
-     * capping at the bare count still demanded that every core be inside a fetch at the same sampled
-     * instant, which a shared 4-core CI runner does not owe anyone — the GC, the sampler and the JIT
-     * compete for exactly the cores the assertion is counting, and it read {@code peak_in_flight = 3}
-     * against a floor of 4 on the standard GitHub runner. One core of headroom keeps the guard
-     * meaningful without asserting perfect occupancy ({@code min(4, 3) = 3} on a 4-core runner;
-     * unchanged at {@code min(4, 7) = 4} on an 8+-core dev box, the original literal threshold):
-     * {@code peak_in_flight} is fundamentally a runtime-achieved-concurrency reading, not a
-     * placement/structure fact, and the zero-latency CPU-bound physics genuinely caps it at core
-     * count — the structural signal cannot substitute for it. The ablated shape still reads far
-     * below this floor (one un-banded range), so the guard keeps its bite.
+     * <p><b>Why the scan below injects a small per-page latency (unlike the seed step above, which
+     * stays at zero).</b> {@code peak_in_flight} is a runtime-achieved-concurrency reading, not a
+     * placement/structure fact, and at zero injected page latency a "page fetch" is pure CPU work —
+     * the whole 6000-key run can complete before the in-flight gauge ever samples a high value, so
+     * the reading measures how fast the runner burned through the work as much as it measures
+     * parallelism (#35: CI read {@code peak_in_flight = 2} against a floor of 3 on the standard
+     * GitHub runner, then passed 20/20 on an identical rerun — pure scheduler luck, not a
+     * regression). A small {@link Duration#ofMillis(long)} latency on the worker listing pages (the
+     * same idiom {@link #healthyNestedFanoutControl_seedBandHighAvgInFlightCheapApi} already uses)
+     * gives the gauge an observation window without changing the shape's own point, which is
+     * banding, not throughput: a virtual thread blocked in {@code Thread.sleep} unmounts from its
+     * carrier, so sleeping fetches don't hold a core and aren't core-bound the way a zero-latency
+     * CPU-bound fetch is — {@code peak_in_flight} can then reach a healthy fraction of {@code W}
+     * regardless of how many physical cores the runner actually schedules on, so the floor no longer
+     * needs the runner's own core count as an input. The seed-time structural assertions above
+     * (radix bands fired, {@code specs.size() > 8}) and the correctness assertion below
+     * ({@code assertExactlyOnce}) stay schedule-invariant and are unaffected by this latency.
      *
      * <p><b>Guard sharpness.</b> Ablating {@code radix_bands} (via {@link EngineToggles#parse}) leaves
      * the dense flat root as ONE un-subdivided seed range ({@code seedCount == 1}) instead of the
@@ -291,17 +288,11 @@ final class ShapeRegressionCorpusTest {
                 .as("dense flat root radix-banded (meeo-s3 shape)").isTrue();
         assertThat(specs.size()).as("banded into many ranges, not one serial root range").isGreaterThan(8);
 
-        Run run = scan(dir, "radix-band", keyspace, workers, 1000, Duration.ZERO, EngineToggles.DEFAULT);
+        Run run = scan(dir, "radix-band", keyspace, workers, 1000, Duration.ofMillis(2), EngineToggles.DEFAULT);
         assertExactlyOnce(run.emitted, keyspace);
-        // peak_in_flight at zero injected latency is CPU-bound, so it cannot exceed the actual
-        // core count the runner schedules on — cap the floor accordingly, keeping one core of
-        // headroom so the assertion never demands perfect occupancy (see javadoc).
-        int concurrencyFloor =
-                Math.min(workers / 4, Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
         assertThat(run.peakInFlight)
-                .as("no collapse: banded root reaches a healthy fraction of W, capped by the runner's "
-                        + "actual core count at zero injected latency")
-                .isGreaterThanOrEqualTo(concurrencyFloor);
+                .as("no collapse: banded root reaches a healthy fraction of W")
+                .isGreaterThanOrEqualTo(workers / 4);
     }
 
     // =====================================================================================

--- a/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/shapecorpus/ShapeRegressionCorpusTest.java
@@ -258,8 +258,14 @@ final class ShapeRegressionCorpusTest {
      * CPU-bound fetch is — {@code peak_in_flight} can then reach a healthy fraction of {@code W}
      * regardless of how many physical cores the runner actually schedules on, so the floor no longer
      * needs the runner's own core count as an input. The seed-time structural assertions above
-     * (radix bands fired, {@code specs.size() > 8}) and the correctness assertion below
-     * ({@code assertExactlyOnce}) stay schedule-invariant and are unaffected by this latency.
+     * (radix bands fired, {@code specs.size() > 8}) stay schedule-invariant and are unaffected by
+     * this latency.
+     *
+     * <p>Exactly-once is asserted on BOTH scans. The zero-latency one is the coverage this shape had
+     * before the pacing was introduced — a CPU-bound run interleaves the workers differently from a
+     * run whose fetches all park in {@code Thread.sleep}, and emission correctness is exactly the
+     * property that must not depend on which interleaving the shape happens to get, so keeping only
+     * the paced run would quietly narrow the guard to one timing regime.
      *
      * <p><b>Guard sharpness.</b> Ablating {@code radix_bands} (via {@link EngineToggles#parse}) leaves
      * the dense flat root as ONE un-subdivided seed range ({@code seedCount == 1}) instead of the
@@ -288,7 +294,10 @@ final class ShapeRegressionCorpusTest {
                 .as("dense flat root radix-banded (meeo-s3 shape)").isTrue();
         assertThat(specs.size()).as("banded into many ranges, not one serial root range").isGreaterThan(8);
 
-        Run run = scan(dir, "radix-band", keyspace, workers, 1000, Duration.ofMillis(2), EngineToggles.DEFAULT);
+        Run correctness = scan(dir, "radix-band", keyspace, workers, 1000, Duration.ZERO, EngineToggles.DEFAULT);
+        assertExactlyOnce(correctness.emitted, keyspace);
+
+        Run run = scan(dir, "radix-band-paced", keyspace, workers, 1000, Duration.ofMillis(2), EngineToggles.DEFAULT);
         assertExactlyOnce(run.emitted, keyspace);
         assertThat(run.peakInFlight)
                 .as("no collapse: banded root reaches a healthy fraction of W")


### PR DESCRIPTION
## Diagnosis

Confirmed from #35: at zero injected page latency a "page fetch" is pure CPU work, so `peak_in_flight` (a runtime-achieved-concurrency reading, not a placement/structure fact) can be capped by however many virtual threads the runner's scheduler actually got to overlap before the whole 6000-key run finished -- not by the shape's own structure, which is already proven schedule-invariant by the same test's `specs.size()>8` / `dense_root_radix_banded` assertions. CI read `peak_in_flight=2` against a floor of 3 on the 4-core runner, then passed 20/20 on an identical rerun: scheduler luck, not a regression.

## Fix

Inject a small (2ms) per-page latency on the scan's worker listing pages, the same idiom `healthyNestedFanoutControl_seedBandHighAvgInFlightCheapApi` already uses, and drop the runner-core-count-capped floor back to the straightforward `workers/4`. A virtual thread blocked in `Thread.sleep` unmounts from its carrier, so a sleeping fetch doesn't hold a core and isn't core-bound the way a zero-latency CPU-bound fetch is -- `peak_in_flight` can then reach a healthy fraction of `W` regardless of how many physical cores the runner schedules on. The seed-time structural assertions (radix bands fired, `specs.size() > 8`) and the correctness assertion (`assertExactlyOnce`) are computed from a separate, latency-free fetcher and stay untouched.

Test-only change -- zero `src/main` diff.

## Evidence

1. **Reproduced the exact CI symptom** against the ORIGINAL (unmodified) test by forcing the JVM's virtual-thread carrier pool down to a single carrier (`-Djdk.virtualThreadScheduler.parallelism=1`, forwarded into the forked test JVM via a temporary build-logic edit) while keeping `Runtime.availableProcessors()=4` via `taskset -c 0-3` (so the floor still read `min(4,3)=3`, same as the reported CI shape). This genuinely restricts achievable concurrency the same way a contended runner's scheduler noise does, without needing to get lucky: the original test failed with
   ```
   Expecting actual: 1L to be greater than or equal to: 3L
   ```
   -- the same shape as CI's reported `expected >= 3L, actual 2L`.

2. With the same single-carrier constraint still in place, ran the **fixed test** (this PR's 2ms latency + `workers/4` floor): PASSED -- confirming the mechanism (a sleeping virtual thread frees its carrier for others) actually restores headroom rather than just relaxing the assertion.

3. Reverted the temporary build-logic forwarding entirely (`git diff --stat` confirmed zero changes outside this one test file going into this PR), then ran the fixed test method **30 times in a loop under `taskset -c 0-3`** (`./gradlew :swath-core:test -Pdeep --tests ...radixBandedFlatRoot_bandsFireNoCollapseAtZeroLatency --rerun`, no artificial throttling): 30/30 green.

Also ran the full `ShapeRegressionCorpusTest` class once under `taskset -c 0-3` with `-Pdeep` (8/8 green) and `:swath-core:spotlessCheck` (clean).

## Review follow-up: exactly-once stays on a zero-latency scan too

CodeRabbit, minor: the paced scan had taken over the correctness assertion as well, so this shape
stopped exercising emission correctness in the CPU-bound timing regime it had covered until then. A
run whose fetches all park in `Thread.sleep` interleaves its workers differently from one that never
blocks, and exactly-once is precisely the property that must not depend on which interleaving a run
happens to get -- the two regimes are not substitutes.

The `Duration.ZERO` scan is restored and exactly-once is asserted on both scans; the paced scan keeps
`peak_in_flight` to itself, the only reading that needed the latency. The two scans checkpoint under
distinct names, so they share no state. Re-verified: the method green **10/10 under `taskset -c 0-3`**
with `-Pdeep` (the same constrained-core condition as the evidence above), spotless clean.

Fixes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated regression tests for concurrent scanning behavior to be schedule- and hardware-invariant.
  * Improved reliability by introducing a small paced scan and using a fixed, worker-based concurrency expectation.
  * Preserved existing checks for radix-band structure and byte-exact correctness of emitted keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
