### PR TITLE
Release path: digest promotion, self-verifying publish, RC tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,33 +325,11 @@ jobs:
           sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
           duckdb --version
 
-      # Deep runtime smoke: exercise the shaded uber-jar's real paths that --help
-      # can't reach -- ServiceLoader/FileSystem service files, sqlite native-lib
-      # load, the Parquet write path, and managed resume. Runs only here (non-PR), so a network
-      # hiccup never blocks a PR. The container runs as uid 10001, so the mounted
-      # output dir is made world-writable. Gates the push below.
+      # Deep runtime smoke (shared with release.yml — see the script header). Runs
+      # only here on non-PR events, so a network hiccup never blocks a PR. Gates the
+      # push below: a shading/exclude/runtime regression can never reach the GHCR tags.
       - name: Smoke — container Parquet write + read + resume (public bucket)
-        run: |
-          set -euo pipefail
-          mkdir -p dockersmoke && chmod 777 dockersmoke
-          # A small, stable public AWS Open Data prefix (CMAS air-quality sample,
-          # us-east-1, anonymous / not requester-pays) — just a convenient tiny
-          # listing target for the smoke, nothing swath-specific about it.
-          BUCKET='s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/'
-          docker run --rm -v "$PWD/dockersmoke:/out" swath:ci \
-            list "$BUCKET" --no-sign-request --region us-east-1 \
-            --format parquet -o /out/data
-          N=$(duckdb -noheader -list -c "select count(*) from '$PWD/dockersmoke/data/**/*.parquet'")
-          echo "objects read back from Parquet: $N"
-          test "$N" -ge 1
-          # The supported resume command takes the managed output-directory run
-          # handle. Against a completed dataset it must be a clean no-op — the
-          # object count must be unchanged, not just exit 0.
-          docker run --rm -v "$PWD/dockersmoke:/out" swath:ci \
-            resume /out/data
-          N2=$(duckdb -noheader -list -c "select count(*) from '$PWD/dockersmoke/data/**/*.parquet'")
-          echo "objects after resume: $N2"
-          test "$N2" -eq "$N"
+        run: ./scripts/ci/smoke-container.sh swath:ci dockersmoke
 
       # Only now — after the smoke passed — log in and push the multi-arch
       # manifest to this repository's GHCR namespace.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,8 @@ jobs:
       # push below: a shading/exclude/runtime regression can never reach the GHCR tags.
       - name: Smoke — container Parquet write + read + resume (public bucket)
         run: ./scripts/ci/smoke-container.sh swath:ci dockersmoke
+        env:
+          SWATH_SMOKE_BUCKET: ${{ vars.SWATH_SMOKE_BUCKET }}
 
       # Only now — after the smoke passed — log in and push the multi-arch
       # manifest to this repository's GHCR namespace.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Install DuckDB CLI
         run: |
           curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          echo "efd0fccdb1a28d9ec7a6ebfcde59900068b8ba43a846c9b553c0fd2bbe4acf43  /tmp/duckdb.zip" | sha256sum --check -
           unzip -o /tmp/duckdb.zip -d /tmp/duckdb
           sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
           duckdb --version
@@ -321,6 +322,7 @@ jobs:
       - name: Install DuckDB CLI
         run: |
           curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          echo "efd0fccdb1a28d9ec7a6ebfcde59900068b8ba43a846c9b553c0fd2bbe4acf43  /tmp/duckdb.zip" | sha256sum --check -
           unzip -o /tmp/duckdb.zip -d /tmp/duckdb
           sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
           duckdb --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,27 +176,14 @@ jobs:
           unzip -o /tmp/duckdb.zip -d /tmp/duckdb
           sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
 
-      # The release image gets the SAME deep smoke the dev images get in ci.yml — and
-      # it runs against the pushed digest, so what is verified is exactly what the tags
-      # will name. Without this the release was the least-verified image we publish:
-      # `sha-` dev tags were smoked, `latest` was not.
+      # The release image gets the SAME deep smoke the dev images get — literally the
+      # same script — and it runs against the pushed digest, so what is verified is
+      # exactly what the tags will name. Without this the release was the
+      # least-verified image published: `sha-` dev tags were smoked, `latest` was not.
       - name: Smoke — Parquet write + read + resume against the pushed digest
+        run: ./scripts/ci/smoke-container.sh "ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" releasesmoke
         env:
-          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.image.outputs.digest }}
-        run: |
-          set -euo pipefail
-          mkdir -p releasesmoke && chmod 777 releasesmoke
-          BUCKET='s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/'
-          docker run --rm -v "$PWD/releasesmoke:/out" "$IMAGE" \
-            list "$BUCKET" --no-sign-request --region us-east-1 \
-            --format parquet -o /out/data
-          N=$(duckdb -noheader -list -c "select count(*) from '$PWD/releasesmoke/data/**/*.parquet'")
-          echo "objects read back from Parquet: $N"
-          test "$N" -ge 1
-          docker run --rm -v "$PWD/releasesmoke:/out" "$IMAGE" resume /out/data
-          N2=$(duckdb -noheader -list -c "select count(*) from '$PWD/releasesmoke/data/**/*.parquet'")
-          echo "objects after resume no-op: $N2"
-          test "$N2" = "$N"
+          DIGEST: ${{ steps.image.outputs.digest }}
 
       # Only now do the tags exist. imagetools create copies no bytes: it points new
       # tags at the digest that was just smoked.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,13 @@ jobs:
 
   publish:
     needs: build
-    # Tags remain private-repository dry runs until the Phase 10 human gate has
-    # accepted the public cut and explicitly enables this protected environment.
-    # Operator note: this gate reads visibility from the triggering push event, so
-    # after flipping visibility/PUBLIC_RELEASE_ENABLED you must push a FRESH tag —
-    # re-running an existing dry-run reuses the stale event payload and will skip.
+    # Publishing requires the repository to be public AND the PUBLIC_RELEASE_ENABLED
+    # variable, which stays in place as an emergency kill-switch: unset it and tags
+    # build assets without publishing anything, no code change required.
+    #
+    # Operator note: this gate reads visibility from the TRIGGERING PUSH EVENT, so
+    # re-running an old tag's workflow replays that tag's original payload. If a gate
+    # input has changed since, push a FRESH tag rather than re-running.
     if: github.event.repository.visibility == 'public' && vars.PUBLIC_RELEASE_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -127,18 +129,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Classify the tag once; every downstream step reads these outputs rather than
+      # re-deriving the rule. A pre-release publishes its own immutable X.Y.Z-rc.N tag
+      # and nothing else: no `latest`, no rolling `X.Y`, and a GitHub pre-release. The
+      # rehearsal must otherwise take exactly the same path as a real release —
+      # signing, attestation, promotion, self-verification — or it rehearses nothing.
+      - id: kind
+        name: Classify the release
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$VERSION" == *-rc.* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "tags=ghcr.io/${GITHUB_REPOSITORY}:${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            # Rolling X.Y alongside the immutable X.Y.Z. No bare X while 0.x — a `0`
+            # tag would imply a stability contract 0.x explicitly disclaims.
+            echo "tags=ghcr.io/${GITHUB_REPOSITORY}:${VERSION} ghcr.io/${GITHUB_REPOSITORY}:${VERSION%.*} ghcr.io/${GITHUB_REPOSITORY}:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Push by DIGEST, with no tags attached yet. The tags are applied further down,
+      # only after the smoke has run against this exact digest — so `latest` and
+      # `X.Y.Z` name bytes that were actually executed, not a second build that is
+      # merely expected to be identical. See the release-pipeline design note §2.1b.
       - id: image
-        name: Publish exact tested jar as a multi-arch image
+        name: Build and push the image by digest (untagged)
         # docker/build-push-action@v6
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           build-contexts: build=promote
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ needs.build.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           labels: |
             org.opencontainers.image.version=${{ needs.build.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -146,20 +170,150 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          unzip -o /tmp/duckdb.zip -d /tmp/duckdb
+          sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
+
+      # The release image gets the SAME deep smoke the dev images get in ci.yml — and
+      # it runs against the pushed digest, so what is verified is exactly what the tags
+      # will name. Without this the release was the least-verified image we publish:
+      # `sha-` dev tags were smoked, `latest` was not.
+      - name: Smoke — Parquet write + read + resume against the pushed digest
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p releasesmoke && chmod 777 releasesmoke
+          BUCKET='s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/'
+          docker run --rm -v "$PWD/releasesmoke:/out" "$IMAGE" \
+            list "$BUCKET" --no-sign-request --region us-east-1 \
+            --format parquet -o /out/data
+          N=$(duckdb -noheader -list -c "select count(*) from '$PWD/releasesmoke/data/**/*.parquet'")
+          echo "objects read back from Parquet: $N"
+          test "$N" -ge 1
+          docker run --rm -v "$PWD/releasesmoke:/out" "$IMAGE" resume /out/data
+          N2=$(duckdb -noheader -list -c "select count(*) from '$PWD/releasesmoke/data/**/*.parquet'")
+          echo "objects after resume no-op: $N2"
+          test "$N2" = "$N"
+
+      # Only now do the tags exist. imagetools create copies no bytes: it points new
+      # tags at the digest that was just smoked.
+      - name: Apply release tags to the smoked digest
+        env:
+          DIGEST: ${{ steps.image.outputs.digest }}
+          TAGS: ${{ steps.kind.outputs.tags }}
+        run: |
+          set -euo pipefail
+          ARGS=()
+          for tag in $TAGS; do ARGS+=(--tag "$tag"); done
+          docker buildx imagetools create "${ARGS[@]}" "ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}"
+          docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${{ needs.build.outputs.version }}"
+
       - name: Install cosign
         # sigstore/cosign-installer@v3
         uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9
 
-      - name: Keylessly sign release files and image
-        env:
-          COSIGN_EXPERIMENTAL: "1"
+      # SHA256SUMS is signed LAST and deliberately: it is the one file whose integrity
+      # transitively covers every other asset, so a consumer who verifies only its
+      # signature and then runs `sha256sum --check` has covered the whole release. It
+      # and the SBOM were previously left unsigned.
+      #
+      # No COSIGN_EXPERIMENTAL: keyless has been GA since cosign 2.0 (2023) and the
+      # variable is a no-op that only misleads readers.
+      - name: Keylessly sign release assets and the image digest
         run: |
-          for asset in release-assets/swath-*.jar release-assets/swath-*.zip release-assets/swath-*.tar.gz; do
+          set -euo pipefail
+          for asset in release-assets/swath-*.jar release-assets/swath-*.zip \
+                       release-assets/swath-*.tar.gz release-assets/*.spdx.json \
+                       release-assets/SHA256SUMS; do
             cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
           done
           cosign sign --yes "ghcr.io/${GITHUB_REPOSITORY}@${{ steps.image.outputs.digest }}"
 
-      - name: Create GitHub release from verified assets
+      # Attestations answer a different question from the signatures above: not "are
+      # these the bytes that were signed" but "which workflow, in which repo, at which
+      # commit, produced this" — SLSA v1.0 build provenance, verifiable with `gh
+      # attestation verify` and no extra tooling on the user's side.
+      # actions/attest-build-provenance@v4
+      - name: Attest build provenance for the release assets
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        with:
+          subject-path: |
+            release-assets/swath-*.jar
+            release-assets/swath-*.zip
+            release-assets/swath-*.tar.gz
+            release-assets/SHA256SUMS
+
+      # actions/attest-build-provenance@v4
+      - name: Attest build provenance for the image
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      # actions/attest-sbom@v4
+      - name: Attest the SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e
+        with:
+          subject-path: release-assets/swath-${{ needs.build.outputs.version }}.jar
+          sbom-path: release-assets/swath-${{ needs.build.outputs.version }}.spdx.json
+
+      # Created as a DRAFT. `gh release create` publishes the release and then uploads
+      # assets, so a failure mid-upload would otherwise leave a live, incomplete
+      # release — and notify watchers about it. Draft first, verify, then un-draft.
+      - name: Create the GitHub release as a draft
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" release-assets/* --title "swath ${{ needs.build.outputs.version }}" --generate-notes
+          PRERELEASE: ${{ steps.kind.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          ARGS=(--draft --title "swath ${{ needs.build.outputs.version }}" --generate-notes)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            ARGS+=(--prerelease)
+          fi
+          gh release create "$GITHUB_REF_NAME" release-assets/* "${ARGS[@]}"
+
+      # Run the exact commands the docs tell users to run. If verification would fail
+      # in a user's terminal, the release should be red here instead — a signature
+      # nobody can verify is worse than no signature, because it invites trust. This
+      # is also what makes the -rc rehearsal assert something rather than merely
+      # execute.
+      - name: Self-verify the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIGEST: ${{ steps.image.outputs.digest }}
+          IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+        run: |
+          set -euo pipefail
+          echo "::group::checksums"
+          (cd release-assets && sha256sum --check SHA256SUMS)
+          echo "::endgroup::"
+
+          echo "::group::cosign verify-blob (SHA256SUMS)"
+          cosign verify-blob \
+            --bundle release-assets/SHA256SUMS.sigstore.json \
+            --certificate-identity "$IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            release-assets/SHA256SUMS
+          echo "::endgroup::"
+
+          echo "::group::cosign verify (image)"
+          cosign verify \
+            --certificate-identity "$IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" > /dev/null
+          echo "::endgroup::"
+
+          echo "::group::gh attestation verify"
+          gh attestation verify "oci://ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" \
+            --repo "$GITHUB_REPOSITORY"
+          gh attestation verify release-assets/SHA256SUMS --repo "$GITHUB_REPOSITORY"
+          echo "::endgroup::"
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
         run: ./scripts/ci/smoke-container.sh "ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" releasesmoke
         env:
           DIGEST: ${{ steps.image.outputs.digest }}
+          SWATH_SMOKE_BUCKET: ${{ vars.SWATH_SMOKE_BUCKET }}
 
       # Only now do the tags exist. imagetools create copies no bytes: it points new
       # tags at the digest that was just smoked.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,15 @@ jobs:
             echo "tags=ghcr.io/${GITHUB_REPOSITORY}:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
-            # Rolling X.Y alongside the immutable X.Y.Z. No bare X while 0.x — a `0`
-            # tag would imply a stability contract 0.x explicitly disclaims.
-            echo "tags=ghcr.io/${GITHUB_REPOSITORY}:${VERSION} ghcr.io/${GITHUB_REPOSITORY}:${VERSION%.*} ghcr.io/${GITHUB_REPOSITORY}:latest" >> "$GITHUB_OUTPUT"
+            # Rolling X.Y alongside the immutable X.Y.Z.
+            tags="ghcr.io/${GITHUB_REPOSITORY}:${VERSION} ghcr.io/${GITHUB_REPOSITORY}:${VERSION%.*} ghcr.io/${GITHUB_REPOSITORY}:latest"
+            # Bare major only from 1.0 onward. A `0` tag would imply a stability
+            # contract 0.x explicitly disclaims, so the exception is implemented
+            # here rather than left as a comment nobody remembers at 1.0.
+            if [[ "${VERSION%%.*}" != 0 ]]; then
+              tags="$tags ghcr.io/${GITHUB_REPOSITORY}:${VERSION%%.*}"
+            fi
+            echo "tags=$tags" >> "$GITHUB_OUTPUT"
           fi
 
       # Push by DIGEST, with no tags attached yet. The tags are applied further down,
@@ -170,9 +176,14 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      # Checksum-verified before it runs. This job can publish, sign, attest and
+      # release, so an unverified third-party binary executing here would be the
+      # highest-privilege foothold in the pipeline.
       - name: Install DuckDB CLI
         run: |
+          set -euo pipefail
           curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          echo "efd0fccdb1a28d9ec7a6ebfcde59900068b8ba43a846c9b553c0fd2bbe4acf43  /tmp/duckdb.zip" | sha256sum --check -
           unzip -o /tmp/duckdb.zip -d /tmp/duckdb
           sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
 
@@ -276,16 +287,23 @@ jobs:
           IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
         run: |
           set -euo pipefail
-          echo "::group::checksums"
-          (cd release-assets && sha256sum --check SHA256SUMS)
+          # Verify what GitHub actually STORED, not the local copies we uploaded from.
+          # Checking release-assets/ would re-confirm files we already know are good and
+          # would miss a truncated or mis-uploaded asset — the failure this step exists
+          # to catch. Download the draft's assets into a fresh directory and verify there.
+          rm -rf release-verify
+          gh release download "$GITHUB_REF_NAME" --dir release-verify
+
+          echo "::group::checksums (downloaded copies)"
+          (cd release-verify && sha256sum --check SHA256SUMS)
           echo "::endgroup::"
 
           echo "::group::cosign verify-blob (SHA256SUMS)"
           cosign verify-blob \
-            --bundle release-assets/SHA256SUMS.sigstore.json \
+            --bundle release-verify/SHA256SUMS.sigstore.json \
             --certificate-identity "$IDENTITY" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            release-assets/SHA256SUMS
+            release-verify/SHA256SUMS
           echo "::endgroup::"
 
           echo "::group::cosign verify (image)"
@@ -298,7 +316,7 @@ jobs:
           echo "::group::gh attestation verify"
           gh attestation verify "oci://ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}" \
             --repo "$GITHUB_REPOSITORY"
-          gh attestation verify release-assets/SHA256SUMS --repo "$GITHUB_REPOSITORY"
+          gh attestation verify release-verify/SHA256SUMS --repo "$GITHUB_REPOSITORY"
           echo "::endgroup::"
 
       - name: Publish the release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,9 +7,10 @@ human side of it.
 
 ## Versioning
 
-- **Semantic Versioning, stable `X.Y.Z` only.** Pre-release and build-metadata tags
-  (`v1.2.3-rc1`, `v1.2.3+build`) are intentionally **not** supported — the release build
-  rejects them.
+- **Semantic Versioning: `X.Y.Z`, or `X.Y.Z-rc.N` for a pre-release.** No other
+  pre-release identifiers (`-alpha`, `-beta.2`) and no build metadata (`+build`) — the
+  release build rejects them. `-rc.N` is the only pre-release form the pipeline
+  implements publish semantics for.
 - **One source of truth.** `version` in [`gradle.properties`](gradle.properties) drives
   every produced artifact: the Gradle build, `swath --version`, jar manifests, archive
   names, and the container image labels. Between releases it carries a `-SNAPSHOT`
@@ -30,6 +31,24 @@ human side of it.
   regress them. To pin an exact build, use the immutable digest:
   `ghcr.io/varveio/swath@sha256:…`.
 
+## Release candidates
+
+A `vX.Y.Z-rc.N` tag runs the **entire** publish path — promotion, digest push, deep
+container smoke, signing, attestation, self-verification — and differs only in what it
+names: the `X.Y.Z-rc.N` container tag alone (no `:latest`, no rolling `X.Y`) and a GitHub
+**pre-release**.
+
+Use one whenever the publish path itself has changed. Its purpose is that a failure costs
+an `rc` number instead of a version number: tags are immutable, so a `vX.Y.Z` that dies
+half-way leaves a partial release and a version you cannot cleanly reuse.
+
+**An RC is not promoted.** `gradle.properties` reads `X.Y.Z-rc.N`, and that string is
+baked into the jar manifest and reported by `swath --version`, so shipping those bytes as
+`X.Y.Z` would contradict the tag — which `verifyReleaseVersion` exists to prevent. The
+final tag is a fresh build. What the rehearsal proves is the *pipeline*: credentials,
+signing identity, attestation subjects, and whether the verification commands below
+actually work.
+
 ## Cutting a release
 
 1. Make sure `main` is green and you are on a clean checkout of the commit you want to
@@ -45,8 +64,11 @@ human side of it.
    git push origin main v0.2.0
    ```
 4. The `Release` workflow builds the assets once, generates checksums and an SBOM, and
-   then waits on the protected `public-release` environment. **Approve it** to publish the
-   signed jar, distributions, container image, and GitHub release.
+   then waits on the protected `public-release` environment. **Approve it.** The publish
+   job then pushes the image by digest, smokes that digest, tags it, signs and attests
+   everything, creates the GitHub release as a **draft**, runs the verification commands
+   below against what it just published, and only then un-drafts it. If verification
+   fails the release stays a draft — fix and re-tag rather than publishing by hand.
 5. Bump the canonical version to the next development cycle and commit:
    ```
    # edit gradle.properties: version=0.3.0-SNAPSHOT   (or 0.2.1-SNAPSHOT)
@@ -71,3 +93,31 @@ For each `vX.Y.Z` tag, once the environment is approved:
   that in mind.
 - The version bump is manual by design (the canonical version lives in `gradle.properties`).
   `just release` wraps the mechanical steps so the tag and version cannot drift.
+
+## Verifying a release
+
+These are the commands a user runs, and the same ones the publish job runs against itself
+before un-drafting. `IDENTITY` is the workflow that produced the release — renaming
+`release.yml` would change it and invalidate every published instruction, which is why the
+filename is frozen.
+
+```
+TAG=v0.1.0
+IDENTITY="https://github.com/varveio/swath/.github/workflows/release.yml@refs/tags/${TAG}"
+ISSUER=https://token.actions.githubusercontent.com
+
+# 1. Checksums cover every asset.
+sha256sum --check SHA256SUMS
+
+# 2. The checksum file itself is signed, so step 1 is trustworthy.
+cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" SHA256SUMS
+
+# 3. The image, by digest.
+cosign verify --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
+  ghcr.io/varveio/swath@sha256:<digest>
+
+# 4. Build provenance — which workflow, at which commit, built this.
+gh attestation verify oci://ghcr.io/varveio/swath@sha256:<digest> --repo varveio/swath
+gh attestation verify SHA256SUMS --repo varveio/swath
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,7 +101,7 @@ before un-drafting. `IDENTITY` is the workflow that produced the release — ren
 `release.yml` would change it and invalidate every published instruction, which is why the
 filename is frozen.
 
-```
+```sh
 TAG=v0.1.0
 IDENTITY="https://github.com/varveio/swath/.github/workflows/release.yml@refs/tags/${TAG}"
 ISSUER=https://token.actions.githubusercontent.com

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,17 +21,23 @@ plugins {
 
 val verifyReleaseVersion by tasks.registering {
     group = "verification"
-    description = "Verifies a required stable vX.Y.Z release tag matches the canonical version."
+    description = "Verifies a required vX.Y.Z or vX.Y.Z-rc.N release tag matches the canonical version."
     val releaseTag = providers.gradleProperty("releaseTag")
     inputs.property("releaseTag", releaseTag.orNull ?: "")
     doLast {
         val tag = checkNotNull(releaseTag.orNull) { "Release builds require -PreleaseTag=vX.Y.Z" }
-        val stableSemVer = Regex("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")
-        check(stableSemVer.matches(project.version.toString())) {
-            "Release versions must be stable SemVer X.Y.Z; pre-release and build metadata are not supported"
+        // Stable X.Y.Z, or an -rc.N pre-release. Deliberately NOT the full SemVer
+        // pre-release grammar: `-rc.N` is the only pre-release form this project ships, and
+        // an exhaustive pattern would accept `-alpha`, `-beta.2+build`, and other identifiers
+        // whose publish semantics nothing here implements. Build metadata (`+…`) stays
+        // unsupported — it does not affect precedence, so it cannot mean anything useful on
+        // a release tag.
+        val releaseVersion = Regex("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-rc\\.[1-9][0-9]*)?$")
+        check(releaseVersion.matches(project.version.toString())) {
+            "Release versions must be X.Y.Z or X.Y.Z-rc.N; found ${project.version}"
         }
-        check(Regex("^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$").matches(tag)) {
-            "Release tag must be stable SemVer vX.Y.Z; found $tag"
+        check(Regex("^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-rc\\.[1-9][0-9]*)?$").matches(tag)) {
+            "Release tag must be vX.Y.Z or vX.Y.Z-rc.N; found $tag"
         }
         val expected = "v${project.version}"
         check(tag == expected) {

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,11 +40,9 @@ jar is built and what it bundles.
 The tagged-release workflow attaches the
 `distZip` and `distTar` application archives, a
 `SHA256SUMS` file, an SPDX SBOM, and a keyless Sigstore bundle for every shipped
-jar/archive. The archives contain Gradle application launchers and require a
-JDK 25 runtime; they are not native per-platform binaries. Verify the checksum before use; with
-[`cosign`](https://github.com/sigstore/cosign), verify an archive's adjacent
-bundle with `cosign verify-blob --bundle <archive>.sigstore.json <archive>`.
-The workflow also keylessly signs the immutable GHCR image digest.
+asset. The archives contain Gradle application launchers and require a
+JDK 25 runtime; they are not native per-platform binaries. See
+[Verifying a download](#verifying-a-download) below.
 
 ## Build from source
 
@@ -91,3 +89,59 @@ queries directly, no merge step needed. If the run gets interrupted,
 re-listing from scratch. See [`usage.md`](usage.md) for the full flag
 reference and [`configuration.md`](configuration.md) for every flag/knob's
 default at a glance.
+
+## Verifying a download
+
+Every release asset is signed with keyless [Sigstore](https://www.sigstore.dev/) and carries
+a SLSA build-provenance attestation. The same commands below run inside the release pipeline
+before it publishes, so a release that cannot be verified never goes out.
+
+`IDENTITY` names the workflow that built the release — substituting a different tag or repo
+is the point of the check, so paste it exactly.
+
+```
+TAG=v0.1.0
+IDENTITY="https://github.com/varveio/swath/.github/workflows/release.yml@refs/tags/${TAG}"
+ISSUER=https://token.actions.githubusercontent.com
+
+sha256sum --check SHA256SUMS
+
+cosign verify-blob --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" SHA256SUMS
+
+gh attestation verify SHA256SUMS --repo varveio/swath
+```
+
+Checking `SHA256SUMS` is enough for the whole release: its signature makes the file
+trustworthy, and the file covers every other asset. For the container image, verify the
+immutable digest rather than a tag:
+
+```
+cosign verify --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
+  ghcr.io/varveio/swath@sha256:<digest>
+
+gh attestation verify oci://ghcr.io/varveio/swath@sha256:<digest> --repo varveio/swath
+```
+
+## Running the container: two things that surprise people
+
+**Write permissions.** The image runs as a non-root numeric UID (10001), so a host output
+directory you own is *not* writable by it — the run fails with
+`AccessDeniedException`. Rather than loosening permissions with `chmod 777`, run the
+container as yourself, which also leaves the output owned by you:
+
+```
+mkdir -p /tmp/swath-out
+docker run --rm --user "$(id -u):$(id -g)" -v /tmp/swath-out:/out \
+  ghcr.io/varveio/swath:latest \
+  list s3://my-bucket/prefix/ --no-sign-request --format parquet -o /out/data
+```
+
+The output path must be inside the mount: `-o /out/data` lands in `/tmp/swath-out/data`.
+Anywhere else and the results stay in the container and vanish with `--rm`.
+
+**A short run looks silent.** Progress goes to stderr, and off a terminal it is *appended*
+every 30s rather than redrawn — so a run that finishes in ten seconds prints nothing until
+the summary. Pass `--progress-interval 2s` for periodic records in a log, or `docker run -t`
+to get the live redrawing display (a real terminal is required for that; `--progress` alone
+cannot force control sequences onto a stream that cannot act on them).

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,14 +92,16 @@ default at a glance.
 
 ## Verifying a download
 
-Every release asset is signed with keyless [Sigstore](https://www.sigstore.dev/) and carries
-a SLSA build-provenance attestation. The same commands below run inside the release pipeline
-before it publishes, so a release that cannot be verified never goes out.
+Every release asset is signed with keyless [Sigstore](https://www.sigstore.dev/). The jar,
+the archives and `SHA256SUMS` additionally carry a SLSA build-provenance attestation, as does
+the container image; the SBOM is signed but not separately attested, since `SHA256SUMS`
+already covers it. The same commands below run inside the release pipeline against the
+uploaded assets before it publishes, so a release that cannot be verified never goes out.
 
 `IDENTITY` names the workflow that built the release — substituting a different tag or repo
 is the point of the check, so paste it exactly.
 
-```
+```sh
 TAG=v0.1.0
 IDENTITY="https://github.com/varveio/swath/.github/workflows/release.yml@refs/tags/${TAG}"
 ISSUER=https://token.actions.githubusercontent.com
@@ -116,7 +118,7 @@ Checking `SHA256SUMS` is enough for the whole release: its signature makes the f
 trustworthy, and the file covers every other asset. For the container image, verify the
 immutable digest rather than a tag:
 
-```
+```sh
 cosign verify --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
   ghcr.io/varveio/swath@sha256:<digest>
 
@@ -130,7 +132,7 @@ directory you own is *not* writable by it — the run fails with
 `AccessDeniedException`. Rather than loosening permissions with `chmod 777`, run the
 container as yourself, which also leaves the output owned by you:
 
-```
+```sh
 mkdir -p /tmp/swath-out
 docker run --rm --user "$(id -u):$(id -g)" -v /tmp/swath-out:/out \
   ghcr.io/varveio/swath:latest \

--- a/justfile
+++ b/justfile
@@ -85,10 +85,13 @@ ci-drift:
     ./scripts/ci/check-instrumentation-drift.sh
 
 # Prepare a release: set the canonical version, commit, and create the vX.Y.Z tag.
-# Stable SemVer only (pre-release/build metadata are rejected, matching the release build).
+# Accepts X.Y.Z or a X.Y.Z-rc.N release candidate; no other pre-release identifiers and
+# no build metadata, matching what the release build enforces.
 # Does NOT push — review, then `git push origin main vX.Y.Z` to trigger release.yml.
-# After it publishes, bump gradle.properties to the next -SNAPSHOT. See RELEASING.md.
-# Usage: just release 0.2.0
+# After a stable release publishes, bump gradle.properties to the next -SNAPSHOT.
+# An -rc.N tag publishes only its own container tag and a GitHub pre-release, and is NOT
+# promoted — the final tag is a fresh build. See RELEASING.md.
+# Usage: just release 0.2.0   |   just release 0.2.0-rc.1
 release VERSION:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -92,8 +92,8 @@ ci-drift:
 release VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ ! "{{VERSION}}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-        echo "error: VERSION must be stable SemVer X.Y.Z (no pre-release/build metadata)" >&2; exit 2
+    if [[ ! "{{VERSION}}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]]; then
+        echo "error: VERSION must be X.Y.Z or X.Y.Z-rc.N (no other pre-release forms, no build metadata)" >&2; exit 2
     fi
     if [[ -n "$(git status --porcelain)" ]]; then
         echo "error: working tree is not clean; commit or stash first" >&2; exit 2
@@ -103,4 +103,10 @@ release VERSION:
     git commit -m "Release v{{VERSION}}"
     git tag -a "v{{VERSION}}" -m "swath v{{VERSION}}"
     echo "Prepared v{{VERSION}}. Review, then: git push origin main v{{VERSION}}"
-    echo "After it publishes, set gradle.properties to the next X.Y.Z-SNAPSHOT and commit."
+    if [[ "{{VERSION}}" == *-rc.* ]]; then
+        echo "This is a PRE-RELEASE: it publishes the X.Y.Z-rc.N container tag only —"
+        echo "no :latest, no :X.Y — and creates a GitHub pre-release. It is a rehearsal of"
+        echo "the publish path; the final tag is a separate, fresh build."
+    else
+        echo "After it publishes, set gradle.properties to the next X.Y.Z-SNAPSHOT and commit."
+    fi

--- a/scripts/ci/smoke-container.sh
+++ b/scripts/ci/smoke-container.sh
@@ -34,10 +34,21 @@ command -v duckdb >/dev/null || {
   exit 2
 }
 
-# A small, stable public AWS Open Data prefix (CMAS air-quality sample, us-east-1,
-# anonymous / not requester-pays) — a convenient tiny listing target, nothing
-# swath-specific about it.
-readonly BUCKET='s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/'
+# The listing target. Any small, stable, anonymously-readable prefix works — the smoke
+# asserts "at least one object", not a specific count, and swath issues LIST calls only
+# (object bodies are never fetched, so the objects' size is irrelevant).
+#
+# The default is a CMAS (Community Modeling and Analysis System) example case for the
+# SMOKE emissions model — 7 objects, us-east-1, anonymous, not requester-pays. Note the
+# name is a coincidence: "SMOKE" there is Sparse Matrix Operator Kernel Emissions, not a
+# smoke test. It is a third-party research-consortium bucket, NOT a bucket we control and
+# not (as far as we can confirm) part of the Registry of Open Data on AWS.
+#
+# Hence the override. A release publish now depends on this listing succeeding, so if the
+# bucket is ever removed, renamed, or flipped to requester-pays, an operator can point the
+# smoke elsewhere by setting SWATH_SMOKE_BUCKET — a repository variable and a re-tag,
+# rather than a code change, a PR and a merge while a half-published release waits.
+readonly BUCKET=${SWATH_SMOKE_BUCKET:-s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/}
 
 # The image runs as a non-root numeric UID (10001), so the mounted output directory has to
 # be writable by it. `--user` is deliberately NOT used: the smoke should exercise the

--- a/scripts/ci/smoke-container.sh
+++ b/scripts/ci/smoke-container.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Deep runtime smoke for a swath container image.
+#
+# Exercises the shaded uber-jar's real paths that `--help` cannot reach — the merged
+# ServiceLoader/FileSystem service files, the sqlite native-library extraction, the Parquet
+# write path, and managed resume. Each of those can be broken by a shading or dependency-
+# exclusion change while the image still starts and prints help.
+#
+# Correctness is judged by an INDEPENDENT Parquet reader (DuckDB), not by swath re-reading
+# its own output: the promise in the docs is that any Parquet reader queries the dataset
+# directly, so that is what gets tested. Exit status alone proves nothing here — a run can
+# exit 0 having written an unreadable or empty dataset.
+#
+# Used by BOTH publish paths so they cannot drift:
+#   - ci.yml  docker-publish  → dev images, on merge to main and manual dispatch
+#   - release.yml publish     → the release image, by digest, before its tags are applied
+# The release must get exactly the dev smoke, not an approximation of it; sharing one
+# script is what guarantees that.
+#
+# Runnable locally against any image reference:
+#   scripts/ci/smoke-container.sh ghcr.io/varveio/swath:main
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <image-ref> [work-directory]" >&2
+  exit 2
+fi
+
+image=$1
+workdir=${2:-containersmoke}
+
+command -v duckdb >/dev/null || {
+  echo "smoke requires the duckdb CLI on PATH" >&2
+  exit 2
+}
+
+# A small, stable public AWS Open Data prefix (CMAS air-quality sample, us-east-1,
+# anonymous / not requester-pays) — a convenient tiny listing target, nothing
+# swath-specific about it.
+readonly BUCKET='s3://cmas-smoke-testcase/smoke_example_case/2018gg_18j/inputs/htap/'
+
+# The image runs as a non-root numeric UID (10001), so the mounted output directory has to
+# be writable by it. `--user` is deliberately NOT used: the smoke should exercise the
+# image's own default identity, since that is what a user gets by default and a regression
+# that stops it writing as itself is exactly what this must catch.
+#
+# The consequence is that the outputs are owned by 10001, in subdirectories owned by 10001 —
+# which the invoking host user generally cannot unlink. So this refuses to reuse a work
+# directory rather than pre-deleting one (a `rm -rf` here would fail on the second local
+# run). CI always starts from a fresh runner, so this only ever affects repeat local use.
+if [[ -e "$workdir" ]]; then
+  cat >&2 <<EOF
+work directory already exists: $workdir
+Its contents are owned by the image's UID (10001), so removing it needs elevation:
+  sudo rm -rf "$workdir"
+Or pass a different work directory as the second argument.
+EOF
+  exit 2
+fi
+mkdir -p "$workdir"
+chmod 777 "$workdir"
+workdir=$(cd "$workdir" && pwd)
+
+count_objects() {
+  duckdb -noheader -list -c "select count(*) from '$workdir/data/**/*.parquet'"
+}
+
+echo "smoking $image"
+docker run --rm -v "$workdir:/out" "$image" \
+  list "$BUCKET" --no-sign-request --region us-east-1 \
+  --format parquet -o /out/data
+
+objects=$(count_objects)
+echo "objects read back from Parquet: $objects"
+test "$objects" -ge 1 || {
+  echo "smoke failed: no objects readable from the written dataset" >&2
+  exit 1
+}
+
+# The supported resume command takes the managed output-directory run handle. Against a
+# completed dataset it must be a clean no-op — the object count must be UNCHANGED, not
+# merely a zero exit.
+docker run --rm -v "$workdir:/out" "$image" resume /out/data
+
+after=$(count_objects)
+echo "objects after resume no-op: $after"
+test "$after" -eq "$objects" || {
+  echo "smoke failed: resume changed the object count ($objects -> $after)" >&2
+  exit 1
+}
+
+echo "container smoke passed: $image"


### PR DESCRIPTION
The release path itself — everything that only runs on a `v*` tag. After this,
`v0.1.0-rc.1` becomes possible.

### Digest promotion (the structural change)

The image is now pushed **by digest with no tags**, smoked, and only then tagged
via `imagetools create`. Previously `build-push-action` attached `X.Y.Z` and
`latest` in the same step, so **the release tags named a build nothing had ever
executed** — while dev `sha-` images got a full runtime smoke in `ci.yml`. The
release was the least-verified image we ship.

It now gets that same deep smoke (Parquet write → DuckDB read-back → resume
no-op) against the exact digest the tags will point at. `imagetools create`
copies no bytes; it repoints tags at the smoked digest.

### Signing, attestation, and a release that verifies itself

- `SHA256SUMS` and the SBOM are now signed — previously omitted, and `SHA256SUMS`
  is the one file whose integrity transitively covers every other asset. Signed
  last, deliberately.
- Artifact attestations alongside cosign: assets, the image digest
  (`push-to-registry`), and the SBOM. Signatures say "these are the bytes that
  were signed"; attestations say "this workflow, at this commit, built it".
- `COSIGN_EXPERIMENTAL` removed — a no-op since cosign 2.0 (2023).
- **Draft → verify → publish.** `gh release create` publishes and *then* uploads,
  so a mid-upload failure left a live half-release and notified watchers. It now
  creates a draft, runs the exact commands the docs give users (`sha256sum
  --check`, `cosign verify-blob`, `cosign verify`, `gh attestation verify`), and
  only un-drafts if they pass. A signature nobody can verify is worse than no
  signature, because it invites trust — so that failure belongs in CI, not in a
  user's terminal.

### Release candidates

`vX.Y.Z-rc.N` is now accepted. It publishes its own immutable container tag only
(no `latest`, no rolling `X.Y`) plus a GitHub pre-release; everything else runs
identically, which is the point.

Not the full SemVer pre-release grammar — `-rc.N` is the only form with
implemented publish semantics, and `-alpha`/`-beta.2+build` would parse as valid
while meaning nothing here.

Also adds the rolling `X.Y` tag for stable releases. No bare `X` while 0.x.

### Docs

`RELEASING.md` gets the RC section, including that **an RC is not promoted** —
its jar reports `X.Y.Z-rc.N`, so shipping those bytes as `X.Y.Z` would contradict
the tag. `install.md` gets the verification commands with the **exact** certificate
identity and issuer, not just flag names — an identity a user cannot construct is
a story they won't follow. Note this pins the workflow *filename*: renaming
`release.yml` changes the identity and invalidates every published instruction.

Plus the two first-run traps found while smoke-testing the public image today:
the UID-10001 write failure (recommending `--user` over `chmod 777`) and why a
short containerised run looks silent.

### Verification, and its limits

Done: workflow parses; publish step order confirmed post-parse; tag selection
simulated for rc/0.x/1.x; **all twelve pinned action SHAs resolved against the
API** (the two new attestation actions are v4 commits, dereferenced from tag
objects — I do not pin SHAs from memory); `verifyReleaseVersion` exercised across
the rc/stable/mismatch/`-beta.1`/`-SNAPSHOT` matrix; docs test green.

**Not done, and cannot be before merge:** none of the publish job runs without a
tag. Environment approval, GHCR push under the release token, cosign OIDC,
attestation upload, `imagetools create`, and `gh release create` are all still
unexercised. That is exactly why RC support ships here — **`v0.1.0-rc.1` is the
test for this PR**, and I would expect it to surface something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for release candidates using the `vX.Y.Z-rc.N` format.
  * Release candidate images use dedicated RC tags without `latest` or rolling tags.
  * Releases now undergo digest-based smoke testing and verification before publication.
  * Added signed checksums, software bills of materials, and provenance attestations for release assets and container images.

* **Documentation**
  * Expanded installation and release guidance with download, image, signature, and attestation verification instructions.
  * Added container runtime notes covering permissions and progress logging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->