### PR TITLE
Add a deep-nested shared-prefix fixture, and the readings that show why it is hard

### DIFF
--- a/swath-sim/README.md
+++ b/swath-sim/README.md
@@ -369,7 +369,18 @@ prefix of a range's own bounds, so on a range spanning sibling subtrees the meas
 page commits therefore advance the cursor without moving the fraction at all, the consumed span reads
 zero, and `estRemaining` falls back to a raw width with the range's emitted keys discarded — which is
 what every layer downstream (victim choice, pivot mass floors, the owner's self-split, the density
-feedback) is then steering on. How much each subtree holds is a separate parameter, because the
+feedback) is then steering on.
+
+**A high invisible-advance share on its own is not diagnostic of any of that**, and the measurements
+say so: the flat hex-named control reproduces it too (95.0% at scale, against this fixture's 94.1%).
+Twelve bytes is simply narrower than the ground a hundred-page range covers, whatever its keys are
+named, so once ranges are that wide the counter is reporting range width rather than taxonomy depth.
+What separates the two shapes is the **consumed span** — whether the window can see the cursor move
+*away from its own `lo`*, which is what decides if the estimate keeps the range's emitted keys or
+throws them away. That is where the fixtures diverge by a factor of two to eleven
+(`est_ignores_keys`, `est_zero`), and it is the reading a cure has to move.
+
+How much each subtree holds is a separate parameter, because the
 geometry decides what can be *measured* and the mass distribution decides whether being unable to
 measure it costs anything: `UNIFORM` isolates the first, and the heavy-tailed law a real archive
 follows is what makes the second visible.

--- a/swath-sim/README.md
+++ b/swath-sim/README.md
@@ -282,6 +282,23 @@ three are choices. So a run record carries them — which store served it, which
 against and how far that term can be trusted, which budgets it declared — alongside the phase shape,
 the counters every policy path engaged, and how many events the kernel dispatched to produce it.
 
+Two parts of that record are worth naming, because a counter total cannot express either.
+
+- **The phase timeline.** Three instants — the seed's end, the last split of any kind, the run's own
+  end — plus what happened between the last two: the keys emitted in that tail, and the *occupancy*,
+  meaning how many ranges were actually being drained while they were. A run that divides its keyspace
+  and one that gives up early can have identical split counts and completely different shapes, and the
+  difference is the whole subject. The run's end here is **quiescence**, not the kernel's last event:
+  a retired park timer still costs a dispatch when it fires, so the clock keeps moving for up to one
+  park window after the last worker has gone home. Both instants are reported, and the gap between them
+  is an artifact of the kernel rather than a property of the modelled fleet.
+- **Position-sensor readings.** Whether the arithmetic the policies steer on can see a given keyspace
+  at all: how many page commits moved the cursor without moving `fracIn`, and how many scanned victims
+  had a consumed span of zero, which is the case where `estRemaining` discards the emitted keys it was
+  given. These are computed by the executor from the same public `StealMath` the decisions call —
+  nothing in swath-core changes to produce them — because whether a sensor works is a property of the
+  keys, and a fixture that defeats it needs to be able to say so in numbers.
+
 ### What a run costs to produce
 
 Two different numbers, and confusing them is the classic simulator mistake. A run's **virtual
@@ -334,9 +351,31 @@ outside this module.
 A policy's behaviour is decided almost entirely by *shape* — where the directories are, whether mass
 sits in a few of them or spreads evenly, whether a split can find a populated pivot — so the tests also
 generate small keyspaces shaped like real buckets: a deep date-partitioned observation archive, a
-hash-fanned content-addressed corpus, a tree with one object per directory, and a single dense flat
-leaf. Each runs in milliseconds and each provokes different policy paths, which a fixture of uniformly
-named keys does not.
+hash-fanned content-addressed corpus, a tree with one object per directory, a single dense flat leaf,
+and a deep-nested shared prefix. Each runs in milliseconds and each provokes different policy paths,
+which a fixture of uniformly named keys does not.
+
+**The deep-nested shared prefix is the one aimed at a specific mechanism.** It is taxonomy-shaped —
+`species/<Genus_epithet>/<accession>/<dataset>/<stage>/<file>` — and its numbers are the point: sibling
+species directories diverge ten bytes in, while everything inside either of them varies only from byte
+39 on. Position is measured by `StealMath.fracIn` over the twelve bytes *after* the longest common
+prefix of a range's own bounds, so on a range spanning sibling subtrees the measured window is bytes
+10–22 and a cursor draining a subtree changes nothing inside it. Ninety-odd per cent of that fixture's
+page commits therefore advance the cursor without moving the fraction at all, the consumed span reads
+zero, and `estRemaining` falls back to a raw width with the range's emitted keys discarded — which is
+what every layer downstream (victim choice, pivot mass floors, the owner's self-split, the density
+feedback) is then steering on. How much each subtree holds is a separate parameter, because the
+geometry decides what can be *measured* and the mass distribution decides whether being unable to
+measure it costs anything: `UNIFORM` isolates the first, and the heavy-tailed law a real archive
+follows is what makes the second visible.
+
+Its readings are pinned in two places, both as characterizations of *current* behaviour that a change
+to how remaining work is measured is expected to break: `PositionSensorCharacterizationTest` runs it
+against the hash-fanned corpus at the same size, and `PositionSensorAtScaleTest` (`@Tag("perf")`) runs
+the same pair ten times further up, where the fleet's inability to divide the shape turns into a
+measurably emptier tail. The second exists because the first honestly cannot show that: at the smaller
+size the seed's own cut set is large relative to the fixture, so a runtime that cannot divide further is
+never asked to.
 
 One of them is adversarial on purpose. **Concurrency poison** is a store whose latency rises with the
 number of calls in flight: the fleet's own success makes every call slower. It exists because one

--- a/swath-sim/README.md
+++ b/swath-sim/README.md
@@ -288,10 +288,15 @@ Two parts of that record are worth naming, because a counter total cannot expres
   end — plus what happened between the last two: the keys emitted in that tail, and the *occupancy*,
   meaning how many ranges were actually being drained while they were. A run that divides its keyspace
   and one that gives up early can have identical split counts and completely different shapes, and the
-  difference is the whole subject. The run's end here is **quiescence**, not the kernel's last event:
-  a retired park timer still costs a dispatch when it fires, so the clock keeps moving for up to one
-  park window after the last worker has gone home. Both instants are reported, and the gap between them
-  is an artifact of the kernel rather than a property of the modelled fleet.
+  difference is the whole subject. The run's end here is **quiescence**, not the kernel's last event.
+  The kernel cannot cancel a timer, so a park that has already been retired still costs a dispatch when
+  it fires, and a dispatch moves the clock. The longest of them is the steal-attempt-slot backstop —
+  one second under the engine's own defaults, the park of a worker that found the fleet's single steal
+  slot busy — so the clock keeps advancing for up to that second after the last worker has retired.
+  Traced after quiescence, the residue is *only* retired parks: no call timeout, no retry, no key.
+  Both instants are reported, and the gap between them (0.75–1.0 s on the in-repo fixtures) is an
+  artifact of the kernel rather than a property of the modelled fleet — **so a comparison between runs
+  belongs on the timeline's end, not on the kernel's.**
 - **Position-sensor readings.** Whether the arithmetic the policies steer on can see a given keyspace
   at all: how many page commits moved the cursor without moving `fracIn`, and how many scanned victims
   had a consumed span of zero, which is the case where `estRemaining` discards the emitted keys it was
@@ -370,12 +375,16 @@ measure it costs anything: `UNIFORM` isolates the first, and the heavy-tailed la
 follows is what makes the second visible.
 
 Its readings are pinned in two places, both as characterizations of *current* behaviour that a change
-to how remaining work is measured is expected to break: `PositionSensorCharacterizationTest` runs it
-against the hash-fanned corpus at the same size, and `PositionSensorAtScaleTest` (`@Tag("perf")`) runs
-the same pair ten times further up, where the fleet's inability to divide the shape turns into a
-measurably emptier tail. The second exists because the first honestly cannot show that: at the smaller
-size the seed's own cut set is large relative to the fixture, so a runtime that cannot divide further is
-never asked to.
+to how remaining work is measured is expected to break. `PositionSensorCharacterizationTest` runs it
+against the hash-fanned corpus at the same size, and against *itself under a uniform mass* — which is
+what separates the two claims: the same geometry is just as blind (94% of commits invisible) and costs
+nothing at all, because equal subtrees leave the seed's own division balanced and the fleet is never
+left having to divide anything. `PositionSensorAtScaleTest` (`@Tag("perf")`) runs the heavy-tailed pair
+ten times further up, where the difference reaches the run: 8.4% of it after the last split at a mean of
+1.6 ranges in flight, against 0.8%. Note what that second test does *not* show — the deep-nested run
+publishes 205 split children there against the control's 64. The division is not missing; it is late,
+driven by thieves that spend 691 attempts to place 118 of them, and refused four thousand times over by
+the owner's own estimate.
 
 One of them is adversarial on purpose. **Concurrency poison** is a store whose latency rises with the
 number of calls in flight: the fleet's own success makes every call slower. It exists because one

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
@@ -154,13 +154,17 @@ public record PolicyRunResult(
         out.append(sensorLine());
         out.append(String.format(Locale.ROOT, "store=%s store_reads=%d%n", storeLabel, storeReads));
         out.append(String.format(Locale.ROOT, "client_cost=%s (%s)%n", term.provenance(), term.sourceLabel()));
+        // The steal-attempt-slot park is printed alongside the idle ladder because it is the longest
+        // timer the kernel cannot cancel, and therefore the whole of the gap between this record's
+        // quiesced and kernel_end instants — a reader checking that attribution needs its value here.
         out.append(String.format(Locale.ROOT, "budgets: worker_attempt_timeout=%dms probe_attempt_timeout=%dms "
-                + "clean_window=%dms idle_park=%dms..%dms%n",
+                + "clean_window=%dms idle_park=%dms..%dms attempt_slot_park=%dms%n",
                 scenario.budgets().workerAttemptTimeoutNanos() / 1_000_000L,
                 scenario.budgets().probeAttemptTimeoutNanos() / 1_000_000L,
                 scenario.budgets().concurrencyCleanWindowNanos() / 1_000_000L,
                 scenario.budgets().idleStealBaseParkNanos() / 1_000_000L,
-                scenario.budgets().idleStealBackoffCapNanos() / 1_000_000L));
+                scenario.budgets().idleStealBackoffCapNanos() / 1_000_000L,
+                scenario.budgets().idleStealAttemptParkNanos() / 1_000_000L));
         return out.toString();
     }
 

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
@@ -66,6 +66,12 @@ public record PolicyRunResult(
     }
 
     public PolicyRunResult {
+        if (run == null || scenario == null || timeline == null) {
+            // Every accessor and describe() dereferences all three, so a missing one has to fail here,
+            // where the caller that dropped it is still on the stack, rather than at the first read.
+            throw new IllegalArgumentException("a run record needs its kernel result, its scenario and "
+                    + "its timeline");
+        }
         counters = Collections.unmodifiableSortedMap(new TreeMap<>(counters));
     }
 
@@ -145,6 +151,7 @@ public record PolicyRunResult(
         out.append(String.format(Locale.ROOT, "seed_mode=%s seed_probes=%d seed_ranges=%d%n",
                 scenario.seedMode(), counter(SimExecutor.SEED_PROBES_COUNTER), counter("seed.ranges")));
         out.append(timeline.describe());
+        out.append(sensorLine());
         out.append(String.format(Locale.ROOT, "store=%s store_reads=%d%n", storeLabel, storeReads));
         out.append(String.format(Locale.ROOT, "client_cost=%s (%s)%n", term.provenance(), term.sourceLabel()));
         out.append(String.format(Locale.ROOT, "budgets: worker_attempt_timeout=%dms probe_attempt_timeout=%dms "
@@ -155,6 +162,31 @@ public record PolicyRunResult(
                 scenario.budgets().idleStealBaseParkNanos() / 1_000_000L,
                 scenario.budgets().idleStealBackoffCapNanos() / 1_000_000L));
         return out.toString();
+    }
+
+    /**
+     * The position-sensor readings as shares of what they were read over, because the raw totals are
+     * only meaningful against their own denominators: how often a page commit moved keys without moving
+     * the fraction, and how often a scored victim's estimate degenerated. Shares are printed as
+     * {@code n/d} alongside the ratio so a run with a tiny denominator cannot masquerade as a result.
+     */
+    private String sensorLine() {
+        long commits = counter(SimExecutor.SENSOR_BOUNDED_COMMITS_COUNTER);
+        long bounded = counter(SimExecutor.SENSOR_VICTIMS_BOUNDED_COUNTER);
+        return String.format(Locale.ROOT,
+                "sensor: cursor_advance_invisible=%d/%d (%.3f) victims_scanned=%d "
+                        + "est_ignores_keys=%d/%d (%.3f) est_zero=%d/%d (%.3f)%n",
+                counter(SimExecutor.SENSOR_INVISIBLE_ADVANCE_COUNTER), commits,
+                share(counter(SimExecutor.SENSOR_INVISIBLE_ADVANCE_COUNTER), commits),
+                counter(SimExecutor.SENSOR_VICTIMS_SCANNED_COUNTER),
+                counter(SimExecutor.SENSOR_EST_IGNORES_KEYS_COUNTER), bounded,
+                share(counter(SimExecutor.SENSOR_EST_IGNORES_KEYS_COUNTER), bounded),
+                counter(SimExecutor.SENSOR_EST_ZERO_COUNTER), bounded,
+                share(counter(SimExecutor.SENSOR_EST_ZERO_COUNTER), bounded));
+    }
+
+    private static double share(long numerator, long denominator) {
+        return denominator == 0L ? 0.0 : (double) numerator / denominator;
     }
 
     private static SortedMap<String, Long> merge(SortedMap<String, Long> kernel,

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunResult.java
@@ -35,6 +35,7 @@ import java.util.TreeMap;
  * @param finalConcurrencyTarget the adaptive controller's target when the run ended
  * @param stuck        whether the run ended because a page fetch exhausted its transient retries, which
  *                     is a modelled failure of the run rather than a completed one
+ * @param timeline     when the run did what: its phase boundaries, and the tail's own rates and occupancy
  */
 public record PolicyRunResult(
         SimRunResult run,
@@ -45,7 +46,8 @@ public record PolicyRunResult(
         long splitsRejected,
         long storeReads,
         int finalConcurrencyTarget,
-        boolean stuck) {
+        boolean stuck,
+        PolicyRunTimeline timeline) {
 
     /**
      * Assembles a result, merging the kernel's counters with the controller's own so a reader has one map
@@ -57,9 +59,10 @@ public record PolicyRunResult(
      */
     static PolicyRunResult of(SimRunResult run, PolicyScenario scenario, String storeLabel,
                               SortedMap<String, Long> gaugeCounters, int finalConcurrencyTarget,
-                              long nodesCreated, long splitsRejected, long storeReads, boolean stuck) {
+                              long nodesCreated, long splitsRejected, long storeReads, boolean stuck,
+                              PolicyRunTimeline timeline) {
         return new PolicyRunResult(run, scenario, storeLabel, merge(run.counters(), gaugeCounters),
-                nodesCreated, splitsRejected, storeReads, finalConcurrencyTarget, stuck);
+                nodesCreated, splitsRejected, storeReads, finalConcurrencyTarget, stuck, timeline);
     }
 
     public PolicyRunResult {
@@ -141,6 +144,7 @@ public record PolicyRunResult(
                 + "splits_rejected=%d%n", nodesCreated, ownerSplitChildren(), thiefChildren(), splitsRejected));
         out.append(String.format(Locale.ROOT, "seed_mode=%s seed_probes=%d seed_ranges=%d%n",
                 scenario.seedMode(), counter(SimExecutor.SEED_PROBES_COUNTER), counter("seed.ranges")));
+        out.append(timeline.describe());
         out.append(String.format(Locale.ROOT, "store=%s store_reads=%d%n", storeLabel, storeReads));
         out.append(String.format(Locale.ROOT, "client_cost=%s (%s)%n", term.provenance(), term.sourceLabel()));
         out.append(String.format(Locale.ROOT, "budgets: worker_attempt_timeout=%dms probe_attempt_timeout=%dms "

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunTimeline.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunTimeline.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sim.executor;
+
+import java.util.Locale;
+
+/**
+ * <b>When</b> a run did what — the phase shape a counter total cannot express.
+ *
+ * <p>Counters say how often a mechanism fired over a whole run; they cannot say that every firing
+ * happened in the first two seconds and the remaining thirty were one worker draining alone. That
+ * difference is the whole subject of a parallel listing, so a run record carries three instants —
+ * the seed's end, the <b>last</b> split of any kind, and the run's own end — and the two quantities
+ * that only mean something relative to them: how many keys came out after the last split, and how
+ * many ranges were being drained while they did.
+ *
+ * <p>The tail is defined as the interval after the last split because that is the moment the fleet
+ * lost its last chance to divide: no mechanism creates work after it, so whatever parallelism exists
+ * at that instant is the parallelism the rest of the run gets. A healthy run's tail is a short
+ * flush of already-divided work; a run that cannot divide has a tail that is most of its duration
+ * and an occupancy near one.
+ *
+ * <p>Everything here is accumulated in constant space by {@link Recorder}: the tail's start is not
+ * known until the run ends, so rather than retain a sample per page the recorder snapshots its
+ * running totals at every split and keeps only the latest snapshot. A run therefore pays no memory
+ * for this, which is what lets it stay on during a sweep, where the event trace is off.
+ *
+ * <p><b>The end of the run is quiescence, not the kernel's last event.</b> Workers park with a backoff
+ * of their own, and a park timer that was already retired still costs a dispatch when it fires: the
+ * kernel's clock therefore keeps moving after the last range completed and every worker has gone home,
+ * by up to one park window. Nothing happened in that interval — no key, no call, no decision — so a
+ * phase record measured against it would credit the tail with dead time no worker spent. Both instants
+ * are carried, and their difference is the artifact rather than a result.
+ *
+ * @param seedCompletedNanos      the instant the seed phase handed its ranges to the fleet
+ * @param lastSplitNanos          the instant of the last published split child, owner-side or thief;
+ *                                equal to {@code seedCompletedNanos} when nothing ever split
+ * @param endNanos                the instant the run went quiescent — its last range completed
+ * @param kernelEndNanos          the kernel's own last event, retired park timers included
+ * @param keysEmitted             keys emitted over the whole run
+ * @param keysInTail              keys emitted after {@code lastSplitNanos}
+ * @param rangeNanosInTail        the integral of concurrently-drained ranges over the tail, in
+ *                                range-nanoseconds — the numerator of the tail's mean occupancy
+ * @param rangeNanos              the same integral over the whole run after the seed
+ * @param serialNanos             time after the seed during which at most one range was being drained
+ * @param maxConcurrentRanges     the most ranges ever being drained at one instant
+ */
+public record PolicyRunTimeline(
+        long seedCompletedNanos,
+        long lastSplitNanos,
+        long endNanos,
+        long kernelEndNanos,
+        long keysEmitted,
+        long keysInTail,
+        long rangeNanosInTail,
+        long rangeNanos,
+        long serialNanos,
+        int maxConcurrentRanges) {
+
+    /** The share of the run's duration that came after the last split. */
+    public double tailFraction() {
+        return endNanos <= 0L ? 0.0 : (double) (endNanos - lastSplitNanos) / endNanos;
+    }
+
+    /** Keys emitted per virtual second over the whole run. */
+    public double keysPerVirtualSecond() {
+        return endNanos <= 0L ? 0.0 : keysEmitted / (endNanos / 1e9);
+    }
+
+    /** Keys emitted per virtual second during the tail. */
+    public double tailKeysPerVirtualSecond() {
+        long tailNanos = endNanos - lastSplitNanos;
+        return tailNanos <= 0L ? 0.0 : keysInTail / (tailNanos / 1e9);
+    }
+
+    /**
+     * Ranges being drained at the average instant of the tail — the achieved occupancy, which for a
+     * fleet that claims one range per worker is how many workers still had work.
+     */
+    public double meanTailOccupancy() {
+        long tailNanos = endNanos - lastSplitNanos;
+        return tailNanos <= 0L ? 0.0 : (double) rangeNanosInTail / tailNanos;
+    }
+
+    /**
+     * Ranges being drained at the average instant after the seed — the fleet's achieved parallelism,
+     * whose ceiling is the worker count.
+     */
+    public double meanOccupancy() {
+        long nanos = endNanos - seedCompletedNanos;
+        return nanos <= 0L ? 0.0 : (double) rangeNanos / nanos;
+    }
+
+    /**
+     * The share of the post-seed run during which at most one range was being drained — the fleet
+     * running serially, whatever its worker count says.
+     */
+    public double serialFraction() {
+        long nanos = endNanos - seedCompletedNanos;
+        return nanos <= 0L ? 0.0 : (double) serialNanos / nanos;
+    }
+
+    /** The phase shape as one line, for a run record. */
+    public String describe() {
+        return String.format(Locale.ROOT,
+                "phases: seed_end=%.3fs last_split=%.3fs quiesced=%.3fs kernel_end=%.3fs "
+                        + "tail_fraction=%.3f%n"
+                        + "rates: keys_per_virtual_second=%.0f tail_keys_per_virtual_second=%.0f "
+                        + "keys_in_tail=%d%n"
+                        + "occupancy: mean_ranges=%.2f mean_tail_ranges=%.2f serial_fraction=%.3f "
+                        + "max_concurrent_ranges=%d%n",
+                seedCompletedNanos / 1e9, lastSplitNanos / 1e9, endNanos / 1e9,
+                kernelEndNanos / 1e9, tailFraction(),
+                keysPerVirtualSecond(), tailKeysPerVirtualSecond(), keysInTail,
+                meanOccupancy(), meanTailOccupancy(), serialFraction(), maxConcurrentRanges);
+    }
+
+    /**
+     * Accumulates a timeline as the run happens, in constant space.
+     *
+     * <p>Two running totals — keys emitted, and the integral of concurrently-drained ranges — are
+     * snapshotted at each split. The last such snapshot is the tail's start, so the tail's own totals
+     * are a subtraction at the end rather than a scan over retained samples.
+     */
+    static final class Recorder {
+
+        private long seedCompletedNanos;
+        private long lastSplitNanos;
+        private long quiescedNanos = -1L;
+        private long keysEmitted;
+        private long keysAtLastSplit;
+        private long rangeNanos;
+        private long rangeNanosAtLastSplit;
+        private long serialNanos;
+        private int concurrentRanges;
+        private int maxConcurrentRanges;
+        private long lastOccupancyChangeNanos;
+
+        /** The seed phase is over: its cut set is published and the fleet may start. */
+        void seedCompleted(long nowNanos) {
+            seedCompletedNanos = nowNanos;
+            lastSplitNanos = nowNanos;
+            lastOccupancyChangeNanos = nowNanos;
+        }
+
+        /** A split child was published, owner-side or by a thief: the tail cannot start before this. */
+        void splitPublished(long nowNanos) {
+            lastSplitNanos = nowNanos;
+            keysAtLastSplit = keysEmitted;
+            rangeNanosAtLastSplit = integralAt(nowNanos);
+        }
+
+        /** A page committed {@code keys} to the output. */
+        void keysCommitted(long keys) {
+            keysEmitted += keys;
+        }
+
+        /** A range was claimed by a worker, or released by one. */
+        void occupancyChanged(long nowNanos, int ranges) {
+            rangeNanos = integralAt(nowNanos);
+            serialNanos = serialNanosAt(nowNanos);
+            lastOccupancyChangeNanos = nowNanos;
+            concurrentRanges = ranges;
+            maxConcurrentRanges = Math.max(maxConcurrentRanges, ranges);
+        }
+
+        /** The last outstanding range completed: the fleet is done, whatever the kernel does next. */
+        void quiesced(long nowNanos) {
+            quiescedNanos = nowNanos;
+        }
+
+        PolicyRunTimeline finish(long kernelEndNanos) {
+            long endNanos = quiescedNanos < 0L ? kernelEndNanos : quiescedNanos;
+            return new PolicyRunTimeline(seedCompletedNanos, lastSplitNanos, endNanos, kernelEndNanos,
+                    keysEmitted, keysEmitted - keysAtLastSplit,
+                    integralAt(endNanos) - rangeNanosAtLastSplit, integralAt(endNanos),
+                    serialNanosAt(endNanos), maxConcurrentRanges);
+        }
+
+        private long integralAt(long nowNanos) {
+            return rangeNanos + (long) concurrentRanges * elapsed(nowNanos);
+        }
+
+        private long serialNanosAt(long nowNanos) {
+            return concurrentRanges <= 1 ? serialNanos + elapsed(nowNanos) : serialNanos;
+        }
+
+        private long elapsed(long nowNanos) {
+            return Math.max(0L, nowNanos - lastOccupancyChangeNanos);
+        }
+    }
+}

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunTimeline.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/PolicyRunTimeline.java
@@ -28,12 +28,20 @@ import java.util.Locale;
  * running totals at every split and keeps only the latest snapshot. A run therefore pays no memory
  * for this, which is what lets it stay on during a sweep, where the event trace is off.
  *
- * <p><b>The end of the run is quiescence, not the kernel's last event.</b> Workers park with a backoff
- * of their own, and a park timer that was already retired still costs a dispatch when it fires: the
- * kernel's clock therefore keeps moving after the last range completed and every worker has gone home,
- * by up to one park window. Nothing happened in that interval — no key, no call, no decision — so a
- * phase record measured against it would credit the tail with dead time no worker spent. Both instants
- * are carried, and their difference is the artifact rather than a result.
+ * <p><b>The end of the run is quiescence, not the kernel's last event.</b> The kernel has no
+ * cancellation, so a park timer that has already been retired still costs a dispatch when it fires —
+ * and a dispatch moves the clock. The longest such timer is the <b>steal-attempt-slot backstop</b>
+ * ({@code idleStealAttemptParkNanos}, one second under the engine's own defaults): the park of a worker
+ * that found the fleet's single steal-attempt slot busy. It is armed hundreds of times in a run that
+ * steals at all, so after the last range completes and every worker has retired, the clock keeps
+ * advancing for as long as the newest of those timers has left to run — measured at 0.75–1.0 s on these
+ * fixtures, and bounded by that one second rather than by the 5–50 ms idle backoff ladder. Traced after
+ * quiescence, the residue is <em>only</em> retired parks: no call timeout, no retry, no decision, no
+ * key. A phase record measured against the kernel's last event would therefore credit the tail with
+ * dead time no worker spent, so both instants are carried and their difference is named as an artifact
+ * of the kernel rather than a result. <b>A comparison between runs — a sweep's ranking, a variant's
+ * verdict — belongs on {@link #endNanos}</b>; the kernel's own duration carries a per-run constant that
+ * has nothing to do with the policies being compared.
  *
  * @param seedCompletedNanos      the instant the seed phase handed its ranges to the fleet
  * @param lastSplitNanos          the instant of the last published split child, owner-side or thief;
@@ -172,6 +180,16 @@ public record PolicyRunTimeline(
             quiescedNanos = nowNanos;
         }
 
+        /**
+         * Closes the timeline at the kernel's last event.
+         *
+         * <p>A run that never went quiescent — one that ended stuck on a retry ceiling, or was cut off
+         * by the event cap — has no completion instant to measure against, so its phase end falls back
+         * to the kernel's. That makes {@code endNanos == kernelEndNanos} the signature of a run that
+         * did not finish, and it is exactly the case where the record's own {@code completed()} is
+         * false: the fallback is a stated definition for an unfinished run, not a second meaning for a
+         * finished one.
+         */
         PolicyRunTimeline finish(long kernelEndNanos) {
             long endNanos = quiescedNanos < 0L ? kernelEndNanos : quiescedNanos;
             return new PolicyRunTimeline(seedCompletedNanos, lastSplitNanos, endNanos, kernelEndNanos,

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/SimExecutor.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/SimExecutor.java
@@ -170,24 +170,43 @@ public final class SimExecutor {
     public static final String OWNER_SPLIT_COUNTER = "owner_split.published";
     /** Children published by a thief's steal. */
     public static final String THIEF_SPLIT_COUNTER = "steal.children";
-    /** Page commits on a bounded range — the denominator the two position-sensor counters below read against. */
+    /**
+     * Page commits on a bounded range that emitted at least one key — a commit that emitted none moved
+     * no cursor, so it is neither visible nor invisible and is not counted either way. The denominator
+     * {@link #SENSOR_INVISIBLE_ADVANCE_COUNTER} reads against.
+     */
     public static final String SENSOR_BOUNDED_COMMITS_COUNTER = "sensor.bounded_page_commits";
     /**
-     * Bounded page commits whose cursor advance did not move {@link io.varve.swath.engine.StealMath#fracIn}
-     * at all: real keys came out and the position the policies measure stayed where it was.
+     * Bounded page commits whose cursor advance did not move {@link StealMath#fracIn} at all: real keys
+     * came out and the position the policies measure stayed where it was.
      */
     public static final String SENSOR_INVISIBLE_ADVANCE_COUNTER = "sensor.cursor_advance_invisible";
-    /** Victims scanned by victim selection, summed over attempts — the denominator of the two below. */
+    /**
+     * Victims whose {@code estRemaining} victim selection actually evaluated, summed over attempts:
+     * the eligible pool minus the candidates the policy skips <em>before</em> scoring them — the
+     * unsplittable ones and the ones holding a futility-pacing skip. Open frontiers are included, as
+     * selection includes them (it scores them {@code +∞}).
+     */
     public static final String SENSOR_VICTIMS_SCANNED_COUNTER = "sensor.victims_scanned";
     /**
-     * Scanned victims whose {@code estRemaining} read zero, so selection skipped them as having no
-     * remaining span — the reading behind a {@code NO_VICTIM.all_no_remaining_span}.
+     * Of {@link #SENSOR_VICTIMS_SCANNED_COUNTER}, those carrying a bound — the denominator of the two
+     * degeneracy counters below, since an open frontier's estimate is {@code +∞} by contract and its
+     * consumed span is not defined.
+     */
+    public static final String SENSOR_VICTIMS_BOUNDED_COUNTER = "sensor.victims_scanned_bounded";
+    /**
+     * Scored bounded victims whose {@code estRemaining} read zero, so selection passed over them as
+     * having no remaining span. An attempt in which <em>every</em> scored candidate reads this way is
+     * what a {@code NO_VICTIM.all_no_remaining_span} is made of; this counter is the per-candidate
+     * reading, not that verdict.
      */
     public static final String SENSOR_EST_ZERO_COUNTER = "sensor.victim_est_zero";
     /**
-     * Scanned victims whose consumed span read zero, so {@code estRemaining} returned the raw remaining
-     * span and <b>ignored {@code keysEmitted}</b>: a worker that has emitted a million keys scores
-     * identically to one that has emitted none.
+     * Scored bounded victims whose consumed span read zero, so {@code estRemaining} returned the raw
+     * remaining span and <b>ignored {@code keysEmitted}</b>: a worker that has emitted a million keys
+     * scores identically to one that has emitted none. These are victims that have <em>certainly</em>
+     * emitted keys — a candidate only becomes steal-eligible after emitting some — which is what makes
+     * a zero consumed span a defect in the measurement rather than a fact about the worker.
      */
     public static final String SENSOR_EST_IGNORES_KEYS_COUNTER = "sensor.victim_est_ignores_keys";
 
@@ -1053,6 +1072,12 @@ public final class SimExecutor {
      * it degenerates: a zero score, which takes a candidate out of the running entirely, and a zero
      * consumed span, which leaves the score a raw width with the candidate's emitted keys discarded.
      *
+     * <p><b>The skip order mirrors the policy's.</b> {@link ThiefPolicy#selectVictim} passes over an
+     * unsplittable candidate, and over one holding a futility-pacing skip, <em>before</em> it computes
+     * any estimate — so scoring those here would report readings selection never took. The mirror is
+     * read-only: a pacing skip is observed, never consumed, because consuming it is the policy's
+     * mutation to return and the executor applies exactly the ones it does.
+     *
      * <p>This duplicates the arithmetic the policy is about to do rather than asking it what it saw:
      * the policy's contract is a {@link Selection}, and widening it to report its own intermediate
      * readings would put a diagnostic in the engine's decision seam. The inputs are the same view the
@@ -1060,10 +1085,14 @@ public final class SimExecutor {
      */
     private static void recordVictimSensorReadings(SimContext ctx, List<VictimView> pool) {
         for (VictimView candidate : pool) {
-            if (candidate.hi() == null) {
+            if (candidate.unsplittable() || candidate.pacingSkipAvailable()) {
                 continue;
             }
             ctx.count(SENSOR_VICTIMS_SCANNED_COUNTER, 1);
+            if (candidate.hi() == null) {
+                continue;
+            }
+            ctx.count(SENSOR_VICTIMS_BOUNDED_COUNTER, 1);
             if (StealMath.estRemaining(candidate.cursor(), candidate.lo(), candidate.hi(),
                     candidate.keysEmitted()) <= 0.0) {
                 ctx.count(SENSOR_EST_ZERO_COUNTER, 1);

--- a/swath-sim/src/main/java/io/varve/swath/sim/executor/SimExecutor.java
+++ b/swath-sim/src/main/java/io/varve/swath/sim/executor/SimExecutor.java
@@ -7,6 +7,7 @@ package io.varve.swath.sim.executor;
 
 import io.varve.swath.engine.ConfettiFeedbackGate;
 import io.varve.swath.engine.EngineToggles;
+import io.varve.swath.engine.StealMath;
 import io.varve.swath.engine.WorkerState;
 import io.varve.swath.engine.policy.Carve;
 import io.varve.swath.engine.policy.Commit;
@@ -121,6 +122,15 @@ import java.util.Set;
  * the seam unchanged, still consulted under the same monitor, so this executor's single check-then-act
  * at the top of an attempt is the engine's own shape rather than a widening of it.
  *
+ * <h2>Instrumenting the position sensor</h2>
+ * Victim choice, pivot mass floors, the owner's self-split and the density feedback all steer on one
+ * quantity: {@link StealMath#estRemaining}, a local density times a remaining span, both measured in
+ * the window-relative fraction {@link StealMath#fracIn} defines. Whether that sensor can actually see a
+ * given keyspace is a property of the keys, not of the policies, so the executor measures it where the
+ * policies read it — at every bounded page commit, and at every victim scanned — using the same public
+ * arithmetic the decisions use. Nothing in swath-core changes to produce these counters; they are a
+ * second reader of a function the engine already exports.
+ *
  * <h2>Determinism</h2>
  * One scenario at one seed against one store reproduces itself exactly, including its event trace. That
  * is a claim about the simulator only. It is not a claim that a seeded live run would produce the same
@@ -160,6 +170,26 @@ public final class SimExecutor {
     public static final String OWNER_SPLIT_COUNTER = "owner_split.published";
     /** Children published by a thief's steal. */
     public static final String THIEF_SPLIT_COUNTER = "steal.children";
+    /** Page commits on a bounded range — the denominator the two position-sensor counters below read against. */
+    public static final String SENSOR_BOUNDED_COMMITS_COUNTER = "sensor.bounded_page_commits";
+    /**
+     * Bounded page commits whose cursor advance did not move {@link io.varve.swath.engine.StealMath#fracIn}
+     * at all: real keys came out and the position the policies measure stayed where it was.
+     */
+    public static final String SENSOR_INVISIBLE_ADVANCE_COUNTER = "sensor.cursor_advance_invisible";
+    /** Victims scanned by victim selection, summed over attempts — the denominator of the two below. */
+    public static final String SENSOR_VICTIMS_SCANNED_COUNTER = "sensor.victims_scanned";
+    /**
+     * Scanned victims whose {@code estRemaining} read zero, so selection skipped them as having no
+     * remaining span — the reading behind a {@code NO_VICTIM.all_no_remaining_span}.
+     */
+    public static final String SENSOR_EST_ZERO_COUNTER = "sensor.victim_est_zero";
+    /**
+     * Scanned victims whose consumed span read zero, so {@code estRemaining} returned the raw remaining
+     * span and <b>ignored {@code keysEmitted}</b>: a worker that has emitted a million keys scores
+     * identically to one that has emitted none.
+     */
+    public static final String SENSOR_EST_IGNORES_KEYS_COUNTER = "sensor.victim_est_ignores_keys";
 
     private static final HexFormat HEX = HexFormat.of();
 
@@ -170,6 +200,7 @@ public final class SimExecutor {
     private final Map<Long, WorkerState> livePool = new LinkedHashMap<>();
     private final Set<Long> ownerSplitTaggedChildren = new HashSet<>();
     private final ConfettiFeedbackGate confettiFeedback = new ConfettiFeedbackGate();
+    private final PolicyRunTimeline.Recorder timeline = new PolicyRunTimeline.Recorder();
     private final OwnerSplitPolicy governor;
     private final SeedPlanner seedPlanner;
     private final SimConcurrencyPolicy gauge;
@@ -238,7 +269,8 @@ public final class SimExecutor {
         kernel.scheduleBootstrap(0, 0, "seed.start", this::startSeedPhase);
         SimRunResult result = kernel.run();
         return PolicyRunResult.of(result, scenario, storeLabel, gauge.counters(), gauge.effectiveT(),
-                ledger.nodesCreated(), ledger.splitsAborted(), view.storeReads(), runStuck);
+                ledger.nodesCreated(), ledger.splitsAborted(), view.storeReads(), runStuck,
+                timeline.finish(result.wallNanos()));
     }
 
     // ---- seed phase ---------------------------------------------------------------------
@@ -312,6 +344,7 @@ public final class SimExecutor {
         }
         ledger.addSeed(lo, null);
         ctx.count("seed.ranges", cuts.size() + 1);
+        timeline.seedCompleted(ctx.nowNanos());
         for (Worker worker : workers) {
             ctx.scheduleFor(worker.id, 0, "worker.start", worker::idle);
         }
@@ -393,6 +426,7 @@ public final class SimExecutor {
             // Seeded so the first qualifying page may carve immediately, then rate-limited.
             lastSelfSplitPage = -OwnerSplitGovernor.SELF_SPLIT_MIN_PAGES_BETWEEN;
             livePool.put(nodeId, state);
+            timeline.occupancyChanged(ctx.nowNanos(), livePool.size());
             ctx.count(RANGES_CLAIMED_COUNTER, 1);
             ctx.record("range.claim", "node=" + nodeId);
             requestPage(0);
@@ -463,7 +497,8 @@ public final class SimExecutor {
          * runs against a view of all of it, before any other actor can observe a half-finished commit.
          */
         private void onPage(SimContext arrived) {
-            SimListingView.Page page = view.page(state.cursor(), scenario.pageSize());
+            byte[] cursorFrom = state.cursor();
+            SimListingView.Page page = view.page(cursorFrom, scenario.pageSize());
             arrived.count(KEYS_LISTED_COUNTER, page.keys().size());
             byte[] hi = state.hi();
             List<byte[]> inRange = new ArrayList<>(page.keys().size());
@@ -484,6 +519,8 @@ public final class SimExecutor {
             ledger.commitPage(nodeId, cursorTo, completed);
             arrived.count(PAGES_COUNTER, 1);
             arrived.count(KEYS_EMITTED_COUNTER, inRange.size());
+            timeline.keysCommitted(inRange.size());
+            recordSensorReading(arrived, state.lo(), cursorFrom, cursorTo, hi);
             if (log.isRecording()) {
                 // The page's own emitted interval goes into the trace, not just its size: a total tells a
                 // reader that the right NUMBER of keys came out, which a gap and an overlap of equal size
@@ -518,6 +555,7 @@ public final class SimExecutor {
 
         private void completeClaim(SimContext at) {
             livePool.remove(nodeId);
+            timeline.occupancyChanged(at.nowNanos(), livePool.size());
             classifyOwnerSplitChild(at);
             at.count(RANGES_COMPLETED_COUNTER, 1);
             at.record("range.complete", "node=" + nodeId + "|keys=" + state.keysEmitted());
@@ -528,6 +566,7 @@ public final class SimExecutor {
             // worker so none of them sits out the end of the run on a stale park timer.
             wakeParked(at);
             if (remaining == 0L) {
+                timeline.quiesced(at.nowNanos());
                 at.record("run.quiescent", "");
             }
             idle(at);
@@ -587,6 +626,7 @@ public final class SimExecutor {
             ledger.enqueueChild(childId, pivot, hi);
             state.markStolen();
             lastSelfSplitPage = committed;
+            timeline.splitPublished(at.nowNanos());
             at.count(OWNER_SPLIT_COUNTER, 1);
             at.count("OWNER_SPLIT.self_published", 1);
             at.record("owner_split", "node=" + nodeId + "|child=" + childId);
@@ -645,6 +685,7 @@ public final class SimExecutor {
                             candidate.pacingSkipAvailable()));
                 }
             }
+            recordVictimSensorReadings(ctx, pool);
             Selection selection = thief.selectVictim(pool);
             recordEngagements(ctx, selection.engagements());
             applyVictimMutations(selection.mutations(), null);
@@ -790,6 +831,7 @@ public final class SimExecutor {
             }
             ledger.enqueueChild(childId, pivot, snapshotHi);
             victim.markStolen();
+            timeline.splitPublished(ctx.nowNanos());
             ctx.count(THIEF_SPLIT_COUNTER, 1);
             ctx.count("PIVOT." + commit.mechanism().code(), 1);
             ctx.record("steal.split", "victim=" + victim.nodeId() + "|child=" + childId
@@ -986,6 +1028,51 @@ public final class SimExecutor {
     private void signalStealableProgress(SimContext ctx) {
         pacingState = idlePacing.onReset();
         wakeParked(ctx);
+    }
+
+    /**
+     * Reads the position sensor across one page commit: did the keys that just came out move the range's
+     * cursor <em>in the fraction the policies measure</em>?
+     *
+     * <p>Only bounded ranges are read. An open frontier has no {@code hi} to define a window and always
+     * scores {@code +∞} in selection, so a fraction over it would be measuring nothing.
+     */
+    private static void recordSensorReading(SimContext ctx, byte[] lo, byte[] cursorFrom, byte[] cursorTo,
+                                            byte[] hi) {
+        if (hi == null || cursorTo == null) {
+            return;
+        }
+        ctx.count(SENSOR_BOUNDED_COMMITS_COUNTER, 1);
+        if (StealMath.fracIn(cursorTo, lo, hi) - StealMath.fracIn(cursorFrom, lo, hi) <= 0.0) {
+            ctx.count(SENSOR_INVISIBLE_ADVANCE_COUNTER, 1);
+        }
+    }
+
+    /**
+     * Reads {@code estRemaining} over the pool victim selection is about to rank, recording the two ways
+     * it degenerates: a zero score, which takes a candidate out of the running entirely, and a zero
+     * consumed span, which leaves the score a raw width with the candidate's emitted keys discarded.
+     *
+     * <p>This duplicates the arithmetic the policy is about to do rather than asking it what it saw:
+     * the policy's contract is a {@link Selection}, and widening it to report its own intermediate
+     * readings would put a diagnostic in the engine's decision seam. The inputs are the same view the
+     * policy gets and the function is the same public one it calls.
+     */
+    private static void recordVictimSensorReadings(SimContext ctx, List<VictimView> pool) {
+        for (VictimView candidate : pool) {
+            if (candidate.hi() == null) {
+                continue;
+            }
+            ctx.count(SENSOR_VICTIMS_SCANNED_COUNTER, 1);
+            if (StealMath.estRemaining(candidate.cursor(), candidate.lo(), candidate.hi(),
+                    candidate.keysEmitted()) <= 0.0) {
+                ctx.count(SENSOR_EST_ZERO_COUNTER, 1);
+            }
+            if (StealMath.spanIn(candidate.lo(), candidate.cursor(), candidate.lo(), candidate.hi())
+                    <= 0.0) {
+                ctx.count(SENSOR_EST_IGNORES_KEYS_COUNTER, 1);
+            }
+        }
     }
 
     /** Records every engagement a policy fired, under the same category and reason the engine uses. */

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorAtScaleTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorAtScaleTest.java
@@ -48,28 +48,42 @@ class PositionSensorAtScaleTest {
         assertThat(deep.completed()).as(deep::describe).isTrue();
         assertThat(control.completed()).as(control::describe).isTrue();
 
-        // Deep-nested: 14.7% of the run happens after the last split anything managed to make, on a
-        // mean of 1.5 ranges. Control: 0.8%, and it is still splitting when it finishes.
+        // Deep-nested: 8.4% of the run happens after the last split anything managed to make, on a mean
+        // of 1.6 ranges. Control: 0.8%, and it is still splitting when it finishes.
         assertThat(deep.timeline().tailFraction())
-                .as("the fleet runs out of ways to divide before it runs out of work").isGreaterThan(0.10);
-        assertThat(control.timeline().tailFraction()).isLessThan(0.05);
-        // Mean ranges in flight after the seed: 6.7 against 7.8 of a possible 8.
-        assertThat(deep.timeline().meanOccupancy()).isLessThan(7.0);
+                .as("the fleet runs out of ways to divide before it runs out of work").isGreaterThan(0.05);
+        assertThat(control.timeline().tailFraction()).isLessThan(0.02);
+        // Mean ranges in flight after the seed: 7.0 against 7.8 of a possible 8.
+        assertThat(deep.timeline().meanOccupancy()).isLessThan(7.3);
         assertThat(control.timeline().meanOccupancy()).isGreaterThan(7.5);
-        // Time spent with at most one range being drained: 7.6% against 0.4%.
-        assertThat(deep.timeline().serialFraction()).isGreaterThan(0.05);
+        // Time spent with at most one range being drained: 3.5% against 0.4%.
+        assertThat(deep.timeline().serialFraction()).isGreaterThan(0.02);
         assertThat(control.timeline().serialFraction()).isLessThan(0.01);
 
-        // 663 steal attempts to publish 102 children, 393 of them refused outright before a probe was
-        // even issued. The control publishes 21 children from 84 attempts and is never left without a
-        // victim at all.
+        // The division itself is not missing — it is the opposite. The deep-nested run publishes 205
+        // children to the control's 64, and is still the less parallel of the two: it divides late,
+        // through the thief rather than the owner, and only after spinning. 691 steal attempts for 118
+        // thief children, 393 of them turned away before a probe was even issued; the control publishes
+        // its 21 from 84 attempts and is never once left without a victim.
+        assertThat(deep.ownerSplitChildren() + deep.thiefChildren())
+                .as("what fails here is when and how the keyspace gets cut, not whether")
+                .isGreaterThan(control.ownerSplitChildren() + control.thiefChildren());
         assertThat(deep.counter(SimExecutor.STEAL_ATTEMPTS_COUNTER)).isGreaterThan(500L);
-        assertThat(deep.counter("steal.outcome.NO_VICTIM")
-                + deep.counter("steal.outcome.RETRY"))
+        assertThat(deep.counter("steal.outcome.NO_VICTIM") + deep.counter("steal.outcome.RETRY"))
                 .as("most of what the thief does on this shape produces nothing")
                 .isGreaterThan(4L * deep.thiefChildren());
         assertThat(control.counter(SimExecutor.STEAL_ATTEMPTS_COUNTER)).isLessThan(200L);
         assertThat(control.counter("steal.outcome.NO_VICTIM")).isZero();
+
+        // 570 of 1,509 scored bounded victims (38%) score zero remaining span outright, against 13 of
+        // 399 (3%) — the reading a victim-selection cure has to move.
+        assertThat(estZeroShare(deep)).isGreaterThan(0.25);
+        assertThat(estZeroShare(control)).isLessThan(0.10);
+    }
+
+    private static double estZeroShare(PolicyRunResult result) {
+        return (double) result.counter(SimExecutor.SENSOR_EST_ZERO_COUNTER)
+                / result.counter(SimExecutor.SENSOR_VICTIMS_BOUNDED_COUNTER);
     }
 
     private static PolicyRunResult run(List<byte[]> keys, String label) {

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorAtScaleTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorAtScaleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sim.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.varve.swath.sim.fixture.KeyspaceFixtures;
+import io.varve.swath.sim.fixture.ListingFixtureStore;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The same two shapes an order of magnitude further up, where being unable to measure progress starts
+ * to cost the run its parallelism.
+ *
+ * <p><b>Why a second size exists at all.</b> At the size its sibling test runs, the seed's cut set is
+ * large relative to the fixture: the fleet is handed more ranges than it has workers and finishes them
+ * at roughly the same time, so a runtime that cannot divide anything further is never asked to. Ten
+ * times the pages per range changes that — ranges outlive the seed's balance, the heavy subtrees become
+ * the run, and whether the fleet can carve them decides how it finishes. The shape parameters are the
+ * same; only the size moves, which is what makes the comparison a scale result rather than a different
+ * experiment.
+ *
+ * <p>Opt-in ({@code @Tag("perf")}), for <b>memory</b> rather than time: each run computes in about a
+ * third of a second, but the two fixtures are three quarters of a million keys apiece and are held on
+ * the heap at once, which is a large share of a default test worker's budget and not something the fast
+ * tier should carry on every commit. Like the characterization these pin <b>current</b> behaviour, and
+ * a change to how remaining work is measured should move them.
+ */
+@Tag("perf")
+class PositionSensorAtScaleTest {
+
+    private static final int WORKERS = 8;
+    private static final int PAGE_SIZE = 100;
+
+    @Test
+    void aDeepNestedKeyspaceFinishesOnADwindlingFleetWhileTheControlStaysFlat() {
+        PolicyRunResult deep = run(KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 20_000,
+                KeyspaceFixtures.SubtreeMass.HEAVY_TAILED), "in-memory deep-nested shared prefix");
+        PolicyRunResult control = run(KeyspaceFixtures.hashFannedCorpus(16, 16, 3_000),
+                "in-memory hash-fanned corpus");
+
+        assertThat(deep.completed()).as(deep::describe).isTrue();
+        assertThat(control.completed()).as(control::describe).isTrue();
+
+        // Deep-nested: 14.7% of the run happens after the last split anything managed to make, on a
+        // mean of 1.5 ranges. Control: 0.8%, and it is still splitting when it finishes.
+        assertThat(deep.timeline().tailFraction())
+                .as("the fleet runs out of ways to divide before it runs out of work").isGreaterThan(0.10);
+        assertThat(control.timeline().tailFraction()).isLessThan(0.05);
+        // Mean ranges in flight after the seed: 6.7 against 7.8 of a possible 8.
+        assertThat(deep.timeline().meanOccupancy()).isLessThan(7.0);
+        assertThat(control.timeline().meanOccupancy()).isGreaterThan(7.5);
+        // Time spent with at most one range being drained: 7.6% against 0.4%.
+        assertThat(deep.timeline().serialFraction()).isGreaterThan(0.05);
+        assertThat(control.timeline().serialFraction()).isLessThan(0.01);
+
+        // 663 steal attempts to publish 102 children, 393 of them refused outright before a probe was
+        // even issued. The control publishes 21 children from 84 attempts and is never left without a
+        // victim at all.
+        assertThat(deep.counter(SimExecutor.STEAL_ATTEMPTS_COUNTER)).isGreaterThan(500L);
+        assertThat(deep.counter("steal.outcome.NO_VICTIM")
+                + deep.counter("steal.outcome.RETRY"))
+                .as("most of what the thief does on this shape produces nothing")
+                .isGreaterThan(4L * deep.thiefChildren());
+        assertThat(control.counter(SimExecutor.STEAL_ATTEMPTS_COUNTER)).isLessThan(200L);
+        assertThat(control.counter("steal.outcome.NO_VICTIM")).isZero();
+    }
+
+    private static PolicyRunResult run(List<byte[]> keys, String label) {
+        ListingFixtureStore store = new ListingFixtureStore(keys);
+        long startedAt = System.nanoTime();
+        PolicyRunResult result = SimExecutor.run(
+                PolicyRunFixtures.scenario(WORKERS, PAGE_SIZE, PolicyRunFixtures.REMOTE_LATENCY,
+                        PolicyRunFixtures.measuredCost()),
+                store, label);
+        System.out.printf(Locale.ROOT, "== %s (%d keys, %.2f s wall)%n%s", label, keys.size(),
+                (System.nanoTime() - startedAt) / 1e9, result.describe());
+        return result;
+    }
+}

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
@@ -8,6 +8,7 @@ package io.varve.swath.sim.executor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.varve.swath.sim.fixture.KeyspaceFixtures;
+import io.varve.swath.sim.fixture.KeyspaceFixtures.SubtreeMass;
 import io.varve.swath.sim.fixture.ListingFixtureStore;
 import java.util.List;
 import java.util.Locale;
@@ -25,16 +26,20 @@ import org.junit.jupiter.api.Test;
  * is what it is here for. The control's numbers are pinned for the same reason in reverse: the contrast
  * is a fact about the shapes, and it belongs in the repository rather than in someone's notes.
  *
- * <p>Both runs are one scenario in everything but the keys: 8 workers, the shallow seed, the measured
+ * <p>Three runs, one scenario in everything but the keys: 8 workers, the shallow seed, the measured
  * composite client cost, the engine's own budgets, a store answering a page in 30 ms — the configuration
- * the end-to-end fixture runs use. Numbers below are from the runs themselves; the thresholds carry
- * enough margin that only a change in behaviour moves them.
+ * the end-to-end fixture runs use. The third is the same deep-nested geometry under a <b>uniform</b>
+ * mass, which is what separates the two claims being made: the geometry is what blinds the sensor, and
+ * the mass distribution is what decides whether being blind costs the run anything.
  *
- * <p><b>What is deliberately not asserted here:</b> a serial tail. At this size the fleet does not
- * develop one on either shape — the seed's own cut set is large enough relative to the fixture that the
- * runtime rarely has to divide anything, so the cost of being unable to is not yet visible. The tail,
- * the occupancy collapse and the steal machinery spinning appear an order of magnitude further up, and
- * are pinned there by {@code PositionSensorAtScaleTest}.
+ * <p><b>What is deliberately not asserted here.</b> Not a serial tail: at this size neither shape
+ * develops one, because the seed's own cut set is large relative to the fixture and a runtime that
+ * cannot divide further is rarely asked to. And not an inability to divide — the deep-nested run
+ * publishes fewer children here, but an order of magnitude further up it publishes <em>three times</em>
+ * as many as the control and still finishes less parallel. What is wrong with its division is that it
+ * is late, steal-spun and refused by its own estimate, not that it is absent; the tail, the occupancy
+ * and the steal machinery spinning are pinned at the size where they exist, in
+ * {@code PositionSensorAtScaleTest}.
  */
 class PositionSensorCharacterizationTest {
 
@@ -47,8 +52,12 @@ class PositionSensorCharacterizationTest {
      * whole shape; the size is the smallest that gives the busiest subtrees tens of pages each.
      */
     private static List<byte[]> deepNested() {
-        return KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 2_000,
-                KeyspaceFixtures.SubtreeMass.HEAVY_TAILED);
+        return KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 2_000, SubtreeMass.HEAVY_TAILED);
+    }
+
+    /** The same geometry with every subtree the same size — the control on mass rather than on shape. */
+    private static List<byte[]> deepNestedUniform() {
+        return KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 150, SubtreeMass.UNIFORM);
     }
 
     /** The control: a same-size keyspace whose bytes vary inside the window position is measured over. */
@@ -63,16 +72,17 @@ class PositionSensorCharacterizationTest {
         assertThat(result.completed()).as(result::describe).isTrue();
         assertThat(result.keysEmitted()).isEqualTo(deepNested().size());
 
-        // 690 of 750 bounded page commits (92%) moved the cursor without moving the fraction at all.
+        // 705 of 757 bounded page commits (93%) moved the cursor without moving the fraction at all.
         assertThat(invisibleAdvanceShare(result))
                 .as("keys come out; the position the policies measure does not move")
                 .isGreaterThan(0.85);
-        // 92 of 227 scanned victims (41%) had a consumed span of zero, so their emitted keys — 6,000 of
-        // them in some cases — were discarded and the estimate fell back to raw remaining width.
+        // 62 of 198 scored bounded victims (31%) had a consumed span of zero, so their emitted keys —
+        // and a candidate is only steal-eligible once it has emitted some — were discarded, leaving the
+        // estimate a raw remaining width.
         assertThat(estIgnoresKeysShare(result))
                 .as("the estimate throws away the one exact quantity the run has")
-                .isGreaterThan(0.30);
-        // 524 refusals over 750 bounded commits: the owner-side governor declining to carve because the
+                .isGreaterThan(0.25);
+        // 490 refusals over 757 bounded commits: the owner-side governor declining to carve because the
         // estimate says the tail it would shed is below the mass floor.
         assertThat(estFloorRefusalsPerCommit(result))
                 .as("the carve the shape most needs is the one the estimate refuses")
@@ -80,23 +90,56 @@ class PositionSensorCharacterizationTest {
     }
 
     @Test
-    void theSameSizedHashFannedCorpusKeepsItsEstimateAndDividesFurther() {
+    void theSameSizedHashFannedCorpusKeepsItsEstimateAndItsOwnerSideSplit() {
         PolicyRunResult control = run(hashFanned(), "in-memory hash-fanned corpus");
         PolicyRunResult deep = run(deepNested(), "in-memory deep-nested shared prefix");
 
         assertThat(control.completed()).as(control::describe).isTrue();
         assertThat(control.keysEmitted()).isEqualTo(hashFanned().size());
 
-        // 34 of 231 scanned victims, against the deep-nested run's 92 of 227.
+        // 34 of 209 scored bounded victims, against the deep-nested run's 62 of 198.
         assertThat(estIgnoresKeysShare(control))
                 .as("a shape whose bytes vary in the window keeps its density signal").isLessThan(0.20);
-        assertThat(estIgnoresKeysShare(deep)).isGreaterThan(2.0 * estIgnoresKeysShare(control));
-        // 137 refusals over 745 bounded commits, against 524 over 750.
+        assertThat(estIgnoresKeysShare(deep)).isGreaterThan(1.5 * estIgnoresKeysShare(control));
+        // 137 refusals over 745 bounded commits (0.18 each), against 490 over 757 (0.65).
         assertThat(estFloorRefusalsPerCommit(control)).isLessThan(0.3);
-        // 103 ranges against 57: the same key count, divided nearly twice as far.
-        assertThat(control.nodesCreated())
-                .as("the deep-nested keyspace is the one the runtime cannot cut")
-                .isGreaterThan(deep.nodesCreated());
+        assertThat(estFloorRefusalsPerCommit(deep))
+                .isGreaterThan(3.0 * estFloorRefusalsPerCommit(control));
+        // The mechanism those refusals belong to is the owner's own: 7 children published against 22.
+        // This is a statement about the owner-side split under a blind estimate, NOT about the fleet's
+        // total ability to divide — at ten times the size the deep-nested run out-publishes this
+        // control three to one and is still the less parallel of the two.
+        assertThat(deep.ownerSplitChildren())
+                .as("the owner-side carve is the mechanism the estimate gates")
+                .isLessThan(control.ownerSplitChildren());
+    }
+
+    /**
+     * The separation the other two assume: the same geometry, the same everything, and a uniform file
+     * count instead of a heavy-tailed one. The sensor is just as blind — a cursor still crosses whole
+     * subtrees without moving the fraction — and the run is nonetheless the healthiest of the three,
+     * because equal-sized subtrees make the seed's own division balanced and the fleet is never left
+     * having to divide anything at run time. Blindness is a property of the byte geometry; paying for
+     * it is a property of the mass distribution.
+     */
+    @Test
+    void theSameGeometryWithUniformMassIsJustAsBlindAndCostsNothing() {
+        PolicyRunResult result = run(deepNestedUniform(), "in-memory deep-nested shared prefix, uniform");
+
+        assertThat(result.completed()).as(result::describe).isTrue();
+        assertThat(result.keysEmitted()).isEqualTo(deepNestedUniform().size());
+
+        // 698 of 743 bounded commits (94%) invisible — the heavy-tailed run's 93%, on the same shape.
+        assertThat(invisibleAdvanceShare(result))
+                .as("the geometry alone is what blinds the sensor").isGreaterThan(0.85);
+        // And nothing to pay for it: 7.6 of 8 ranges in flight on average, 1.1% of the run serial, and
+        // not one scored victim whose estimate discarded its keys (0 of 59) — the fleet is never in the
+        // position where a blind estimate has to be acted on.
+        assertThat(result.timeline().meanOccupancy())
+                .as("balanced subtrees keep the fleet full without a single run-time division")
+                .isGreaterThan(7.0);
+        assertThat(result.timeline().serialFraction()).isLessThan(0.05);
+        assertThat(estIgnoresKeysShare(result)).isLessThan(0.05);
     }
 
     private static double invisibleAdvanceShare(PolicyRunResult result) {
@@ -106,7 +149,7 @@ class PositionSensorCharacterizationTest {
 
     private static double estIgnoresKeysShare(PolicyRunResult result) {
         return (double) result.counter(SimExecutor.SENSOR_EST_IGNORES_KEYS_COUNTER)
-                / result.counter(SimExecutor.SENSOR_VICTIMS_SCANNED_COUNTER);
+                / result.counter(SimExecutor.SENSOR_VICTIMS_BOUNDED_COUNTER);
     }
 
     private static double estFloorRefusalsPerCommit(PolicyRunResult result) {

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sim.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.varve.swath.sim.fixture.KeyspaceFixtures;
+import io.varve.swath.sim.fixture.ListingFixtureStore;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What today's policies do on a keyspace their position sensor cannot see, and — beside it, at the same
+ * size and the same settings — what they do on one it can.
+ *
+ * <p><b>These are characterizations of current behaviour, not statements of what the policies ought to
+ * do.</b> They pin the readings a deep-nested shared-prefix keyspace produces: a position fraction that
+ * does not move while keys come out, a remaining-work estimate that discards how many came out, and an
+ * owner-side split governor that refuses most of its carves on the strength of that estimate. A change
+ * to how remaining work is measured is expected to make this test fail — deliberately, and that failure
+ * is what it is here for. The control's numbers are pinned for the same reason in reverse: the contrast
+ * is a fact about the shapes, and it belongs in the repository rather than in someone's notes.
+ *
+ * <p>Both runs are one scenario in everything but the keys: 8 workers, the shallow seed, the measured
+ * composite client cost, the engine's own budgets, a store answering a page in 30 ms — the configuration
+ * the end-to-end fixture runs use. Numbers below are from the runs themselves; the thresholds carry
+ * enough margin that only a change in behaviour moves them.
+ *
+ * <p><b>What is deliberately not asserted here:</b> a serial tail. At this size the fleet does not
+ * develop one on either shape — the seed's own cut set is large enough relative to the fixture that the
+ * runtime rarely has to divide anything, so the cost of being unable to is not yet visible. The tail,
+ * the occupancy collapse and the steal machinery spinning appear an order of magnitude further up, and
+ * are pinned there by {@code PositionSensorAtScaleTest}.
+ */
+class PositionSensorCharacterizationTest {
+
+    private static final int WORKERS = 8;
+    private static final int PAGE_SIZE = 100;
+
+    /**
+     * The taxonomy-shaped keyspace: 64 species subtrees over a heavy-tailed file count, 75,680 keys.
+     * Sibling species diverge at byte 10 and their contents vary only from byte 39 on, which is the
+     * whole shape; the size is the smallest that gives the busiest subtrees tens of pages each.
+     */
+    private static List<byte[]> deepNested() {
+        return KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 2_000,
+                KeyspaceFixtures.SubtreeMass.HEAVY_TAILED);
+    }
+
+    /** The control: a same-size keyspace whose bytes vary inside the window position is measured over. */
+    private static List<byte[]> hashFanned() {
+        return KeyspaceFixtures.hashFannedCorpus(8, 8, 1_200);
+    }
+
+    @Test
+    void aDeepNestedSharedPrefixLeavesTheRemainingWorkEstimateBlind() {
+        PolicyRunResult result = run(deepNested(), "in-memory deep-nested shared prefix");
+
+        assertThat(result.completed()).as(result::describe).isTrue();
+        assertThat(result.keysEmitted()).isEqualTo(deepNested().size());
+
+        // 690 of 750 bounded page commits (92%) moved the cursor without moving the fraction at all.
+        assertThat(invisibleAdvanceShare(result))
+                .as("keys come out; the position the policies measure does not move")
+                .isGreaterThan(0.85);
+        // 92 of 227 scanned victims (41%) had a consumed span of zero, so their emitted keys — 6,000 of
+        // them in some cases — were discarded and the estimate fell back to raw remaining width.
+        assertThat(estIgnoresKeysShare(result))
+                .as("the estimate throws away the one exact quantity the run has")
+                .isGreaterThan(0.30);
+        // 524 refusals over 750 bounded commits: the owner-side governor declining to carve because the
+        // estimate says the tail it would shed is below the mass floor.
+        assertThat(estFloorRefusalsPerCommit(result))
+                .as("the carve the shape most needs is the one the estimate refuses")
+                .isGreaterThan(0.5);
+    }
+
+    @Test
+    void theSameSizedHashFannedCorpusKeepsItsEstimateAndDividesFurther() {
+        PolicyRunResult control = run(hashFanned(), "in-memory hash-fanned corpus");
+        PolicyRunResult deep = run(deepNested(), "in-memory deep-nested shared prefix");
+
+        assertThat(control.completed()).as(control::describe).isTrue();
+        assertThat(control.keysEmitted()).isEqualTo(hashFanned().size());
+
+        // 34 of 231 scanned victims, against the deep-nested run's 92 of 227.
+        assertThat(estIgnoresKeysShare(control))
+                .as("a shape whose bytes vary in the window keeps its density signal").isLessThan(0.20);
+        assertThat(estIgnoresKeysShare(deep)).isGreaterThan(2.0 * estIgnoresKeysShare(control));
+        // 137 refusals over 745 bounded commits, against 524 over 750.
+        assertThat(estFloorRefusalsPerCommit(control)).isLessThan(0.3);
+        // 103 ranges against 57: the same key count, divided nearly twice as far.
+        assertThat(control.nodesCreated())
+                .as("the deep-nested keyspace is the one the runtime cannot cut")
+                .isGreaterThan(deep.nodesCreated());
+    }
+
+    private static double invisibleAdvanceShare(PolicyRunResult result) {
+        return (double) result.counter(SimExecutor.SENSOR_INVISIBLE_ADVANCE_COUNTER)
+                / result.counter(SimExecutor.SENSOR_BOUNDED_COMMITS_COUNTER);
+    }
+
+    private static double estIgnoresKeysShare(PolicyRunResult result) {
+        return (double) result.counter(SimExecutor.SENSOR_EST_IGNORES_KEYS_COUNTER)
+                / result.counter(SimExecutor.SENSOR_VICTIMS_SCANNED_COUNTER);
+    }
+
+    private static double estFloorRefusalsPerCommit(PolicyRunResult result) {
+        return (double) result.counter("OWNER_SPLIT.remaining_est_floor")
+                / result.counter(SimExecutor.SENSOR_BOUNDED_COMMITS_COUNTER);
+    }
+
+    private static PolicyRunResult run(List<byte[]> keys, String label) {
+        ListingFixtureStore store = new ListingFixtureStore(keys);
+        PolicyRunResult result = SimExecutor.run(
+                PolicyRunFixtures.scenario(WORKERS, PAGE_SIZE, PolicyRunFixtures.REMOTE_LATENCY,
+                        PolicyRunFixtures.measuredCost()),
+                store, label);
+        System.out.printf(Locale.ROOT, "== %s (%d keys)%n%s", label, keys.size(), result.describe());
+        return result;
+    }
+}

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/PositionSensorCharacterizationTest.java
@@ -130,8 +130,11 @@ class PositionSensorCharacterizationTest {
         assertThat(result.keysEmitted()).isEqualTo(deepNestedUniform().size());
 
         // 698 of 743 bounded commits (94%) invisible — the heavy-tailed run's 93%, on the same shape.
+        // Only the comparison with that run is being made here: this share does not by itself separate
+        // the deep-nested shape from anything, since the flat control reaches it too once its ranges are
+        // wide enough. What it says is that changing the mass leaves this geometry exactly as blind.
         assertThat(invisibleAdvanceShare(result))
-                .as("the geometry alone is what blinds the sensor").isGreaterThan(0.85);
+                .as("the same geometry is just as blind under a uniform mass").isGreaterThan(0.85);
         // And nothing to pay for it: 7.6 of 8 ranges in flight on average, 1.1% of the run serial, and
         // not one scored victim whose estimate discarded its keys (0 of 59) — the fleet is never in the
         // position where a blind estimate has to be acted on.

--- a/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixtures.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixtures.java
@@ -46,8 +46,11 @@ public final class KeyspaceFixtures {
             "genomic_data/ont_ul",
             "genomic_data/pacbio_hifi"};
 
-    /** Leaf directories per accession — see {@link #LEAF_DIRS}. */
-    static final int LEAF_DIR_COUNT = 4;
+    /**
+     * Leaf directories per accession. Derived from {@link #LEAF_DIRS} rather than written down, so
+     * adding a directory cannot leave the javadoc that quotes this constant claiming the old number.
+     */
+    static final int LEAF_DIR_COUNT = LEAF_DIRS.length;
 
     /**
      * The stride the heavy-tailed mass law deals ranks by. Prime, so it is coprime with every species
@@ -58,6 +61,9 @@ public final class KeyspaceFixtures {
     static final int GENUS_GROUP_LIMIT = 8;
     static final int SPECIES_PER_GROUP_LIMIT = 8;
     static final int ACCESSIONS_PER_SPECIES_LIMIT = 9;
+
+    /** Files per leaf directory, capped by the six-digit field their names are formatted with. */
+    static final int FILES_PER_LEAF_DIR_LIMIT = 999_999;
 
     private KeyspaceFixtures() {
     }
@@ -147,9 +153,11 @@ public final class KeyspaceFixtures {
      * @param speciesPerGroup     species in each group, at most {@value #SPECIES_PER_GROUP_LIMIT}
      * @param accessionsPerSpecies sequenced individuals per species, at most
      *                            {@value #ACCESSIONS_PER_SPECIES_LIMIT}
-     * @param filesPerLeafDir     files in each of the {@value #LEAF_DIR_COUNT} leaf directories of an
-     *                            accession — of every accession under {@link SubtreeMass#UNIFORM}, of
-     *                            the largest species under {@link SubtreeMass#HEAVY_TAILED}
+     * @param filesPerLeafDir     files in each leaf directory of an accession — of every accession
+     *                            under {@link SubtreeMass#UNIFORM}, of the largest species under
+     *                            {@link SubtreeMass#HEAVY_TAILED}, where the rest hold a fraction of
+     *                            it and no species is ever left with none. At most
+     *                            {@value #FILES_PER_LEAF_DIR_LIMIT}, the width of the file-name field
      * @param mass                how the file count is distributed across species
      */
     public static List<byte[]> deepNestedSharedPrefix(int genusGroups, int speciesPerGroup,
@@ -158,6 +166,10 @@ public final class KeyspaceFixtures {
         require(genusGroups, GENUS_GROUP_LIMIT, "genusGroups");
         require(speciesPerGroup, SPECIES_PER_GROUP_LIMIT, "speciesPerGroup");
         require(accessionsPerSpecies, ACCESSIONS_PER_SPECIES_LIMIT, "accessionsPerSpecies");
+        // A zero here is asymmetric between the two laws — it would empty a uniform keyspace outright,
+        // while the heavy-tailed one's floor of one file would quietly keep generating — so neither is
+        // allowed rather than one of them silently meaning something different.
+        require(filesPerLeafDir, FILES_PER_LEAF_DIR_LIMIT, "filesPerLeafDir");
         int speciesCount = genusGroups * speciesPerGroup;
         List<byte[]> keys = new ArrayList<>();
         for (int group = 0; group < genusGroups; group++) {
@@ -188,9 +200,11 @@ public final class KeyspaceFixtures {
         UNIFORM,
         /**
          * Zipf: the species of rank {@code r} holds {@code 1/r} of the largest one's files, which is
-         * the distribution file counts in a real archive follow. The ranks are dealt out by a fixed
-         * stride so the heavy subtrees are scattered through the keyspace rather than bunched at its
-         * start — where a single seed cut would separate them from everything else for free.
+         * the distribution file counts in a real archive follow. Ranks are dealt by a fixed stride from
+         * a fixed offset, so the heavy species land at reproducible but non-adjacent positions rather
+         * than in a block at the keyspace's start, where one seed cut would separate them from
+         * everything else for free. The deal is a permutation — every rank is used exactly once — so
+         * which species is heaviest is a property of the stride and offset, not of its position.
          */
         HEAVY_TAILED
     }
@@ -215,14 +229,19 @@ public final class KeyspaceFixtures {
 
     /**
      * The files one species holds in each of its leaf directories: {@code largest} for every species
-     * under a uniform mass, and {@code largest / rank} under a heavy-tailed one, where the rank is
-     * dealt by a stride coprime with the species count so the heavy subtrees are scattered.
+     * under a uniform mass, and {@code largest / rank} under a heavy-tailed one.
+     *
+     * <p>The rank is dealt by a stride coprime with the species count, so the deal is a permutation and
+     * the heavy subtrees end up scattered. It starts half way along, which is what keeps rank 1 — the
+     * one species that dominates the keyspace — away from position zero: dealt from the start, the
+     * heaviest subtree would always be the keyspace's first, and a fixture whose mass sits at one end
+     * flatters any seed that happens to cut there.
      */
     private static int fileCount(int largest, SubtreeMass mass, int species, int speciesCount) {
         if (mass == SubtreeMass.UNIFORM) {
             return largest;
         }
-        int rank = 1 + (species * RANK_STRIDE) % speciesCount;
+        int rank = 1 + (species * RANK_STRIDE + speciesCount / 2) % speciesCount;
         return Math.max(1, largest / rank);
     }
 

--- a/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixtures.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixtures.java
@@ -25,6 +25,40 @@ import java.util.Locale;
  */
 public final class KeyspaceFixtures {
 
+    /** Two-letter genus groups, ascending. Siblings inside one share bytes 8–9 and differ at byte 10. */
+    private static final String[] GENUS_GROUPS = {"Ba", "Ca", "Da", "Er", "Fa", "Ga", "He", "Ic"};
+
+    /** Genus stems, ascending, nine bytes each, with pairwise distinct first letters. */
+    private static final String[] GENUS_STEMS = {"cephalura", "docerinus", "gastropha", "learicula",
+            "melanurus", "nomoceras", "ryosaurus", "thysaurus"};
+
+    /** Species epithets, nine bytes each. */
+    private static final String[] EPITHETS = {"australis", "japonicus", "maritimus", "orientale",
+            "regulorum", "virginica"};
+
+    /** The accession's leading class letter, as a genomics archive names its individuals. */
+    private static final String[] CLASS_LETTERS = {"a", "b", "f", "m", "r"};
+
+    /** The data tree every accession has, ascending — where a deep-nested keyspace's mass actually is. */
+    private static final String[] LEAF_DIRS = {
+            "assembly_vgp_standard_1.6/evaluation",
+            "assembly_vgp_standard_1.6/intermediates",
+            "genomic_data/ont_ul",
+            "genomic_data/pacbio_hifi"};
+
+    /** Leaf directories per accession — see {@link #LEAF_DIRS}. */
+    static final int LEAF_DIR_COUNT = 4;
+
+    /**
+     * The stride the heavy-tailed mass law deals ranks by. Prime, so it is coprime with every species
+     * count these limits allow and the dealing is therefore a permutation: every rank is used once.
+     */
+    private static final int RANK_STRIDE = 37;
+
+    static final int GENUS_GROUP_LIMIT = 8;
+    static final int SPECIES_PER_GROUP_LIMIT = 8;
+    static final int ACCESSIONS_PER_SPECIES_LIMIT = 9;
+
     private KeyspaceFixtures() {
     }
 
@@ -82,6 +116,86 @@ public final class KeyspaceFixtures {
     }
 
     /**
+     * <b>Deep-nested shared prefix</b> (taxonomy-shaped). Many sibling subtrees under a shallow common
+     * structure — {@code species/<Genus_epithet>/<accession>/<dataset>/<stage>/<file>} — where each
+     * subtree holds hundreds of keys whose bytes differ only <em>far below</em> the depth at which the
+     * subtrees themselves differ. Two adjacent species diverge at byte 10; everything inside either of
+     * them varies from byte 39 on.
+     *
+     * <p>That gap is the shape, and it is the one thing about this fixture that is not free to move.
+     * A range's position fraction ({@code StealMath.fracIn}) is measured over the 12 bytes after the
+     * longest common prefix of the range's own bounds, so on a range spanning sibling subtrees the
+     * measured window is bytes 10–22 — inside the directory name, above every byte a cursor draining
+     * that subtree actually changes. The keys move; the window does not. Every layer that steers on
+     * that fraction (victim choice, pivot mass floors, the owner's self-split, the density feedback) is
+     * therefore reading a sensor this keyspace holds still, which no fixture of uniformly-named or
+     * shallowly-nested keys can reproduce.
+     *
+     * <p>Names are synthetic but structured like a real genomics archive's, because the depths are what
+     * matter: a fixed-width binomial directory, a fixed-width accession, then the per-accession data
+     * tree the mass actually lives in. Sibling genera within a group share their first two letters and
+     * differ at the third, which is what puts the divergence at byte 10.
+     *
+     * <p><b>How much each subtree holds is a second, separable property</b>, which is why it is a
+     * parameter rather than a constant. The geometry above decides what the policies can <em>measure</em>;
+     * the mass distribution decides whether being unable to measure it costs anything. A real archive's
+     * is heavy-tailed — a few reference-quality species carry most of the files and the long tail carries
+     * hundreds each — so {@link SubtreeMass#HEAVY_TAILED} is the realistic setting and
+     * {@link SubtreeMass#UNIFORM} is the control that isolates one property from the other.
+     *
+     * @param genusGroups         two-letter genus groups, at most {@value #GENUS_GROUP_LIMIT}
+     * @param speciesPerGroup     species in each group, at most {@value #SPECIES_PER_GROUP_LIMIT}
+     * @param accessionsPerSpecies sequenced individuals per species, at most
+     *                            {@value #ACCESSIONS_PER_SPECIES_LIMIT}
+     * @param filesPerLeafDir     files in each of the {@value #LEAF_DIR_COUNT} leaf directories of an
+     *                            accession — of every accession under {@link SubtreeMass#UNIFORM}, of
+     *                            the largest species under {@link SubtreeMass#HEAVY_TAILED}
+     * @param mass                how the file count is distributed across species
+     */
+    public static List<byte[]> deepNestedSharedPrefix(int genusGroups, int speciesPerGroup,
+                                                      int accessionsPerSpecies, int filesPerLeafDir,
+                                                      SubtreeMass mass) {
+        require(genusGroups, GENUS_GROUP_LIMIT, "genusGroups");
+        require(speciesPerGroup, SPECIES_PER_GROUP_LIMIT, "speciesPerGroup");
+        require(accessionsPerSpecies, ACCESSIONS_PER_SPECIES_LIMIT, "accessionsPerSpecies");
+        int speciesCount = genusGroups * speciesPerGroup;
+        List<byte[]> keys = new ArrayList<>();
+        for (int group = 0; group < genusGroups; group++) {
+            for (int species = 0; species < speciesPerGroup; species++) {
+                String genus = GENUS_GROUPS[group] + GENUS_STEMS[species];
+                String epithet = EPITHETS[species % EPITHETS.length];
+                int files = fileCount(filesPerLeafDir, mass, group * speciesPerGroup + species,
+                        speciesCount);
+                for (int accession = 0; accession < accessionsPerSpecies; accession++) {
+                    String directory = String.format(Locale.ROOT, "species/%s_%s/%s%s%s%d/",
+                            genus, epithet, CLASS_LETTERS[species % CLASS_LETTERS.length],
+                            syllable(genus), syllable(epithet), accession + 1);
+                    for (String leafDir : LEAF_DIRS) {
+                        for (int file = 0; file < files; file++) {
+                            keys.add(utf8(String.format(Locale.ROOT, "%s%s/%06d.fastq.gz",
+                                    directory, leafDir, file)));
+                        }
+                    }
+                }
+            }
+        }
+        return keys;
+    }
+
+    /** How {@link #deepNestedSharedPrefix} spreads its file count across species. */
+    public enum SubtreeMass {
+        /** Every species holds the same number of files: the control on mass, not on shape. */
+        UNIFORM,
+        /**
+         * Zipf: the species of rank {@code r} holds {@code 1/r} of the largest one's files, which is
+         * the distribution file counts in a real archive follow. The ranks are dealt out by a fixed
+         * stride so the heavy subtrees are scattered through the keyspace rather than bunched at its
+         * start — where a single seed cut would separate them from everything else for free.
+         */
+        HEAVY_TAILED
+    }
+
+    /**
      * <b>A single dense flat leaf.</b> No directories at all below the prefix, so structure discovery
      * has nothing to find and every split has to be placed by interpolation. This is the shape where a
      * pivot landing in a dead zone — a region of the code-point space no key occupies — costs a whole
@@ -97,5 +211,29 @@ public final class KeyspaceFixtures {
 
     private static byte[] utf8(String key) {
         return key.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * The files one species holds in each of its leaf directories: {@code largest} for every species
+     * under a uniform mass, and {@code largest / rank} under a heavy-tailed one, where the rank is
+     * dealt by a stride coprime with the species count so the heavy subtrees are scattered.
+     */
+    private static int fileCount(int largest, SubtreeMass mass, int species, int speciesCount) {
+        if (mass == SubtreeMass.UNIFORM) {
+            return largest;
+        }
+        int rank = 1 + (species * RANK_STRIDE) % speciesCount;
+        return Math.max(1, largest / rank);
+    }
+
+    /** The three-letter, initial-capital syllable an accession name is built from. */
+    private static String syllable(String name) {
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1, 3);
+    }
+
+    private static void require(int value, int limit, String name) {
+        if (value < 1 || value > limit) {
+            throw new IllegalArgumentException(name + " must be in 1.." + limit + ", got " + value);
+        }
     }
 }

--- a/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixturesTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixturesTest.java
@@ -6,6 +6,7 @@
 package io.varve.swath.sim.fixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import io.varve.swath.engine.StealMath;
 import io.varve.swath.sim.fixture.KeyspaceFixtures.SubtreeMass;
@@ -41,9 +42,19 @@ class KeyspaceFixturesTest {
                         KeyspaceFixtures.deepNestedSharedPrefix(4, 4, 2, 40, SubtreeMass.HEAVY_TAILED));
     }
 
+    /**
+     * The class's own claim, checked against every generator it has: keys come out in ascending
+     * unsigned byte order, which is what lets a fixture store take them without a sort. One generator
+     * quietly violating it would be found by a store's precondition, but only in whichever test
+     * happened to use that shape.
+     */
     @Test
     void everyGeneratedKeyAscendsInUnsignedByteOrder() {
         for (List<byte[]> keys : List.of(
+                KeyspaceFixtures.observationArchive(3, 4, 5, 6),
+                KeyspaceFixtures.hashFannedCorpus(4, 4, 30),
+                KeyspaceFixtures.oneObjectPerDirectory(500),
+                KeyspaceFixtures.denseFlatLeaf(500),
                 KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 3, SubtreeMass.UNIFORM),
                 KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 9, 64, SubtreeMass.HEAVY_TAILED))) {
             for (int i = 1; i < keys.size(); i++) {
@@ -51,6 +62,17 @@ class KeyspaceFixturesTest {
                         .as("entry %d must be strictly greater than its predecessor", i).isNegative();
             }
         }
+    }
+
+    @Test
+    void aFileCountTheNameFieldCannotHoldIsRefused() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KeyspaceFixtures.deepNestedSharedPrefix(1, 1, 1, 1_000_000,
+                        SubtreeMass.UNIFORM))
+                .withMessageContaining("filesPerLeafDir");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KeyspaceFixtures.deepNestedSharedPrefix(1, 1, 1, 0,
+                        SubtreeMass.HEAVY_TAILED));
     }
 
     /**
@@ -109,9 +131,18 @@ class KeyspaceFixturesTest {
             expected += 4 * (64 / rank);
         }
         assertThat(heavy).hasSize(expected);
-        assertThat(largestSubtree(heavy))
-                .as("the largest species holds a fifth of a heavy-tailed keyspace")
-                .isGreaterThan(heavy.size() / 5);
+        // Rank 1 of eight: 64 files per leaf directory where rank 8 has 8, which over the harmonic
+        // series is a little over a third of the whole keyspace.
+        assertThat(largestSubtree(heavy)).isBetween(heavy.size() / 3, heavy.size() / 2);
+        assertThat(firstSubtree(heavy))
+                .as("the deal starts half way along, so the heaviest species is not the first")
+                .isLessThan(largestSubtree(heavy));
+    }
+
+    /** Keys under the first {@code species/<name>/} directory. */
+    private static int firstSubtree(List<byte[]> keys) {
+        byte[] first = Arrays.copyOf(keys.getFirst(), 30);
+        return (int) keys.stream().filter(k -> Arrays.equals(Arrays.copyOf(k, 30), first)).count();
     }
 
     /** Keys under the busiest {@code species/<name>/} directory. */

--- a/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixturesTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/fixture/KeyspaceFixturesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sim.fixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.varve.swath.engine.StealMath;
+import io.varve.swath.sim.fixture.KeyspaceFixtures.SubtreeMass;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The generated shapes' own contract: a generator produces the same keys every time, and the
+ * deep-nested one produces the byte geometry it claims.
+ *
+ * <p>The geometry is asserted rather than described because it is the entire reason that fixture
+ * exists. A keyspace that merely <em>looks</em> deep — long names, many slashes — proves nothing about
+ * a policy if its bytes still vary inside the window position is measured over. What has to hold is the
+ * gap: sibling subtrees differing high up, their contents differing far below, and the measured
+ * fraction consequently standing still while a cursor crosses a whole subtree.
+ */
+class KeyspaceFixturesTest {
+
+    private static final byte[] NO_KEY = new byte[0];
+
+    @Test
+    void aGeneratorProducesTheSameKeysEveryTime() {
+        List<byte[]> first = KeyspaceFixtures.deepNestedSharedPrefix(4, 4, 2, 40, SubtreeMass.UNIFORM);
+        List<byte[]> second = KeyspaceFixtures.deepNestedSharedPrefix(4, 4, 2, 40, SubtreeMass.UNIFORM);
+
+        assertThat(second).usingElementComparator(Arrays::compareUnsigned)
+                .containsExactlyElementsOf(first);
+        assertThat(KeyspaceFixtures.deepNestedSharedPrefix(4, 4, 2, 40, SubtreeMass.HEAVY_TAILED))
+                .usingElementComparator(Arrays::compareUnsigned)
+                .containsExactlyElementsOf(
+                        KeyspaceFixtures.deepNestedSharedPrefix(4, 4, 2, 40, SubtreeMass.HEAVY_TAILED));
+    }
+
+    @Test
+    void everyGeneratedKeyAscendsInUnsignedByteOrder() {
+        for (List<byte[]> keys : List.of(
+                KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 2, 3, SubtreeMass.UNIFORM),
+                KeyspaceFixtures.deepNestedSharedPrefix(8, 8, 9, 64, SubtreeMass.HEAVY_TAILED))) {
+            for (int i = 1; i < keys.size(); i++) {
+                assertThat(Arrays.compareUnsigned(keys.get(i - 1), keys.get(i)))
+                        .as("entry %d must be strictly greater than its predecessor", i).isNegative();
+            }
+        }
+    }
+
+    /**
+     * The worked example the shape is built around: two adjacent species subtrees whose directories
+     * diverge ten bytes in, holding files that differ only from byte 39 on. The twenty-nine bytes
+     * between those two numbers are the whole defect — {@code fracIn} measures twelve bytes from the
+     * first, and every byte a draining cursor changes is past the second.
+     */
+    @Test
+    void adjacentSubtreesDivergeFarAboveTheDepthTheirContentsVaryAt() {
+        List<byte[]> keys = KeyspaceFixtures.deepNestedSharedPrefix(1, 2, 1, 4, SubtreeMass.UNIFORM);
+        byte[] firstOfSubtreeA = keys.getFirst();
+        byte[] firstOfSubtreeB = keys.get(keys.size() / 2);
+
+        assertThat(new String(firstOfSubtreeA, StandardCharsets.UTF_8))
+                .isEqualTo("species/Bacephalura_australis/aBacAus1/"
+                        + "assembly_vgp_standard_1.6/evaluation/000000.fastq.gz");
+        assertThat(commonPrefixLength(firstOfSubtreeA, firstOfSubtreeB))
+                .as("sibling species diverge inside the directory name").isEqualTo(10);
+        assertThat(commonPrefixLength(firstOfSubtreeA, keys.get(keys.size() / 2 - 1)))
+                .as("two keys in one subtree share everything down to the leaf directory")
+                .isGreaterThanOrEqualTo(39);
+    }
+
+    /**
+     * The consequence, stated in the arithmetic the policies actually run: over a range spanning two
+     * sibling subtrees, draining the first one from end to end moves neither the position fraction nor
+     * the consumed span — so {@code estRemaining} discards the emitted keys entirely and returns the
+     * same number for a worker that has finished a subtree as for one that has not started.
+     */
+    @Test
+    void drainingAWholeSubtreeMovesNeitherTheFractionNorTheConsumedSpan() {
+        List<byte[]> keys = KeyspaceFixtures.deepNestedSharedPrefix(1, 2, 1, 100, SubtreeMass.UNIFORM);
+        byte[] lo = keys.getFirst();
+        byte[] hi = keys.getLast();
+        byte[] lastKeyOfFirstSubtree = keys.get(keys.size() / 2 - 1);
+
+        assertThat(StealMath.fracIn(lastKeyOfFirstSubtree, lo, hi))
+                .isEqualTo(StealMath.fracIn(lo, lo, hi));
+        assertThat(StealMath.spanIn(lo, lastKeyOfFirstSubtree, lo, hi)).isZero();
+        assertThat(StealMath.estRemaining(lastKeyOfFirstSubtree, lo, hi, keys.size() / 2))
+                .as("half the range emitted, and the estimate is the one it started with")
+                .isEqualTo(StealMath.estRemaining(lo, lo, hi, 0L));
+    }
+
+    @Test
+    void theHeavyTailedMassLawSpreadsFilesAsOneOverRank() {
+        List<byte[]> uniform = KeyspaceFixtures.deepNestedSharedPrefix(2, 4, 1, 64, SubtreeMass.UNIFORM);
+        List<byte[]> heavy = KeyspaceFixtures.deepNestedSharedPrefix(2, 4, 1, 64,
+                SubtreeMass.HEAVY_TAILED);
+
+        assertThat(uniform).hasSize(2 * 4 * 4 * 64);
+        // Ranks 1..8 dealt over eight species: sum of 64/r, over the four leaf directories each has.
+        int expected = 0;
+        for (int rank = 1; rank <= 8; rank++) {
+            expected += 4 * (64 / rank);
+        }
+        assertThat(heavy).hasSize(expected);
+        assertThat(largestSubtree(heavy))
+                .as("the largest species holds a fifth of a heavy-tailed keyspace")
+                .isGreaterThan(heavy.size() / 5);
+    }
+
+    /** Keys under the busiest {@code species/<name>/} directory. */
+    private static int largestSubtree(List<byte[]> keys) {
+        int largest = 0;
+        int current = 0;
+        byte[] currentPrefix = NO_KEY;
+        for (byte[] key : keys) {
+            byte[] prefix = Arrays.copyOf(key, 30);   // "species/" + the 21-byte binomial + "/"
+            if (!Arrays.equals(prefix, currentPrefix)) {
+                largest = Math.max(largest, current);
+                current = 0;
+                currentPrefix = prefix;
+            }
+            current++;
+        }
+        return Math.max(largest, current);
+    }
+
+    private static int commonPrefixLength(byte[] a, byte[] b) {
+        int i = 0;
+        while (i < Math.min(a.length, b.length) && a[i] == b[i]) {
+            i++;
+        }
+        return i;
+    }
+}


### PR DESCRIPTION
The generated keyspace shapes so far all vary their bytes near where a range's bounds diverge — which
is exactly where `StealMath.fracIn` looks. This adds one that does not, plus the two things a run
record needed in order to say so in numbers.

## The shape

`species/<Genus_epithet>/<accession>/<dataset>/<stage>/<file>`, taxonomy-shaped and fixed-width:
sibling species directories diverge at byte 10, everything inside either of them varies only from
byte 39 on. Position is measured over the twelve bytes *after* the longest common prefix of a range's
own bounds, so a range spanning sibling subtrees measures bytes 10–22 — and a cursor draining one of
those subtrees changes nothing inside that window. Drain a whole subtree and the fraction is where it
started, the consumed span reads zero, and `estRemaining` returns a raw remaining width with the
range's emitted keys discarded entirely.

How much each subtree holds is a separate parameter, because the geometry decides what can be
*measured* and the mass distribution decides whether being unable to measure it costs anything.
`UNIFORM` isolates the first; the heavy-tailed law a real archive follows makes the second visible.

## What the executor now reports

- **Position-sensor readings** — bounded page commits whose cursor advance did not move `fracIn`, and
  scanned victims whose consumed span was zero. Computed from the same public `StealMath` the
  decisions call, so **nothing in swath-core changes**. The reading is duplicated beside the policy
  rather than obtained from it on purpose: widening a decision's contract to report its own
  intermediate values would put a diagnostic in the engine's seam.
- **A phase timeline** — seed end, last split, run end, and for the interval after the last split the
  keys emitted and the ranges actually being drained. Split counts cannot tell a fleet that divided
  its keyspace from one that gave up early. Accumulated in constant space (running totals snapshotted
  at each split), so it stays on during a sweep where the trace is off.

The timeline's end is **quiescence**, not the kernel's last event. A retired park timer still costs a
dispatch when it fires, so the clock keeps moving for up to one park window after the last worker has
gone home — about a second on these runs. Both instants are reported and the gap is named as an
artifact of the kernel rather than a property of the modelled fleet.

## What is pinned, and what is honestly not

Both new run tests are characterizations of **current** behaviour: a change to how remaining work is
measured is expected to break them, and that is what they are for.

At 76,800 keys (`PositionSensorCharacterizationTest`, ordinary suite) the readings are already stark —
92% of bounded page commits invisible, 41% of victim scans with the emitted keys discarded against the
hash-fanned control's 15%, 524 owner-side carves refused on the strength of the estimate against 137,
and 57 ranges created against 103 for the same key count. **The fleet does not yet pay for any of it**,
because at that size the seed's cut set is large relative to the fixture and a runtime that cannot
divide further is never asked to. The test says so rather than implying otherwise.

Ten times further up (`PositionSensorAtScaleTest`, `@Tag("perf")` for its memory rather than its time)
it does pay: 14.7% of the run after the last split at a mean of 1.5 ranges in flight and 7.6% of the
time with at most one, against 0.8% / 0.4% for a control that is still splitting when it finishes —
and 663 steal attempts to publish 102 children, against 84 attempts for 21.

## Tests

`./gradlew :swath-sim:test` green; `./gradlew :swath-sim:test -PonlyPerf --tests '*PositionSensorAtScaleTest'`
green. New: `KeyspaceFixturesTest` (generator determinism, ascending order, and the byte geometry
asserted in the arithmetic the policies actually run), `PositionSensorCharacterizationTest`,
`PositionSensorAtScaleTest`.
