### PR TITLE
just release: emit the post-release -SNAPSHOT bump commit too

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,13 +53,20 @@ actually work.
 
 1. Make sure `main` is green and you are on a clean checkout of the commit you want to
    release.
-2. Prepare the release commit and tag:
+2. Prepare the release commits and tag:
    ```
    just release 0.2.0
    ```
-   This sets the canonical version, commits `Release v0.2.0`, and creates the annotated
-   tag `v0.2.0`. It does **not** push — review first.
-3. Push to trigger the release pipeline:
+   This produces **two** commits and tags the first:
+
+   1. `Release v0.2.0` — the canonical version, **tagged**; this is what the workflow builds
+   2. `Begin 0.2.1 development` — restores a `-SNAPSHOT` version on `main`
+
+   so `main` can never be left sitting on a released version. Override the next cycle with a
+   second argument (`just release 0.2.0 0.3.0`); after an `-rc.N` the default returns to the
+   same `X.Y.Z-SNAPSHOT`, since development continues toward that release. It does **not**
+   push — review both commits first.
+3. Push to trigger the release pipeline — this sends both commits and the tag together:
    ```
    git push origin main v0.2.0
    ```
@@ -69,12 +76,6 @@ actually work.
    everything, creates the GitHub release as a **draft**, runs the verification commands
    below against what it just published, and only then un-drafts it. If verification
    fails the release stays a draft — fix and re-tag rather than publishing by hand.
-5. Bump the canonical version to the next development cycle and commit:
-   ```
-   # edit gradle.properties: version=0.3.0-SNAPSHOT   (or 0.2.1-SNAPSHOT)
-   git commit -am "Begin 0.3.0 development"
-   git push
-   ```
 
 ## What the pipeline produces
 
@@ -91,8 +92,9 @@ For each `vX.Y.Z` tag, once the environment is approved:
 
 - Release notes are generated from merged PRs (`--generate-notes`); write PR titles with
   that in mind.
-- The version bump is manual by design (the canonical version lives in `gradle.properties`).
-  `just release` wraps the mechanical steps so the tag and version cannot drift.
+- Choosing the version is manual by design (the canonical version lives in
+  `gradle.properties`); `just release` wraps the mechanical steps so the tag and version
+  cannot drift, and reopens the next `-SNAPSHOT` cycle in the same invocation.
 
 ## Verifying a release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,7 +54,7 @@ actually work.
 1. Make sure `main` is green and you are on a clean checkout of the commit you want to
    release.
 2. Prepare the release commits and tag:
-   ```
+   ```sh
    just release 0.2.0
    ```
    This produces **two** commits and tags the first:

--- a/justfile
+++ b/justfile
@@ -84,15 +84,27 @@ jmh:
 ci-drift:
     ./scripts/ci/check-instrumentation-drift.sh
 
-# Prepare a release: set the canonical version, commit, and create the vX.Y.Z tag.
+# Prepare a release: set the canonical version, commit, tag, and open the next dev cycle.
 # Accepts X.Y.Z or a X.Y.Z-rc.N release candidate; no other pre-release identifiers and
 # no build metadata, matching what the release build enforces.
-# Does NOT push — review, then `git push origin main vX.Y.Z` to trigger release.yml.
-# After a stable release publishes, bump gradle.properties to the next -SNAPSHOT.
-# An -rc.N tag publishes only its own container tag and a GitHub pre-release, and is NOT
-# promoted — the final tag is a fresh build. See RELEASING.md.
-# Usage: just release 0.2.0   |   just release 0.2.0-rc.1
-release VERSION:
+#
+# Produces TWO commits and tags the first:
+#   1. "Release vX.Y.Z"        <- tagged; this is what the release workflow builds
+#   2. "Begin <next> development"  <- restores a -SNAPSHOT version on main
+# so `main` can never be left sitting on a released version. That happened after v0.1.0:
+# every dev build, including the container image published on each merge, then reports the
+# released version string. Nothing breaks (this recipe overwrites the version at the next
+# release regardless) but X.Y.Z should mean exactly one thing.
+#
+# NEXT defaults sensibly and can be overridden:
+#   just release 0.1.1            -> next dev cycle 0.1.2-SNAPSHOT   (patch + 1)
+#   just release 0.2.0-rc.1       -> next dev cycle 0.2.0-SNAPSHOT   (still working TOWARD 0.2.0)
+#   just release 0.1.1 0.2.0      -> next dev cycle 0.2.0-SNAPSHOT   (explicit)
+#
+# Does NOT push — review, then `git push origin main vX.Y.Z`, which sends both commits and
+# the tag together. An -rc.N tag publishes only its own container tag and a GitHub
+# pre-release, and is NOT promoted: the final tag is a fresh build. See RELEASING.md.
+release VERSION NEXT="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ ! "{{VERSION}}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]]; then
@@ -101,15 +113,35 @@ release VERSION:
     if [[ -n "$(git status --porcelain)" ]]; then
         echo "error: working tree is not clean; commit or stash first" >&2; exit 2
     fi
+    base="{{VERSION}}"; base="${base%%-rc.*}"
+    next="{{NEXT}}"
+    if [[ -z "$next" ]]; then
+        if [[ "{{VERSION}}" == *-rc.* ]]; then
+            # An RC is a rehearsal for X.Y.Z, so development continues toward the SAME
+            # version -- not the next patch.
+            next="$base"
+        else
+            IFS='.' read -r ma mi pa <<< "$base"
+            next="${ma}.${mi}.$((pa + 1))"
+        fi
+    fi
+    if [[ ! "$next" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+        echo "error: NEXT must be a stable X.Y.Z (the -SNAPSHOT suffix is added for you); got '$next'" >&2; exit 2
+    fi
     sed -i -E 's/^version=.*/version={{VERSION}}/' gradle.properties
     git add gradle.properties
     git commit -m "Release v{{VERSION}}"
     git tag -a "v{{VERSION}}" -m "swath v{{VERSION}}"
-    echo "Prepared v{{VERSION}}. Review, then: git push origin main v{{VERSION}}"
+    sed -i -E "s/^version=.*/version=${next}-SNAPSHOT/" gradle.properties
+    git add gradle.properties
+    git commit -m "Begin ${next} development"
+    echo
+    echo "Prepared v{{VERSION}}, and reopened development at ${next}-SNAPSHOT."
+    echo "The tag points at the release commit; main ends on the snapshot."
+    echo "Review both commits, then: git push origin main v{{VERSION}}"
     if [[ "{{VERSION}}" == *-rc.* ]]; then
+        echo
         echo "This is a PRE-RELEASE: it publishes the X.Y.Z-rc.N container tag only —"
         echo "no :latest, no :X.Y — and creates a GitHub pre-release. It is a rehearsal of"
         echo "the publish path; the final tag is a separate, fresh build."
-    else
-        echo "After it publishes, set gradle.properties to the next X.Y.Z-SNAPSHOT and commit."
     fi

--- a/justfile
+++ b/justfile
@@ -110,8 +110,18 @@ release VERSION NEXT="":
     if [[ ! "{{VERSION}}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]]; then
         echo "error: VERSION must be X.Y.Z or X.Y.Z-rc.N (no other pre-release forms, no build metadata)" >&2; exit 2
     fi
+    current_branch="$(git branch --show-current)"
+    if [[ "$current_branch" != "main" ]]; then
+        echo "error: must be run from main (currently on '${current_branch:-detached HEAD}') -- the documented push is 'git push origin main vX.Y.Z', so preparing the release anywhere else can tag the release while leaving remote main without the snapshot commit" >&2; exit 2
+    fi
     if [[ -n "$(git status --porcelain)" ]]; then
         echo "error: working tree is not clean; commit or stash first" >&2; exit 2
+    fi
+    if git rev-parse -q --verify "refs/tags/v{{VERSION}}" >/dev/null; then
+        echo "error: tag v{{VERSION}} already exists locally" >&2; exit 2
+    fi
+    if git ls-remote --exit-code --tags origin "refs/tags/v{{VERSION}}" >/dev/null 2>&1; then
+        echo "error: tag v{{VERSION}} already exists on origin" >&2; exit 2
     fi
     base="{{VERSION}}"; base="${base%%-rc.*}"
     next="{{NEXT}}"


### PR DESCRIPTION
Closes #64.

After v0.1.0, `main` sat on `version=0.1.0` until someone remembered step 5 of
`RELEASING.md`. Nothing surfaced it, and strictly nothing *breaks* — `just
release` overwrites the version at the next release regardless. But while `main`
carries a release version, every dev build reports it, including the container
image published on each merge. Demonstrated at the time:

```
ghcr.io/varveio/swath:main   →  swath 0.1.0 (298de90e644b)
ghcr.io/varveio/swath:0.1.0  →  swath 0.1.0 (298de90e644b)
```

Same version string, different digests. After the next merge `:main` carries code
the release doesn't, still claiming `0.1.0`.

### The change

`just release` now produces **two** commits and tags the first:

1. `Release vX.Y.Z` — tagged; what the release workflow builds
2. `Begin <next> development` — restores `-SNAPSHOT` on `main`

A single `git push origin main vX.Y.Z` sends both commits and the tag. The
omission becomes structurally impossible rather than remembered.

`NEXT` defaults to patch+1 and takes an optional second argument. **After an
`-rc.N` it defaults back to the same `X.Y.Z-SNAPSHOT`** — an RC is a rehearsal
for that release, so development continues toward it, not past it.

### Rejected alternative

A CI guard failing any `main` push whose version lacks `-SNAPSHOT`. The `Release
vX.Y.Z` commit legitimately lands on `main` with a non-snapshot version, so the
guard would have to special-case exactly the commit it exists to police.

### Verification

Exercised against scratch tags, then reset:

| case | next version | tag placement |
|---|---|---|
| `just release 0.9.0` | `0.9.1-SNAPSHOT` | on the release commit |
| `just release 0.9.0-rc.1` | `0.9.0-SNAPSHOT` | on the release commit |
| `just release 0.9.0 1.0.0` | `1.0.0-SNAPSHOT` | on the release commit |

And the property the whole release depends on: **checked out at the tag,
`gradle.properties` reads `0.9.0` and `verifyReleaseVersion -PreleaseTag=v0.9.0`
PASSES** — the bump commit does not disturb what CI builds.

Negative paths all exit 2: malformed `VERSION`, malformed `NEXT`, a `NEXT` that
already carries `-SNAPSHOT`, and a dirty working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release instructions to describe a streamlined two-commit tagging flow and how to use an optional second version argument.
  * Clarified that version selection remains intentional/manual, and that the process prevents tag/version drift while reopening the next development cycle.

* **Chores**
  * Enhanced the release command to accept an optional next stable version, validate inputs, and automatically handle release-candidate vs non-RC version progression.
  * Improved safety checks (main branch + clean working state) and revised console messaging to match the tag vs snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->