### PR TITLE
Reject --bearer-token-refresh-interval without --bearer-token-command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ all of these.
 | `--endpoint-url` | unset |
 | `--force-path-style` | on when `--endpoint-url` is set |
 | `--bearer-token-command` | unset |
-| `--bearer-token-refresh-interval` | `45m` |
+| `--bearer-token-refresh-interval` | `45m` (requires `--bearer-token-command`) |
 | `--fetch-owner` | off |
 | `--requester-pays` | off |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -443,7 +443,7 @@ prefixes, endpoints, paths, filters, or keys are sensitive.
 | `--endpoint-url URL` | — | Custom S3-compatible endpoint (LocalStack, MinIO, etc.) |
 | `--force-path-style` / `--no-force-path-style` | on when `--endpoint-url` is set | Force path-style S3 addressing |
 | `--bearer-token-command CMD` | — | Shell command whose stdout is a fresh OAuth bearer token, used instead of AWS SigV4 signing for every request |
-| `--bearer-token-refresh-interval DURATION` | `45m` | How often to re-run `--bearer-token-command` for a fresh token |
+| `--bearer-token-refresh-interval DURATION` | `45m` | How often to re-run `--bearer-token-command` for a fresh token; rejected without that flag |
 | `--fetch-owner` | off | Request the `Owner` field from S3 (`FetchOwner=true`); populates `owner_id` and `owner_display_name` in output |
 | `--requester-pays requester` | off | Requester-pays buckets: send `x-amz-request-payer: requester` on every S3 request (only accepted value: `requester`) |
 | `--metrics-endpoint URL` | environment or off | Export OTLP metrics to URL; overrides `SWATH_OTLP_ENDPOINT` |
@@ -495,7 +495,8 @@ swath resume ./out --bearer-token-command 'gcloud auth print-access-token'
 ```
 
 Omit it and the resumed run falls back to SigV4 signing, which a bearer-auth endpoint will
-reject.
+reject. Re-passing only `--bearer-token-refresh-interval` — the likeliest version of that
+slip — is rejected outright (exit 2) rather than silently signing with SigV4.
 
 #### Seeding
 

--- a/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ConnectionOptions.java
@@ -201,9 +201,19 @@ final class ConnectionOptions {
      * Resolve {@code --bearer-token-command}/{@code --bearer-token-refresh-interval} into a {@link
      * BearerTokenSupplier}, or {@code null} when unset (the overwhelmingly common case: normal
      * SigV4/{@code --profile} signing).
+     *
+     * <p>A refresh interval without a command is rejected rather than ignored: the two flags only
+     * mean anything together, and on {@code swath resume} — where the command is {@link
+     * ResumeClass#FREE} and must be re-passed by hand — dropping just the command is a plausible
+     * slip. Silently signing with SigV4 instead would surface as a confusing auth failure (or, worse,
+     * a run against the wrong identity) rather than as the operator's actual mistake.
      */
     private BearerTokenSupplier resolveBearerTokenSupplier() throws InvalidConfigException {
         if (bearer.command == null) {
+            if (bearer.refreshInterval != null) {
+                throw new InvalidConfigException(
+                        "--bearer-token-refresh-interval requires --bearer-token-command");
+            }
             return null;
         }
         Duration refreshInterval = bearer.refreshInterval == null

--- a/swath-cli/src/test/java/io/varve/swath/cli/BearerTokenRefreshIntervalValidationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/BearerTokenRefreshIntervalValidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.varve.swath.error.InvalidConfigException;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * {@code --bearer-token-refresh-interval} only means anything alongside {@code
+ * --bearer-token-command}: alone it used to be silently ignored, and the run would sign with SigV4
+ * instead. That slip is most likely on {@code swath resume}, where the command is {@link
+ * ResumeClass#FREE} and has to be re-passed by hand — so the failure mode was "confusing auth error
+ * against a bearer-only endpoint", or a run against whatever ambient identity the SDK chain found,
+ * rather than the operator's actual mistake. Reject it at exit 2 instead.
+ */
+class BearerTokenRefreshIntervalValidationTest {
+
+    @Test
+    void refreshIntervalWithoutACommandIsRejected() {
+        ListCommand cmd = new ListCommand();
+        new CommandLine(cmd).parseArgs("s3://bucket/prefix", "--checkpoint", "none",
+                "--region", "us-east-1",
+                "--bearer-token-refresh-interval", "10m");
+
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .satisfies(e -> assertThat(ExitCodes.forThrowable(e)).isEqualTo(2))
+                .hasMessageContaining("--bearer-token-refresh-interval")
+                .hasMessageContaining("--bearer-token-command");
+    }
+
+    /**
+     * The same rejection on {@code swath resume}, which is where the slip is likeliest: the command
+     * is never persisted, so an operator re-passing the pair by hand can easily carry over only the
+     * interval. Both flags are forwarded onto the delegated {@link ListCommand}, so one guard covers
+     * both commands.
+     */
+    @Test
+    void refreshIntervalWithoutACommandIsRejectedOnResumeToo() {
+        ResumeCommand resume = new ResumeCommand();
+        ListCommand cmd = new ListCommand();
+        new CommandLine(cmd).parseArgs("s3://bucket/prefix", "--checkpoint", "none",
+                "--region", "us-east-1");
+        resume.bearer.refreshInterval = "10m";
+        cmd.connection.bearer.copyFrom(resume.bearer);
+
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("--bearer-token-refresh-interval");
+    }
+
+    /**
+     * The guard must not fire on the overwhelmingly common case — neither flag passed — which is
+     * what {@code null} out of {@code resolveBearerTokenSupplier()} encodes. A malformed interval
+     * alongside a command still reaches the parser, proving the early return did not swallow it.
+     */
+    @Test
+    void aCommandWithAnIntervalStillParsesTheInterval() {
+        ListCommand cmd = new ListCommand();
+        new CommandLine(cmd).parseArgs("s3://bucket/prefix", "--checkpoint", "none",
+                "--region", "us-east-1",
+                "--bearer-token-command", "printf token",
+                "--bearer-token-refresh-interval", "not-a-duration");
+
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("bearer-token-refresh-interval");
+    }
+}

--- a/swath-cli/src/test/java/io/varve/swath/cli/BearerTokenRefreshIntervalValidationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/BearerTokenRefreshIntervalValidationTest.java
@@ -36,25 +36,10 @@ class BearerTokenRefreshIntervalValidationTest {
                 .hasMessageContaining("--bearer-token-command");
     }
 
-    /**
-     * The same rejection on {@code swath resume}, which is where the slip is likeliest: the command
-     * is never persisted, so an operator re-passing the pair by hand can easily carry over only the
-     * interval. Both flags are forwarded onto the delegated {@link ListCommand}, so one guard covers
-     * both commands.
-     */
-    @Test
-    void refreshIntervalWithoutACommandIsRejectedOnResumeToo() {
-        ResumeCommand resume = new ResumeCommand();
-        ListCommand cmd = new ListCommand();
-        new CommandLine(cmd).parseArgs("s3://bucket/prefix", "--checkpoint", "none",
-                "--region", "us-east-1");
-        resume.bearer.refreshInterval = "10m";
-        cmd.connection.bearer.copyFrom(resume.bearer);
-
-        assertThatThrownBy(cmd::call)
-                .isInstanceOf(InvalidConfigException.class)
-                .hasMessageContaining("--bearer-token-refresh-interval");
-    }
+    // The same rejection driven through the real `swath resume` — where the slip is likeliest, since
+    // the command is never persisted and has to be re-passed by hand — lives in ResumeCommandTest,
+    // next to that command's own bearer-forwarding coverage and the run-seeding helpers it needs:
+    // ResumeCommandTest#resumeRejectsABearerRefreshIntervalWithoutItsCommand.
 
     /**
      * The guard must not fire on the overwhelmingly common case — neither flag passed — which is

--- a/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
@@ -873,6 +873,29 @@ final class ResumeCommandTest {
                 .hasMessageContaining("bearer-token-refresh-interval");
     }
 
+    /**
+     * Re-passing ONLY the interval is the likeliest version of getting that re-pass wrong, and it is
+     * the one shape where the flags mean nothing together: the run would fall back to SigV4 signing,
+     * which the bearer-auth endpoint it was resuming against rejects — or, worse, would succeed
+     * against whatever ambient identity the SDK chain resolved. Rejected at exit 2 instead of
+     * silently ignored, through the real resume path (a hand-copied {@code bearer} would leave a
+     * regression in the forwarding itself undetected).
+     */
+    @Test
+    void resumeRejectsABearerRefreshIntervalWithoutItsCommand(@TempDir Path tempDir) throws Exception {
+        Path outputDir = seedCompletedRunDir(tempDir);
+
+        ResumeCommand cmd = new ResumeCommand();
+        cmd.directory = outputDir;
+        cmd.bearer.refreshInterval = "10m";
+
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .satisfies(e -> assertThat(ExitCodes.forThrowable(e)).isEqualTo(2))
+                .hasMessageContaining("--bearer-token-refresh-interval")
+                .hasMessageContaining("--bearer-token-command");
+    }
+
     private static void overwriteOutputFormat(Path db, String format) throws Exception {
         try (Connection c = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
              PreparedStatement ps = c.prepareStatement("UPDATE run_meta SET output_format=?")) {


### PR DESCRIPTION
A review comment on #23 landed after that PR merged, so it comes as a follow-up.

`--bearer-token-refresh-interval` only means anything alongside
`--bearer-token-command`. Passed alone it was silently ignored and the run signed
with SigV4 instead. The slip is likeliest on `swath resume`, where the command is
deliberately never persisted and has to be re-passed by hand — so dropping just the
command surfaced as a confusing auth failure against a bearer-only endpoint, or as a
run against whatever ambient identity the SDK chain happened to resolve, rather than
as the operator's actual mistake.

Now rejected at exit 2. One guard in `ConnectionOptions#resolveBearerTokenSupplier()`
covers both commands, since `resume` forwards the pair onto the delegated `list`.

**Tests.** New `BearerTokenRefreshIntervalValidationTest`: the `list` rejection, the
same rejection via the `resume` forwarding path, and a positive control (a command
plus a malformed interval still reaches the duration parser, so the guard's early
return doesn't swallow it). Mutation-checked — 2 of the 3 fail with the guard removed.
Docs updated in `docs/usage.md` and `docs/configuration.md`.

`:swath-cli:test` for the new class + `ResumeCommandTest` + `HelpUsageGoldenTest` green;
`:swath-cli:spotlessCheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now rejects `--bearer-token-refresh-interval` when `--bearer-token-command` is not provided, returning a clear configuration error instead of falling back to another authentication method.
  * Resume operations now enforce the same validation.

* **Documentation**
  * Updated configuration and usage guidance to clarify the required flag relationship and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->