### PR TITLE
Release prep 1/3: pin what rots, and stop calling the repo private

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot keeps the SHA-pinned inputs current.
+#
+# Every action in .github/workflows/ is pinned by commit SHA and every Dockerfile
+# FROM by image digest, which is the right call for supply-chain integrity — but a
+# pin never moves on its own. Without this file the pins silently rot: in a year the
+# workflows run year-old runners and the image ships a year-old JRE with known CVEs,
+# and nobody notices because nothing is red. Pinning and automated bumping are one
+# practice, not two; this file is the second half.
+#
+# Dependabot rewrites the SHA and updates the trailing `# v4` comment, so the pins
+# stay readable after a bump.
+#
+# Everything is grouped and weekly on purpose: this is a solo-maintainer repo, and a
+# dozen individual dependency PRs a week is how update automation gets muted. One PR
+# per ecosystem per week is reviewable; muted automation is not.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+
+  # The root build: version catalog (gradle/libs.versions.toml) + module build files.
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Test-only dependencies can move on their own cadence — a JUnit or Testcontainers
+      # bump carries no shipped-artifact risk, so it should not queue behind review of a
+      # Parquet/Hadoop bump that does.
+      test-dependencies:
+        patterns:
+          - "org.junit*"
+          - "org.assertj*"
+          - "org.mockito*"
+          - "org.testcontainers*"
+          - "net.jqwik*"
+      production-dependencies:
+        exclude-patterns:
+          - "org.junit*"
+          - "org.assertj*"
+          - "org.mockito*"
+          - "org.testcontainers*"
+          - "net.jqwik*"
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"
+
+  # build-logic is a separate included build (settings.gradle.kts: includeBuild), so
+  # its dependencies are invisible to the root scan above and need their own entry.
+  - package-ecosystem: gradle
+    directory: /build-logic
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      build-logic:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"
+
+  # Keeps the digest-pinned eclipse-temurin base images current — the pin that would
+  # otherwise leave a stale JRE in every published image.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      base-images:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,16 +33,16 @@ jobs:
     # The perf tier (1M-key SORT-PERF, 100k PERF-1/2) is the long pole; deep is ~minutes.
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v4
         with:
           distribution: temurin
           java-version: "25"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
 
       # Deep tier serially (-PtestMaxParallelForks=1) so probe budgets are asserted without
       # cross-fork CPU contention, exactly as the main-merge deep-tests job runs them.
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-reports-nightly
           path: "*/build/reports/tests/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@
 # from source. The override dir mirrors this stage's output path
 # (/src/swath-cli/build/libs/swath.jar); keep the runtime COPY below in sync with it.
 # See .github/workflows/ci.yml.
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble AS build
+# Base images are pinned by DIGEST, not just tag: `25-jdk-noble` is mutable, so a
+# tag-only pin means two builds of the "same" release can differ — the largest
+# unpinned input in an otherwise SHA-pinned supply chain. The digest is the
+# multi-arch INDEX digest (not a per-arch manifest), so `--platform` selection still
+# resolves every target normally. The tag is kept alongside it for readability and
+# because Dependabot updates both (.github/dependabot.yml, `docker` ecosystem).
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble@sha256:3eb81ed94d8c1a34422f19f8188548bdf02cae69c91d0328afdbb7abed90f617 AS build
 WORKDIR /src
 
 # The checked-in legal notices verifier runs its renderer during shadowJar.
@@ -75,7 +81,10 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :swath-cli:sha
 #     would reintroduce foreign-arch emulation.
 # `COPY --chown` sets ownership without a `chown` RUN. 10001 is a high UID
 # chosen to avoid colliding with host UIDs on shared volumes.
-FROM eclipse-temurin:25-jre-noble AS runtime
+# Digest-pinned for the same reason as the build stage above; this is the one that
+# ships, so a mutable base here is what would put an unnoticed stale JRE in every
+# published image.
+FROM eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175 AS runtime
 
 COPY --from=build --chown=10001:10001 /src/swath-cli/build/libs/swath.jar /opt/swath/swath.jar
 COPY --from=build --chown=10001:10001 /src/LICENSE /opt/swath/LICENSE

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,26 +1,23 @@
 # Install & quickstart
 
 `swath` ships three ways once a release exists: a Docker image, an uber-jar,
-and JDK-requiring application-distribution archives. All three are planned to be built from the
+and JDK-requiring application-distribution archives. All three are built from the
 same Gradle output and signed with [sigstore](https://www.sigstore.dev/)
 keyless signing (GitHub OIDC, no key custody).
-**None of that exists yet.** Tags in the current private repository run the
-release build and upload its artifacts, but do not publish until the Phase 10
-human acceptance gate makes the repository public and enables publication.
-Until then,
-**build from source** (below) is the only path; this page states the shape
-the other install paths will take so we don't have to change this doc again
-once they land.
+
+**No release has been cut yet.** Until the first `vX.Y.Z` tag ships,
+**build from source** (below) is the only path. This page states the shape the
+other install paths take, so it does not have to change once they land.
 
 ## Docker
 
 ```
-docker run --rm -v "$PWD/out:/out" <repo>/swath \
+docker run --rm -v "$PWD/out:/out" ghcr.io/varveio/swath \
   list s3://my-bucket/prefix/ --no-sign-request \
   --format parquet -o /out/data
 ```
 
-Replace `<repo>/swath` with the published image reference once one exists.
+Images are published to `ghcr.io/varveio/swath` from the first release onward.
 Drop `--no-sign-request` and add credentials for a private bucket. See
 [`packaging-and-docker.md`](packaging-and-docker.md) for the image's signal
 handling, tag scheme, and how to pin a digest rather than a mutable tag.
@@ -40,7 +37,7 @@ jar is built and what it bundles.
 
 ## Application distribution archive
 
-After public-release activation, the tagged-release workflow attaches the
+The tagged-release workflow attaches the
 `distZip` and `distTar` application archives, a
 `SHA256SUMS` file, an SPDX SBOM, and a keyless Sigstore bundle for every shipped
 jar/archive. The archives contain Gradle application launchers and require a

--- a/docs/packaging-and-docker.md
+++ b/docs/packaging-and-docker.md
@@ -207,26 +207,22 @@ no such script in between, so those variables have no effect here.
 
 ## 6. Container images (GHCR)
 
-After the Phase 10 human acceptance gate makes the repository public and enables
-the protected `public-release` environment, the tag-driven release workflow
-publishes a multi-arch image at
-`ghcr.io/<owner>/<repository>`, using the repository that ran the workflow.
-The exact image path and digest are printed in the workflow run summary. Package
-visibility is controlled by that repository's GHCR settings; build from source
-(§3–§5) when the package is not available to your account.
-Set the package visibility to public in GHCR when the project intends to offer
-anonymous pulls.
+The tag-driven release workflow publishes a multi-arch image at
+`ghcr.io/varveio/swath`. The exact image path and digest are printed in the
+workflow run summary. Package visibility is controlled by the repository's GHCR
+settings; build from source (§3–§5) if the package is not available to your
+account.
 
 Prefer pinning by **digest** over a mutable tag — the digest is the only
 immutable reference:
 
 ```
-docker pull ghcr.io/<owner>/<repository>@sha256:<digest>
+docker pull ghcr.io/varveio/swath@sha256:<digest>
 ```
 
-The public-release workflow prints the pushed manifest's digest to its run
-summary, so a consumer can copy the exact digest to pin against. Tags in the
-current private repository are build-and-artifact dry runs and do not publish.
+The release workflow prints the pushed manifest's digest to its run summary, so
+a consumer can copy the exact digest to pin against. **No release has been
+published yet** — until the first `vX.Y.Z` tag ships, build from source (§3–§5).
 
 ### Tags & versioning
 
@@ -249,8 +245,8 @@ builds the multi-arch image (validating both `linux/amd64` and `linux/arm64`,
 no QEMU per §5), loads the native-arch build, and smoke-tests it
 (`docker run … --help`) — it never pushes. **`docker-publish`** is a manual
 maintainer-only smoke/publish path; ordinary `main` pushes never publish.
-Public tagged publication belongs to `.github/workflows/release.yml` and is
-disabled while this repository is private.
+Tagged publication belongs to `.github/workflows/release.yml`, behind the
+protected `public-release` environment.
 
 Which jobs run depends on the trigger:
 
@@ -266,9 +262,9 @@ because `docker-publish` builds the image itself (running it too would just be a
 redundant second multi-arch build).
 
 The manual `docker-publish` path is gated on green tests and its deep container
-smoke. The public release job is separately protected by the `public-release`
-environment and requires both public repository visibility and the explicit
-`PUBLIC_RELEASE_ENABLED=true` repository variable after Phase 10 acceptance.
+smoke. The release publish job is separately protected by the `public-release`
+environment and requires the explicit `PUBLIC_RELEASE_ENABLED=true` repository
+variable, which acts as a publish kill-switch.
 
 The **CI image checks** have no scheduled run — they fire only on pull
 requests, pushes to `main`, and manual dispatch. (A separate `nightly` workflow


### PR DESCRIPTION
First of three PRs preparing the repo for its first release. This one is the
supply-chain and honesty pass: no behaviour changes, nothing that affects what
gets built.

### What's here

**SHA-pin `nightly.yml`'s actions.** It was the one workflow still on floating
`v4` tags for checkout / setup-java / setup-gradle / upload-artifact, while
`ci.yml` and `release.yml` pin everything by SHA. Small blast radius (scheduled,
`contents: read`), but a compromised `v4` tag would run arbitrary code in repo
context nightly. Pinned to the SHAs `ci.yml` already uses, keeping the `# v4`
comment convention.

**Add `.github/dependabot.yml`.** There was none. SHA/digest pins never move on
their own, so without bump automation they rot silently — year-old runners, a
JRE with known CVEs, and nothing red to notice it. Four ecosystems:
`github-actions`, `gradle` (root), `gradle` (`/build-logic`, a separate included
build invisible to the root scan), and `docker`. Everything grouped and weekly,
because a dozen individual PRs a week is how a solo maintainer ends up muting
the automation entirely. Gradle splits test-only from production deps so a JUnit
bump doesn't queue behind review of a Parquet one.

**Digest-pin the base images.** `eclipse-temurin:25-{jdk,jre}-noble` were the
largest unpinned input in an otherwise SHA-pinned supply chain. Both pins are
multi-arch **index** digests (verified via the registry API: `oci.image.index.v1+json`,
covering amd64 and arm64), so `--platform` selection is unaffected and the
multi-arch build still works. Verified with `docker build --check` — both
digests resolve, no warnings.

**Stop telling readers this is a private repository.** `docs/install.md` opened
with *"Tags in the current private repository … do not publish until the Phase 10
human acceptance gate makes the repository public"*, and
`docs/packaging-and-docker.md` repeated it in four places. Every stranger who has
read the install page since the 2026-07-25 cut has been told the project isn't
public yet. Replaced with the honest state — no release cut yet, so
build-from-source is the only path — and swapped the `<owner>/<repository>`
placeholders for the real `ghcr.io/varveio/swath`.

### Deliberately not in this PR

`docs/packaging-and-docker.md` §7 still says `docker-image` skips merges
"because `docker-publish` builds the image itself". That's a real inaccuracy —
`docker-publish` is `workflow_dispatch`-only, so **nothing builds an image on a
merge at all**. It's fixed in PR 2 alongside the workflow change that makes the
sentence true again, rather than rewritten twice.

### Verification

- `nightly.yml` and `dependabot.yml` parse; no `@v[0-9]` action pins remain in `nightly.yml`.
- `docker build --check` clean; both base digests confirmed as multi-arch indexes.
- `HeadlineDocsCommandSmokeTest` (reads `docs/install.md`) passes.
- No Java changed, so no engine impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
