### PR TITLE
Add --latency-scale to the replay server for compressed-time replay runs

### DIFF
--- a/docs/replay-troubleshooting.md
+++ b/docs/replay-troubleshooting.md
@@ -108,7 +108,7 @@ know immediately if step (b) didn't stamp a servable file. A healthy start
 prints one line naming the resolved mode and every knob that's live:
 
 ```
-s3_listing_replay_server endpoint=http://127.0.0.1:19090 bucket=<bucket> fixture=<cut-fixture> serving_mode=SORTED parquet_connections=4 inject_latency=off
+s3_listing_replay_server endpoint=http://127.0.0.1:19090 bucket=<bucket> fixture=<cut-fixture> serving_mode=SORTED parquet_connections=4 inject_latency=off latency_scale=1.0
 ```
 
 ### d. Calibrate a per-shape latency profile from the sick run's own metrics
@@ -148,6 +148,17 @@ swath-replay-server serve ... \
 
 The `55ms/cp` slope shown is the current calibration of the built-in reference
 profile.
+
+A faithful profile is also an expensive one — injecting a 6.9 s structure probe
+means waiting 6.9 s per probe, and a run that reproduces a 55-minute tail takes
+55 minutes. `--latency-scale N` (see
+[`swath-replay-server.md`](swath-replay-server.md#compressed-time---latency-scale))
+divides every injected delay by `N` while preserving the profile's shape, which
+turns that into an iteration loop you can run repeatedly. It is a shape-only
+instrument: at `--latency-scale 50` the server's and client's own unscaled
+per-request costs are weighted ~50× heavier relative to the profile, so score a
+compressed run on the trajectory and engagement counters (§4.3) and never on its
+absolute wall clock — confirm any timing-dependent result at `--latency-scale 1`.
 
 The `/cp` term is the reason this lives in the server rather than in a TCP
 proxy: the injector sees the parsed response, so it can charge a structure

--- a/docs/swath-replay-server.md
+++ b/docs/swath-replay-server.md
@@ -179,6 +179,31 @@ measurements from the public Common Crawl bucket. Jitter is a deterministic
 fraction in `[0,1)` keyed off the request bytes, so a run is exactly
 reproducible. Injection is off by default and adds no cost when off.
 
+#### Compressed time (`--latency-scale`)
+
+`--latency-scale N` divides every injected delay by `N`, so a profile that
+describes an hour-long run can be walked in a fraction of that wall clock:
+
+```bash
+swath-replay-server serve ... --inject-latency prod-commoncrawl --latency-scale 50
+```
+
+Both terms of a delay scale — the flat base and the `/cp` slope — so the
+profile keeps its *shape*: a wide structure probe stays the same multiple of a
+worker page that it was, which is the relationship a split/steal pathology
+turns on. It requires `--inject-latency` (a scale with no profile to scale is
+rejected, not ignored), and the default `1` injects the profile exactly as
+written, to the nanosecond.
+
+The distortion to keep in mind: **only the injected delay scales.** The
+server's own per-request cost, the client's CPU, and the engine's own
+scheduling do not, so at `--latency-scale 50` those fixed costs are weighted
+~50× heavier relative to the profile than they are in the unscaled run. A
+scaled run's wall clock is therefore not the unscaled run's divided by `N`, and
+must never be quoted as an absolute time. Use it to compress a long profile
+into an affordable iteration loop, and confirm any result that depends on
+absolute timing at `--latency-scale 1`.
+
 ### `--serving-mode` (`auto` | `sorted` | `duckdb`)
 
 `--serving-mode` chooses how a fixture is served (default `auto`):

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/server/ReplayServerApp.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/server/ReplayServerApp.java
@@ -58,17 +58,18 @@ public final class ReplayServerApp implements Callable<Integer> {
     private static Integer serve(Path fixture, String bucket, ServeOptions options) throws Exception {
         int connections = options.parquetConnections > 0
                 ? options.parquetConnections : DuckDbListingStore.defaultConnectionCount();
-        ShapeLatency injected = ShapeLatency.parse(options.injectLatency, options.latencyJitter);
+        ShapeLatency injected =
+                ShapeLatency.parse(options.injectLatency, options.latencyJitter, options.latencyScale);
         try (ReplayServer server = injected == null
                 ? new ReplayServer(options.host, options.port, bucket, fixture, connections, options.servingMode)
                 : new ReplayServer(options.host, options.port, bucket, fixture, connections, options.servingMode,
                         injected)) {
             server.start();
             System.err.printf("s3_listing_replay_server endpoint=http://%s:%d bucket=%s fixture=%s "
-                            + "serving_mode=%s parquet_connections=%d inject_latency=%s%n",
+                            + "serving_mode=%s parquet_connections=%d inject_latency=%s latency_scale=%s%n",
                     options.host, server.port(), bucket, fixture.toAbsolutePath(),
                     server.resolvedServingMode(), connections,
-                    injected == null ? "off" : options.injectLatency);
+                    injected == null ? "off" : options.injectLatency, options.latencyScale);
             server.join();
         }
         return 0;

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/server/ServeOptions.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/server/ServeOptions.java
@@ -42,4 +42,12 @@ final class ServeOptions {
             description = "Deterministic jitter fraction in [0,1) applied to injected latency, "
                     + "keyed off the request bytes (reproducible across runs).")
     double latencyJitter;
+
+    @Option(names = "--latency-scale", defaultValue = "1",
+            description = "Divide every injected latency by this factor, for compressed-time replay "
+                    + "runs (e.g. 50 walks a profile in a fiftieth of the wall clock it describes). "
+                    + "Requires --inject-latency. Only the injected delay scales, not the server's "
+                    + "own per-request cost, so a scaled run's absolute wall clock is not the "
+                    + "unscaled run's divided. Default 1 injects the profile as written.")
+    double latencyScale;
 }

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/server/ShapeLatency.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/server/ShapeLatency.java
@@ -48,8 +48,17 @@ import java.util.function.BiFunction;
  * +jitter]}, keyed off the request bytes (never {@code Math.random}, which would make a run
  * irreproducible). Two runs against the same fixture with the same profile see byte-identical
  * delays.
+ *
+ * <p><b>Compressed time.</b> A profile can be divided by a scale factor at parse time, so a long
+ * profile can be walked end to end in a fraction of the wall clock it describes. The scale divides
+ * only what this injector adds; the server's own per-request cost is untouched, so a scaled run
+ * over-weights that fixed cost by the same factor and its absolute wall clock is not a prediction
+ * of the unscaled one.
  */
 public final class ShapeLatency implements BiFunction<S3ListRequest, S3ListResult, Duration> {
+
+    /** No compression: the profile's delays are injected exactly as written. */
+    public static final double UNSCALED = 1.0;
 
     /** The three request shapes a work-stealing scan issues, in classification order. */
     public enum Shape {
@@ -173,13 +182,25 @@ public final class ShapeLatency implements BiFunction<S3ListRequest, S3ListResul
      * millisecond count like {@code 250}), optionally — for {@code structure_probe} only — followed
      * by a per-CommonPrefix term: {@code structure_probe=223ms+55ms/cp}. An unlisted shape gets no
      * delay. Returns {@code null} for a null/blank spec so the caller can install a no-op.
+     *
+     * <p>{@code scale} divides every parsed delay ({@link #UNSCALED} leaves the profile exactly as
+     * written). A scale other than {@link #UNSCALED} against a spec that injects nothing is refused
+     * rather than ignored: it scales nothing, and an operator who passed it meant to compress a
+     * profile that is not there.
      */
-    public static ShapeLatency parse(String spec, double jitter) {
+    public static ShapeLatency parse(String spec, double jitter, double scale) {
+        // The negated in-range form, so NaN is rejected too (see the constructor's jitter check).
+        if (!(scale > 0.0 && scale < Double.POSITIVE_INFINITY)) {
+            throw new IllegalArgumentException("latency scale must be finite and > 0, got " + scale);
+        }
         if (spec == null || spec.isBlank()) {
+            if (scale != UNSCALED) {
+                throw new IllegalArgumentException("a latency scale requires a latency profile to scale");
+            }
             return null;
         }
         if (spec.trim().toLowerCase(Locale.ROOT).equals("prod-commoncrawl")) {
-            return new ShapeLatency(PROD_COMMONCRAWL, jitter);
+            return new ShapeLatency(scaled(PROD_COMMONCRAWL, scale), jitter);
         }
         Map<Shape, Delay> delays = new LinkedHashMap<>();
         for (String pair : spec.split(",")) {
@@ -194,7 +215,25 @@ public final class ShapeLatency implements BiFunction<S3ListRequest, S3ListResul
             Shape shape = parseShape(trimmed.substring(0, eq).trim());
             delays.put(shape, parseDelay(shape, trimmed.substring(eq + 1).trim()));
         }
-        return new ShapeLatency(delays, jitter);
+        return new ShapeLatency(scaled(delays, scale), jitter);
+    }
+
+    /**
+     * Divides every delay in a profile by {@code scale}. {@link #UNSCALED} returns the profile
+     * itself, so the default path cannot perturb a single nanosecond of the wire behavior.
+     */
+    private static Map<Shape, Delay> scaled(Map<Shape, Delay> delays, double scale) {
+        if (scale == UNSCALED) {
+            return delays;
+        }
+        Map<Shape, Delay> compressed = new LinkedHashMap<>();
+        delays.forEach((shape, delay) -> compressed.put(shape,
+                new Delay(divide(delay.base(), scale), divide(delay.perCommonPrefix(), scale))));
+        return compressed;
+    }
+
+    private static Duration divide(Duration delay, double scale) {
+        return Duration.ofNanos((long) (delay.toNanos() / scale));
     }
 
     private static Shape parseShape(String s) {

--- a/swath-replay-server/src/test/java/io/varve/swath/replay/server/ServeLatencyScaleOptionTest.java
+++ b/swath-replay-server/src/test/java/io/varve/swath/replay/server/ServeLatencyScaleOptionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.replay.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Flag-level coverage for {@code --latency-scale}: it reaches {@link ServeOptions} from both the
+ * {@code serve} subcommand and the top-level invocation that shares the same mixin, and it defaults
+ * to {@link ShapeLatency#UNSCALED} so an operator who never passes it gets the profile as written.
+ * The scale's arithmetic and its validation live in {@link ShapeLatencyTest}.
+ */
+class ServeLatencyScaleOptionTest {
+
+    /** Mirrors {@link ReplayServerApp#main}'s own parser configuration. */
+    private static CommandLine parser(Object command) {
+        return new CommandLine(command).setCaseInsensitiveEnumValuesAllowed(true);
+    }
+
+    @Test
+    void serveParsesTheLatencyScale() {
+        ReplayServerApp.ServeCommand cmd = new ReplayServerApp.ServeCommand();
+        parser(cmd).parseArgs("--fixture", "f", "--bucket", "b",
+                "--inject-latency", "prod-commoncrawl", "--latency-scale", "50");
+
+        assertThat(cmd.serveOptions.latencyScale).isEqualTo(50.0);
+    }
+
+    @Test
+    void theTopLevelInvocationSharesTheSameFlag() {
+        ReplayServerApp app = new ReplayServerApp();
+        parser(app).parseArgs("--fixture", "f", "--bucket", "b",
+                "--inject-latency", "prod-commoncrawl", "--latency-scale", "12.5");
+
+        assertThat(app.serveOptions.latencyScale).isEqualTo(12.5);
+    }
+
+    @Test
+    void defaultsToUnscaled() {
+        ReplayServerApp.ServeCommand cmd = new ReplayServerApp.ServeCommand();
+        parser(cmd).parseArgs("--fixture", "f", "--bucket", "b");
+
+        assertThat(cmd.serveOptions.latencyScale).isEqualTo(ShapeLatency.UNSCALED);
+    }
+}

--- a/swath-replay-server/src/test/java/io/varve/swath/replay/server/ShapeLatencyTest.java
+++ b/swath-replay-server/src/test/java/io/varve/swath/replay/server/ShapeLatencyTest.java
@@ -102,7 +102,7 @@ class ShapeLatencyTest {
 
     @Test
     void parsesTheProdCommoncrawlProfile() {
-        ShapeLatency latency = ShapeLatency.parse("prod-commoncrawl", 0.0);
+        ShapeLatency latency = ShapeLatency.parse("prod-commoncrawl", 0.0, ShapeLatency.UNSCALED);
         S3ListRequest probe = req(new byte[]{'p', '/'}, new byte[]{'/'}, 1000);
         S3ListRequest page = req(null, null, 1000);
         S3ListRequest pivot = req(null, null, 1);
@@ -116,7 +116,7 @@ class ShapeLatencyTest {
     @Test
     void parsesACustomShapeSpecWithMixedUnitsAndAPerCpTerm() {
         ShapeLatency latency = ShapeLatency.parse(
-                "structure_probe=1.5s+40ms/cp,pivot_probe=120ms,worker_page=200", 0.0);
+                "structure_probe=1.5s+40ms/cp,pivot_probe=120ms,worker_page=200", 0.0, ShapeLatency.UNSCALED);
         S3ListRequest probe = req(new byte[]{'p', '/'}, new byte[]{'/'}, 1000);
         S3ListRequest pivot = req(null, null, 1);
         S3ListRequest page = req(null, null, 1000);
@@ -125,24 +125,70 @@ class ShapeLatencyTest {
         assertThat(latency.apply(page, result(page, 0))).isEqualTo(Duration.ofMillis(200));   // bare number = ms
     }
 
+    /**
+     * Compressed time: the scale divides the flat base AND the per-CommonPrefix slope, so a scaled
+     * run keeps the profile's shape — a wide structure probe stays as many times a worker page as
+     * it was — and only its absolute magnitude moves.
+     */
+    @Test
+    void latencyScaleDividesEveryTermOfTheProfile() {
+        ShapeLatency latency = ShapeLatency.parse("prod-commoncrawl", 0.0, 50.0);
+        S3ListRequest probe = req(new byte[]{'p', '/'}, new byte[]{'/'}, 1000);
+        S3ListRequest page = req(null, null, 1000);
+        S3ListRequest pivot = req(null, null, 1);
+        assertThat(latency.apply(probe, result(probe, 121)))
+                .as("(223 + 55 × 121) ms ÷ 50, both terms scaled")
+                .isEqualTo(Duration.ofNanos((223_000_000L / 50) + 121 * (55_000_000L / 50)));
+        assertThat(latency.apply(page, result(page, 0))).isEqualTo(Duration.ofNanos(223_000_000L / 50));
+        assertThat(latency.apply(pivot, result(pivot, 0))).isEqualTo(Duration.ofNanos(121_000_000L / 50));
+    }
+
+    /**
+     * The default is conformance-neutral: an unscaled parse must inject the profile to the
+     * nanosecond, never a rounded division by one.
+     */
+    @Test
+    void unscaledIsTheProfileExactlyAsWritten() {
+        ShapeLatency latency = ShapeLatency.parse(
+                "structure_probe=6.865s+55ms/cp,worker_page=223ms", 0.0, ShapeLatency.UNSCALED);
+        S3ListRequest probe = req(new byte[]{'p', '/'}, new byte[]{'/'}, 1000);
+        S3ListRequest page = req(null, null, 1000);
+        assertThat(latency.apply(probe, result(probe, 7))).isEqualTo(Duration.ofMillis(6865 + 55 * 7));
+        assertThat(latency.apply(page, result(page, 0))).isEqualTo(Duration.ofMillis(223));
+    }
+
+    @Test
+    void rejectsALatencyScaleThatIsNotAPositiveFactorOrHasNoProfileToScale() {
+        assertThatThrownBy(() -> ShapeLatency.parse("prod-commoncrawl", 0.0, 0.0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ShapeLatency.parse("prod-commoncrawl", 0.0, -50.0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ShapeLatency.parse("prod-commoncrawl", 0.0, Double.NaN))
+                .as("NaN divides every delay to zero — injection silently off")
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ShapeLatency.parse(null, 0.0, 50.0))
+                .as("a scale with nothing to scale is the operator's mistake, not a no-op")
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
     @Test
     void blankSpecDeclinesSoTheCallerInstallsANoOp() {
-        assertThat(ShapeLatency.parse(null, 0.0)).isNull();
-        assertThat(ShapeLatency.parse("  ", 0.0)).isNull();
+        assertThat(ShapeLatency.parse(null, 0.0, ShapeLatency.UNSCALED)).isNull();
+        assertThat(ShapeLatency.parse("  ", 0.0, ShapeLatency.UNSCALED)).isNull();
     }
 
     @Test
     void rejectsBadSpecsAndOutOfRangeJitter() {
-        assertThatThrownBy(() -> ShapeLatency.parse("worker_page", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("worker_page", 0.0, ShapeLatency.UNSCALED))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ShapeLatency.parse("bogus_shape=1s", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("bogus_shape=1s", 0.0, ShapeLatency.UNSCALED))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=fast", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=fast", 0.0, ShapeLatency.UNSCALED))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=100ms+5ms/cp", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=100ms+5ms/cp", 0.0, ShapeLatency.UNSCALED))
                 .as("a /cp term is meaningless without a delimiter'd response")
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ShapeLatency.parse("structure_probe=100ms+5ms", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("structure_probe=100ms+5ms", 0.0, ShapeLatency.UNSCALED))
                 .as("the per-entry term must name its unit (/cp)")
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ShapeLatency(Map.of(), 1.0))
@@ -150,7 +196,7 @@ class ShapeLatencyTest {
         assertThatThrownBy(() -> new ShapeLatency(Map.of(), Double.NaN))
                 .as("NaN would scale every delay to zero — injection silently off")
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=-1s", 0.0))
+        assertThatThrownBy(() -> ShapeLatency.parse("worker_page=-1s", 0.0, ShapeLatency.UNSCALED))
                 .as("a negative delay is silently no-sleep at the handler — refuse at parse")
                 .isInstanceOf(IllegalArgumentException.class);
     }


### PR DESCRIPTION
Adds `--latency-scale N` to `swath-replay-server serve`: a divisor applied to every
delay `--inject-latency` injects, for compressed-time replay runs.

### Why

A faithful latency profile is an expensive one. The built-in `prod-commoncrawl` reference
charges ~223 ms per worker page and up to ~6.9 s per structure probe, so walking a fixture
at that profile costs the wall clock the profile describes — which is the point when you
are reproducing a pathology, and pure overhead when you are iterating on the twentieth
variant of a fix. `--latency-scale 50` runs the same walk in a fraction of the time.

### What it does

Both terms of a delay scale — the flat per-shape base and the structure probe's `/cp`
slope — so the profile keeps its *shape*: a wide structure probe stays the same multiple
of a worker page that it was, which is the relationship a split/steal pathology turns on.

Conformance-neutral by construction: the default `1` returns the parsed profile object
itself rather than dividing it by one, so an unscaled run injects exactly what it injected
before, to the nanosecond. A scale passed without `--inject-latency` is rejected rather
than silently scaling nothing, matching how the CLI treats other flags that only mean
something in a pair.

### Measured, and documented as such

Across two ~400k-key fixtures at scale 1 vs 50, the output key-set digests
(`count | sum(size) | md5(sorted hex keys)`) were identical and API-call counts agreed to
within 1.5% and 8.2%, while wall clock compressed only 2.9x and 3.6x — because **only the
injected delay scales.** Fixed client- and server-side per-request cost does not, so it is
over-weighted by roughly the scale factor (measured `worker_page` p50: 234.9 ms at scale 1,
of which ~12 ms was real cost, vs 32.0 ms at scale 50, of which ~27 ms was). A related and
sharper caveat: engine behavior gated on a *fixed absolute* budget — the 3 s probe attempt
timeout, retry windows, the liveness watchdog — is not preserved by scaling, so a
compressed run can complete cleanly where the unscaled one is killed by timeouts.

Both caveats are written into `docs/swath-replay-server.md` and
`docs/replay-troubleshooting.md` where an operator will hit them: never quote a scaled
wall clock as an absolute, and confirm any timing-dependent result at `--latency-scale 1`.

### Tests

Unit coverage for the scale arithmetic (both terms divided; `1` byte-identical to the
unscaled profile), its validation (non-positive, non-finite, NaN, and scale-without-profile
all rejected), and the flag reaching `ServeOptions` from both the `serve` subcommand and
the top-level invocation that shares its mixin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--latency-scale` option to compress injected replay delays by a specified factor.
  - Scaling applies to both base latency and common-prefix latency adjustments, while other server costs remain unchanged.
  - Startup output now reports the configured latency scale.

- **Documentation**
  - Updated replay server setup, troubleshooting, and latency calibration guidance.
  - Added examples and recommendations for validating timing-sensitive results with unscaled latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->