### PR TITLE
Run the release build on the same test tier CI gates every merge with

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,25 @@ jobs:
       # gradle/actions/setup-gradle@v4
       - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
 
+      # -PnoIntegration matches ci.yml's fast-tests EXACTLY, and that is the point: this
+      # must be an invocation CI runs on every PR and every merge, so a release cannot
+      # fail in a way no merge would have caught.
+      #
+      # A bare `./gradlew build` is NOT that. It runs the fast and integration tiers
+      # together, so swath-core's timing-sensitive tests execute across parallel forks
+      # while other modules' Testcontainers/LocalStack ITs start containers alongside them
+      # — the exact cross-fork contention the tier split in swath.java-conventions exists
+      # to prevent (see its maxParallelForks comment). On a 4-core runner that made the
+      # release build flaky by construction: the first two v0.1.0 attempts failed on two
+      # DIFFERENT timing assertions that both pass on main. See issue #62.
+      #
+      # Integration coverage for the released commit comes from ci.yml's integration-tests
+      # job on main, and deep coverage from deep-tests — neither of which the release build
+      # ran even before this change.
       - name: Verify tag and build the release once
         run: |
-          ./gradlew verifyReleaseVersion build :swath-cli:shadowJar :swath-cli:distZip :swath-cli:distTar \
+          ./gradlew verifyReleaseVersion build -PnoIntegration \
+            :swath-cli:shadowJar :swath-cli:distZip :swath-cli:distTar \
             -PreleaseTag="${GITHUB_REF_NAME}" --no-daemon --stacktrace
 
       - id: version


### PR DESCRIPTION
Unblocks `v0.1.0`, which failed twice. Fixes half of #62 — the structural half.

### What happened

Two attempts at the same commit, two **different** failures:

| attempt | failing test |
|---|---|
| 1 | `RunMetricsContractTest#customProgressIntervalEmitsInFlightField` |
| 2 | `ParquetWriterPoolMetricsTest#finalizeFailureRecordsFinalizeFailed` |

The identical commit passed fast, integration **and** deep tiers on `main`
(run `30297470334`). Two different tests failing means this was never one flaky
test.

### Why

The release build ran a bare `./gradlew build` — a tier combination **no CI job
runs**:

| job | invocation |
|---|---|
| `fast-tests` | `build -PnoIntegration` |
| `integration-tests` | `test -PonlyIntegration` |
| `deep-tests` | `test -Pdeep -PtestMaxParallelForks=1` |
| release (before) | `build` |

A bare `build` runs the fast and integration tiers together, so `swath-core`'s
timing-sensitive tests execute across parallel forks while other modules start
Testcontainers/LocalStack containers alongside them — on a 4-core runner.

That is exactly what the tier split exists to prevent. From
`swath.java-conventions.gradle.kts`:

> *Other modules stay serial: … their socket/Testcontainers ITs would only risk
> port/container contention under concurrent forks.*
> *The `deep` and `perf` tiers stay SERIAL (forks=1): … cross-fork CPU contention
> makes them flaky.*

So the release build was flaky **by construction**, and "`main` is green" never
implied "the release will build".

### The change

`-PnoIntegration`, making it byte-identical to what `fast-tests` runs on every PR
and every merge. A release can no longer fail in a way no merge would have caught.

Integration coverage for the released commit comes from `integration-tests` on
`main`; deep from `deep-tests`. The release build never ran the deep tier even
before this change, so nothing is lost — the coverage always came from the commit
having been on `main`.

### Still open in #62

The two tests are genuinely timing-fragile and should be made deterministic —
this change removes the contention that exposed them, not the fragility itself.
Note `ParquetWriterPoolMetricsTest` was already deflaked once in #39.

Also still unenforced: nothing checks that a release tag is an ancestor of `main`,
which is what the integration/deep coverage argument above depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release verification build to exclude integration tests.
  * Added workflow documentation clarifying the release build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->