### PR TITLE
Release prep 2/3: publish on merge, stop leaking branch names, settle naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,13 +371,22 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ghcr.io/${{ github.repository }}
-          # Dev images only: immutable sha- tags plus the branch name. The mutable
-          # `latest` tag belongs to published releases and is owned solely by
-          # release.yml, so a manual dev publish can never regress it to an
-          # unversioned main build.
+          # Dev images only. The mutable `latest` tag belongs to published releases
+          # and is owned solely by release.yml, so a dev publish can never regress
+          # it to an unversioned main build.
+          #
+          # `sha-<gitsha>` is emitted for every publish — immutable and bisectable,
+          # and enough to pull any branch's image for testing.
+          #
+          # The branch-name tag is deliberately restricted to `main`. A dispatch can
+          # run on ANY ref, and type=ref,event=branch would otherwise paint the
+          # branch name onto a public registry: dispatching `sim/streaming-tier`
+          # would publish ghcr.io/varveio/swath:sim-streaming-tier, leaking internal
+          # branch names to anyone listing the package. That was harmless while the
+          # repository was private; it is not now.
           tags: |
             type=sha,prefix=sha-
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/main' }}
 
       # Provenance note: the deep smoke above ran the native `--load`ed amd64 image;
       # this step rebuilds the multi-arch manifest from the SAME build cache in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       # from-source recompile inside the Docker build. docker-publish promotes it via a
       # BuildKit --build-context override of the Dockerfile's `build` stage — ship exactly
       # what was tested. PR runs do not publish an image, so they do not need this artifact.
-      - name: Prepare checked container-promotion payload
+      - name: Prepare container-promotion payload
         if: github.event_name != 'pull_request'
         run: ./scripts/ci/prepare-container-promotion.sh promote
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,10 +243,16 @@ jobs:
       - name: Smoke — image runs and entrypoint passes args to swath
         run: docker run --rm swath:ci --help
 
-  # Manual GHCR publish + deep runtime smoke. Tagged releases publish through
-  # release.yml; ordinary main pushes never publish a mutable image. Gated on the tests: `needs`
-  # fast-tests + integration-tests, so an image is never published from code that
-  # fails its tests. It builds the image itself (so it does not need docker-image).
+  # Dev-image GHCR publish + deep runtime smoke. Runs on every `main` merge and on
+  # manual dispatch from any branch. Tagged releases publish through release.yml
+  # instead; `latest` and the semver tags are owned solely by that workflow, so this
+  # job can never regress a release pointer.
+  #
+  # Running on merges is what gives `main` any Docker coverage at all: docker-check
+  # is PR-only, so without this a merge would build no image, and a break that only
+  # appears in the merge result (a semantic conflict between two green PRs, a RUN
+  # added to the runtime stage) would stay invisible until someone cut a tag.
+  #
   # Gated on ALL test jobs (`needs` fast-tests + integration-tests + deep-tests), so an image
   # is never published from code that fails any tier. It also promotes the tested uber-jar
   # from fast-tests into the image (see the build-context step below) rather than recompiling.
@@ -255,7 +261,9 @@ jobs:
   # settings; the workflow itself does not assume private or public visibility.
   docker-publish:
     needs: [fast-tests, integration-tests, deep-tests]
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     # Serialize ALL publishes globally (main + any dispatched branch share this one
     # group) so two publishes can never race the shared GHCR tags (main/sha-).
     # cancel-in-progress: false — never kill a publish mid-push; queue instead. If

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           # (read-only token) — degrade to a warning instead of failing the build.
           cache-to: type=gha,mode=max,ignore-error=true
 
-      - name: Build native image + load for smoke
+      - name: Build image (builder-native arch) + load for smoke
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -304,10 +304,10 @@ jobs:
       - name: Verify container-promotion payload
         run: ./scripts/ci/verify-container-promotion.sh promote
 
-      # Smoke BEFORE push: build the native image, run the deep runtime smoke,
+      # Smoke BEFORE push: build the builder-native-arch image, run the deep runtime smoke,
       # and only push if it passes — so a shading/exclude/runtime regression can
       # never reach the GHCR tags (`branch`/`sha-`).
-      - name: Build native image + load for deep smoke
+      - name: Build image (builder-native arch) + load for deep smoke
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -392,7 +392,7 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/main' }}
 
-      # Provenance note: the deep smoke above ran the native `--load`ed amd64 image;
+      # Provenance note: the deep smoke above ran the `--load`ed builder-native amd64 image;
       # this step rebuilds the multi-arch manifest from the SAME build cache in the
       # SAME job seconds later, so the pushed amd64 is effectively the smoked amd64.
       # Two residual facts, accepted as low-risk for an arch-neutral RUN-free jar:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,12 +206,16 @@ jobs:
   # build would just be a redundant second multi-arch build per merge. No push, no
   # credentials, no network — fork-safe.
   #
+  # Named `docker-check`, not `docker-image`: it is a gate that builds and smokes
+  # an image and throws it away, so the name says what it does rather than what it
+  # touches, and pairs with `docker-publish` as validate/publish.
+  #
   # Deliberately NO docker/setup-qemu-action: the runtime stage only pulls the
   # JRE base and COPYs the arch-neutral uber-jar (no RUN), so building the foreign
   # arch on this amd64 runner is pure pull+copy+metadata and needs no emulation.
   # That also makes this job a guard -- add a RUN to the runtime stage and the
   # arm64 build here starts needing QEMU and fails, flagging the regression.
-  docker-image:
+  docker-check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
         run: |
           echo "version=$(./gradlew -q properties | sed -n 's/^version: //p' | head -1)" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare exact container payload
+      - name: Prepare container-promotion payload
         run: ./scripts/ci/prepare-container-promotion.sh promote
 
-      - name: Stage release payloads
+      - name: Stage release assets
         run: |
           mkdir -p release-assets
           cp swath-cli/build/libs/swath.jar release-assets/
@@ -56,7 +56,7 @@ jobs:
           format: spdx-json
           output-file: release-assets/swath-${{ steps.version.outputs.version }}.spdx.json
 
-      - name: Write checksums for every unsigned release payload
+      - name: Write SHA256SUMS for release assets
         run: (cd release-assets && sha256sum swath.jar swath-*.zip swath-*.tar *.spdx.json > SHA256SUMS)
 
       # actions/upload-artifact@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,9 +21,14 @@ human side of it.
 ## Container tags
 
 - **Releases** publish `ghcr.io/varveio/swath:X.Y.Z` and `:latest`.
-- **Development builds** (main / manual CI) publish immutable `sha-<gitsha>` and branch
-  tags. `:latest` is owned solely by releases. To pin an exact build, use the immutable
-  digest: `ghcr.io/varveio/swath@sha256:…`.
+- **Merges to `main`** publish the immutable `sha-<gitsha>` tag plus the mutable `main`
+  pointer.
+- **Manual dispatch** (any branch) publishes `sha-<gitsha>` **only** — the branch-name tag
+  is restricted to `main`, so internal branch names never reach the public package. Pull a
+  branch build by its `sha-` tag.
+- `:latest` and every semver tag are owned solely by releases; no development build can
+  regress them. To pin an exact build, use the immutable digest:
+  `ghcr.io/varveio/swath@sha256:…`.
 
 ## Cutting a release
 

--- a/docs/packaging-and-docker.md
+++ b/docs/packaging-and-docker.md
@@ -240,31 +240,37 @@ it — for example a downstream image built `FROM` this one — pin the digest, 
 
 ## 7. CI image checks and release publication
 
-Two jobs in `.github/workflows/ci.yml` handle CI image checks. **`docker-image`**
+Two jobs in `.github/workflows/ci.yml` handle CI images. **`docker-check`**
 builds the multi-arch image (validating both `linux/amd64` and `linux/arm64`,
 no QEMU per §5), loads the native-arch build, and smoke-tests it
-(`docker run … --help`) — it never pushes. **`docker-publish`** is a manual
-maintainer-only smoke/publish path; ordinary `main` pushes never publish.
-Tagged publication belongs to `.github/workflows/release.yml`, behind the
-protected `public-release` environment.
+(`docker run … --help`) — it never pushes. **`docker-publish`** builds, runs a
+deep container smoke, and pushes dev images to GHCR. Tagged publication belongs
+to `.github/workflows/release.yml`, behind the protected `public-release`
+environment.
 
 Which jobs run depends on the trigger:
 
-| Event | fast-tests | integration-tests | docker-image | docker-publish |
-|---|:--:|:--:|:--:|:--:|
-| **Pull request** (feature branch) | ✅ | — | ✅ (build + smoke, no push) | — |
-| **Push to `main`** (i.e. a merge) | ✅ | ✅ | — | — |
-| **Manual** (`workflow_dispatch`) | ✅ | ✅ | — | ✅ (builds + pushes) |
+| Event | fast-tests | integration-tests | deep-tests | docker-check | docker-publish |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **Pull request** (feature branch) | ✅ | — | — | ✅ (build + smoke, no push) | — |
+| **Push to `main`** (i.e. a merge) | ✅ | ✅ | ✅ | — | ✅ (`sha-<gitsha>` + `main`) |
+| **Manual** (`workflow_dispatch`) | ✅ | ✅ | ✅ | — | ✅ (`sha-<gitsha>` only) |
 
-`docker-image` is the **PR-only** build gate — it validates the multi-arch build
-and runs `--help`, but never pushes. On a merge / dispatch it doesn't run,
-because `docker-publish` builds the image itself (running it too would just be a
+`docker-check` is the **PR-only** build gate — it validates the multi-arch build
+and runs `--help`, but never pushes. On a merge or dispatch it doesn't run,
+because `docker-publish` builds the image itself (running both would just be a
 redundant second multi-arch build).
 
-The manual `docker-publish` path is gated on green tests and its deep container
-smoke. The release publish job is separately protected by the `public-release`
-environment and requires the explicit `PUBLIC_RELEASE_ENABLED=true` repository
-variable, which acts as a publish kill-switch.
+A dispatch can run on any branch, so it publishes the immutable `sha-<gitsha>`
+tag **only** — the mutable branch-name tag is restricted to `main`, keeping
+internal branch names off the public package. Pull a branch build by its
+`sha-` tag.
+
+`docker-publish` is gated on all three test tiers, so no image is published from
+code that failed any of them. The release publish job is separately protected by
+the `public-release` environment and requires the explicit
+`PUBLIC_RELEASE_ENABLED=true` repository variable, which acts as a publish
+kill-switch.
 
 The **CI image checks** have no scheduled run — they fire only on pull
 requests, pushes to `main`, and manual dispatch. (A separate `nightly` workflow


### PR DESCRIPTION
Second of three release-prep PRs. This one makes the CI pipeline do what its own
comments and docs already claimed, and settles naming before the first tag
freezes it. No Java or Gradle changes.

### Behaviour

**`docker-publish` now runs on every `main` merge**, not only on manual dispatch.
`docker-check` is PR-only, so until now **a merge built no container image at
all** — a break appearing only in the merge result (a semantic conflict between
two individually-green PRs, a `RUN` added to the runtime stage) stayed invisible
until someone dispatched by hand or cut a tag. Still gated on all three test
tiers, so a red merge publishes nothing, and `latest`/semver tags remain owned
solely by `release.yml`.

**The branch-name tag is now restricted to `main`.** A dispatch can run on any
ref, and `type=ref,event=branch` was emitting the branch name on every publish —
so dispatching CI on `sim/streaming-tier` published
`ghcr.io/varveio/swath:sim-streaming-tier`, readable by anyone listing the
now-public package. Feature-branch dispatches now publish `sha-<gitsha>` only:
still pullable, still bisectable.

### Naming (settled now, deliberately)

Job ids become branch-protection required-check names, and none are configured
yet — so these are free today and turn into add-new/flip-protection/drop-old
later. Same reason naming must settle before the first tag: the workflow
filename ends up inside cosign certificate identities.

- **`docker-image` → `docker-check`.** It never produces an image anyone keeps —
  it builds one, smokes it, discards it. Pairs with `docker-publish` as
  validate/publish.
- **"Build native image" → "Build image (builder-native arch)".** In a JVM repo
  "native image" reads as GraalVM native-image, which swath deliberately doesn't
  do. It means the builder's own architecture.
- **"payload" split from "release assets".** One word was covering both the
  container-promotion contract and GitHub-release files, in adjacent steps.

### Docs corrected

The packaging doc's trigger table was stale in four ways — it omitted
`deep-tests`, showed no publish on a merge, showed dispatch publishing branch
tags, and used the old job name. `RELEASING.md` claimed development builds
publish "`sha-<gitsha>` and branch tags", which was wrong in both directions.
Both now match the workflow.

This also closes the §7 sentence I flagged as knowingly-left in #53 — it said
`docker-check` skips merges "because `docker-publish` builds the image itself",
which is true again as of the first commit here.

### Verification

- Both workflows parse; `docker-publish` condition and `meta` tag list confirmed post-parse.
- No `docker-image` or "native image" references remain outside the explanatory comment.
- No test reads `RELEASING.md` or `packaging-and-docker.md` (`docs/install.md`, which is read by `HeadlineDocsCommandSmokeTest`, is untouched here).
- The real proof is the first merge to `main` after this lands: `docker-publish` should run and push `sha-<gitsha>` + `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
