### PR TITLE
replay-server: serve open-upper-bound delimiter rollups through the native skip-scan

### DIFF
--- a/docs/swath-replay-server.md
+++ b/docs/swath-replay-server.md
@@ -382,11 +382,19 @@ fixed ~31 ms store-query cost per hop that multiplied into seconds on a wide
 directory) and an interim one-query `DISTINCT` rollup (fast constant, but
 O(subtree) and blind to `max-keys`).
 
-The skip-scan is gated to the single-byte `/` delimiter and a finite upper
-bound; everything else declines to the pager's range walk. It must return
-byte-identical results to that walk — the sorted-vs-DuckDB differential suite
-enforces this, and the DuckDB oracle deliberately does not take the skip-scan
-so the range walk stays the reference.
+The skip-scan is gated to the single-byte `/` delimiter only; an open upper
+bound (a no-prefix root rollup, or a prefix whose `0xFF`-carry has no finite
+bound) is scanned to the end of the fixture, same as a plain range read.
+Root rollups are exactly the wide structure probes an engine's seed phase
+issues, and before the open-bound case was admitted (issue #77) they fell to
+the range walk's seek-per-prefix cost — 70 s on a fixture with ~1,000 dense
+date prefixes, against a ~3 s engine probe budget. Every other delimiter shape
+declines to the pager's range walk. The skip-scan must return byte-identical
+results to that walk — the sorted-vs-DuckDB differential suite enforces this,
+and the DuckDB oracle deliberately does not take the skip-scan so the range
+walk stays the reference. Which path actually served a delimited request is
+visible in `swath.replay.delimiter.path` and a debug log line, so a stalled
+probe is attributable to the server without a bisecting session.
 
 On startup in the **DuckDB** path (unsorted fixtures, or `--serving-mode duckdb`),
 the server materializes the swath Parquet fixture into a temporary DuckDB database.
@@ -554,6 +562,8 @@ documents the replay-server-specific set.
 | `swath.replay.index.entries` | distribution | Row-group index entries produced by one derive pass. |
 | `swath.replay.serving.fallback{reason}` | counter | Auto serving-mode declined sorted serving. Reasons: `no_stamp` (a resolved file carries no recognized sortedness stamp), `unsupported_mode` (a resolved file is stamped a `versions` file — unsupported for serving in v1), `unknown_format_version` (a resolved file's stamp carries a `format_version` this reader doesn't recognize), `incomplete_multifile` (the resolved file set's `file_index`/`file_final` stamps don't prove completeness — e.g. a crash left only a prefix of a multi-file publish on disk), `mixed_row_types` (a row group's `row_type` footer stats do not prove every row is `OBJECT` — e.g. a legacy delimiter'd capture re-sorted by `sort-fixture`, which stamps `mode=objects` unconditionally without checking `row_type`), `sanity_failed` (the derived row-group first-key array was not strictly ascending — a corrupt/mis-stamped/mis-ordered fixture). Every resolved file is checked for the first four reasons, not just the first one. |
 | `swath.replay.serving.refused{reason}` | counter | A request the sorted path had to refuse outright, tagged with the typed reason from `io.varve.swath.sort.RowGroupOrderException`: `row_group_disorder` (a row group's own rows are not in strictly ascending key order, seen by the `delimiter=/` skip-scan's key cursor as it steps over them). NOT a `serving.fallback` reason: eligibility already passed (it proves the ascent of row-group *first* keys only), the serving path was chosen at startup, and nothing can take the request over — it fails `500`. Bumped BEFORE the throw, so the exclusion survives into a sweep's metrics; a corpus sweep classifies a disordered capture from this counter, never from the error body. |
+| `swath.replay.delimiter.path{path}` | counter | Which implementation served one `delimiter=/` list request: `rollup` (the store's native skip-scan) or `walk` (the pager's seek-per-prefix range walk, i.e. the store declined). A wide structure probe landing on `walk` is the #77 cost profile — attribute a stalled probe here first. |
+| `swath.replay.delimiter.skipscan.row_group_opens` | counter | Row groups the skip-scan actually opened a key cursor on (the zero-I/O whole-group skip does not count). Pinned by a regression test to stay O(prefixes emitted), never O(keys under them). |
 | `swath.replay.page.read.latency` | timer | One store-level range read (`ListingStore#rows`), excluding connection-pool wait. Emitted by both stores. |
 | `swath.replay.serving.path{mode}` | counter | Per-`list`-request engagement signal for the resolved serving path (`sorted` or `duckdb`), fixed once at server startup. |
 

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
@@ -8,9 +8,12 @@ package io.varve.swath.replay.protocol;
 import io.varve.swath.replay.server.ReplayMetrics;
 import io.varve.swath.replay.store.ListingStore;
 import io.varve.swath.replay.store.Projection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Owns every S3 ListObjectsV2 protocol rule once, driving a range-only {@link ListingStore}:
@@ -26,6 +29,8 @@ import java.util.List;
  * {@code successor(P)} inclusive ({@link ByteKeys#successor}).
  */
 public final class ListObjectsV2Pager implements ListingFixture {
+
+    private static final Logger log = LoggerFactory.getLogger(ListObjectsV2Pager.class);
 
     private static final int DELIMITER_BATCH = 4096;
 
@@ -111,16 +116,25 @@ public final class ListObjectsV2Pager implements ListingFixture {
         Lower cur = lowerBound(prefix, boundary);
 
         // Fast path: let the store answer the whole rollup in one set-oriented pass instead of a seek
-        // per common prefix. Only when the prefix has a finite upper bound (the all-0xFF prefix's open
-        // bound falls back); a store that declines returns null and the range walk below runs as before.
-        if (upper instanceof UpperBound.Bounded(ByteKey upperKey)) {
-            List<ListingStore.DelimitedEntry> rollup = store.delimitedRollup(
-                    cur.key(), cur.inclusive(), upperKey, prefix, delimiter, maxKeys,
-                    Projection.of(request.fetchOwner()));
-            if (rollup != null) {
-                return buildDelimitedPage(request, rollup, maxKeys);
-            }
+        // per common prefix — including an open upper bound (no prefix, or a prefix whose 0xFF-carry
+        // has no finite bound): a store that can serve that natively (SortedParquetStore) does; one
+        // that can't, or that declines the delimiter shape, returns null and the range walk below runs
+        // as before.
+        ByteKey upperKey = switch (upper) {
+            case UpperBound.Bounded(ByteKey bounded) -> bounded;
+            case UpperBound.Open() -> null;
+        };
+        List<ListingStore.DelimitedEntry> rollup = store.delimitedRollup(
+                cur.key(), cur.inclusive(), upperKey, prefix, delimiter, maxKeys,
+                Projection.of(request.fetchOwner()));
+        if (rollup != null) {
+            metrics.recordDelimiterPath(ReplayMetrics.DELIMITER_PATH_ROLLUP);
+            log.debug("delimited list served by store rollup: prefix={} maxKeys={}", prefixForLog(prefix), maxKeys);
+            return buildDelimitedPage(request, rollup, maxKeys);
         }
+        metrics.recordDelimiterPath(ReplayMetrics.DELIMITER_PATH_WALK);
+        log.debug("delimited list served by range walk (store declined the rollup): prefix={} maxKeys={}",
+                prefixForLog(prefix), maxKeys);
 
         List<S3ResultEntry> entries = new ArrayList<>(maxKeys);
 
@@ -284,6 +298,11 @@ public final class ListObjectsV2Pager implements ListingFixture {
             }
         }
         return null;
+    }
+
+    /** Best-effort display form of a scan prefix for the delimiter-path debug log — never load-bearing. */
+    private static String prefixForLog(byte[] prefix) {
+        return prefix == null || prefix.length == 0 ? "<root>" : new String(prefix, StandardCharsets.UTF_8);
     }
 
     private static boolean matchesAt(byte[] key, byte[] delimiter, int offset) {

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/server/ReplayMetrics.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/server/ReplayMetrics.java
@@ -35,6 +35,12 @@ public final class ReplayMetrics {
     /** The sorted-Parquet role-2 serving path tag. */
     public static final String SERVING_MODE_SORTED = "sorted";
 
+    /** {@code swath.replay.delimiter.path} tag: the store answered the whole rollup in one set-oriented pass. */
+    public static final String DELIMITER_PATH_ROLLUP = "rollup";
+
+    /** {@code swath.replay.delimiter.path} tag: the store declined and the pager walked ranges instead. */
+    public static final String DELIMITER_PATH_WALK = "walk";
+
     private final MeterRegistry registry;
     private final String servingMode;
     private final Counter httpRequests;
@@ -49,6 +55,7 @@ public final class ReplayMetrics {
     private final Counter prefetchWindowHit;
     private final DistributionSummary prefetchFillRows;
     private final Timer prefetchWindowFill;
+    private final Counter delimiterSkipScanRowGroupOpens;
     private final AtomicLong parquetQueriesInFlight = new AtomicLong();
     private final long startedNanos = System.nanoTime();
 
@@ -87,6 +94,8 @@ public final class ReplayMetrics {
         prefetchFillRows = DistributionSummary.builder("swath.replay.prefetch.fill.rows").register(registry);
         prefetchWindowFill = Timer.builder("swath.replay.prefetch.window.fill")
                 .publishPercentiles(0.5, 0.99).register(registry);
+        delimiterSkipScanRowGroupOpens = Counter.builder("swath.replay.delimiter.skipscan.row_group_opens")
+                .register(registry);
         Gauge
                 .builder("swath.replay.parquet.queries.in_flight", parquetQueriesInFlight, AtomicLong::get)
                 .register(registry);
@@ -176,6 +185,27 @@ public final class ReplayMetrics {
     public void recordServingRefused(String reason) {
         Counter.builder("swath.replay.serving.refused")
                 .tag("reason", reason).register(registry).increment();
+    }
+
+    /**
+     * Records which path served one {@code delimiter=/} listing request — {@link #DELIMITER_PATH_ROLLUP}
+     * (the store answered the whole rollup natively) or {@link #DELIMITER_PATH_WALK} (the store declined
+     * and the pager fell back to a seek per common prefix). Silent-until-someone-times-it was the whole
+     * complaint that motivated this counter: a stalled delimiter panel is now attributable to the
+     * fallback path from the metrics alone, without a wall-clock reproduction.
+     */
+    public void recordDelimiterPath(String path) {
+        Counter.builder("swath.replay.delimiter.path").tag("path", path).register(registry).increment();
+    }
+
+    /**
+     * Records one row-group open inside {@code SortedParquetStore}'s delimiter skip-scan (a group the
+     * zero-I/O whole-group shortcut couldn't resolve without decoding). A test asserting this stays
+     * bounded by the number of rolled-up prefixes — not by the number of keys under them — is the cost
+     * regression guard for the skip-scan itself.
+     */
+    public void recordDelimiterSkipScanRowGroupOpen() {
+        delimiterSkipScanRowGroupOpens.increment();
     }
 
     /** Records how many rows one window fill asked the delegate for (proves the ramp engages). */

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/store/ListingStore.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/store/ListingStore.java
@@ -69,9 +69,12 @@ public interface ListingStore extends AutoCloseable {
      * Returns {@code null} to decline — the caller then walks ranges via {@link #rows} (the default,
      * and the behaviour of every store that does not override this).
      *
+     * @param toExclusive exclusive upper bound; {@code null} = open (no prefix, or a prefix whose
+     *                    0xFF-carry has no finite bound — see {@code ByteKeys#prefixUpper})
+     * @param prefix      the scan prefix every returned key/common-prefix starts with; {@code null} or
+     *                    empty for a root (no-prefix) rollup
      * @param delimiter   the raw delimiter bytes; an implementation MAY restrict its fast path (e.g.
      *                    to a single {@code /}) and decline otherwise
-     * @param prefix      the scan prefix every returned key/common-prefix starts with
      * @return up to {@code limit + 1} entries, or {@code null} to decline
      */
     default List<DelimitedEntry> delimitedRollup(ByteKey from, boolean fromInclusive, ByteKey toExclusive,

--- a/swath-replay-server/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
+++ b/swath-replay-server/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
@@ -159,15 +159,15 @@ public final class SortedParquetStore implements ListingStore {
 
     /**
      * The native {@code delimiter=/} skip-scan (the {@link ListingStore#delimitedRollup} fast path).
-     * Only the single {@code /} (0x2F) delimiter and a finite {@code toExclusive} are handled; every
-     * other shape (multi-byte delimiter, the all-{@code 0xFF} prefix whose upper bound is open)
-     * declines and the pager walks ranges instead.
+     * Only the single {@code /} (0x2F) delimiter is handled; every other shape (multi-byte delimiter)
+     * declines and the pager walks ranges instead. {@code toExclusive} and {@code prefix} may both be
+     * {@code null} — an open upper bound (no prefix, or the all-{@code 0xFF} prefix whose 0xFF-carry
+     * has no finite bound) is scanned to the end of the fixture, same as {@link #rows}.
      */
     @Override
     public List<DelimitedEntry> delimitedRollup(ByteKey from, boolean fromInclusive, ByteKey toExclusive,
                                                 byte[] prefix, byte[] delimiter, int limit, Projection projection) {
-        if (toExclusive == null || prefix == null
-                || delimiter == null || delimiter.length != 1 || delimiter[0] != (byte) '/') {
+        if (delimiter == null || delimiter.length != 1 || delimiter[0] != (byte) '/') {
             return null;
         }
         var sample = metrics.startParquetQueryTimer();
@@ -241,7 +241,7 @@ public final class SortedParquetStore implements ListingStore {
             return List.of();
         }
         byte[] fromBytes = from == null ? null : from.toByteArray();
-        byte[] upper = toExclusive.toByteArray();
+        byte[] upper = toExclusive == null ? null : toExclusive.toByteArray();
         List<DelimitedEntry> out = new ArrayList<>();
 
         byte[] cursor = fromBytes;
@@ -257,7 +257,7 @@ public final class SortedParquetStore implements ListingStore {
                 int rg = SortedRouting.startRowGroup(index, cursor == null ? null : ByteKey.copyOf(cursor));
                 IndexEntry entry = index.get(rg);
                 byte[] groupFirstKey = entry.firstKey().toByteArray();
-                if (ByteKeys.compareUnsigned(groupFirstKey, upper) >= 0) {
+                if (upper != null && ByteKeys.compareUnsigned(groupFirstKey, upper) >= 0) {
                     break;   // this group starts at/past the upper bound: nothing more in range
                 }
 
@@ -309,6 +309,11 @@ public final class SortedParquetStore implements ListingStore {
                     keyCursor = reader.openKeyCursor(entry.rowGroup());
                     cachedBlockIndex = entry.rowGroup();
                     cachedRows = null;   // decoded lazily below, only if a bare object actually needs it
+                    // A row-group open the zero-I/O shortcut above didn't catch (the group straddles a
+                    // prefix boundary, or is the fixture's last group). Counted so a test can pin the
+                    // skip-scan's cost to O(prefixes emitted) rather than O(keys under the prefix) —
+                    // the very regression this rollup exists to avoid.
+                    metrics.recordDelimiterSkipScanRowGroupOpen();
                 }
                 keyCursor.advanceTo(cursor, inclusive);
                 if (!keyCursor.hasCurrent()) {
@@ -322,7 +327,7 @@ public final class SortedParquetStore implements ListingStore {
                     continue;
                 }
                 byte[] key = keyCursor.currentKey();
-                if (ByteKeys.compareUnsigned(key, upper) >= 0) {
+                if (upper != null && ByteKeys.compareUnsigned(key, upper) >= 0) {
                     break;   // past the scan's upper bound: nothing more in range
                 }
                 byte[] commonPrefix = commonPrefixAfter(key, prefix);
@@ -363,10 +368,12 @@ public final class SortedParquetStore implements ListingStore {
      * {@code key}'s rolled-up common prefix under {@code prefix} for the single {@code '/'} delimiter —
      * {@code prefix} plus everything up to and including the first {@code '/'} found strictly after it
      * — or {@code null} when {@code key} is a bare object directly under {@code prefix} (no {@code '/'}
-     * appears past the scan prefix).
+     * appears past the scan prefix). {@code prefix == null} (a root, no-prefix rollup) scans from the
+     * start of the key, same as the pager's own {@code commonPrefix} treats an absent prefix.
      */
     private static byte[] commonPrefixAfter(byte[] key, byte[] prefix) {
-        for (int i = prefix.length; i < key.length; i++) {
+        int start = prefix == null ? 0 : prefix.length;
+        for (int i = start; i < key.length; i++) {
             if (key[i] == '/') {
                 return Arrays.copyOf(key, i + 1);
             }

--- a/swath-replay-server/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
+++ b/swath-replay-server/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
@@ -169,6 +169,54 @@ class SortedServingFullDifferentialTest {
         differential(dir, keys, manySmallGroups(), scenarios);
     }
 
+    /**
+     * The fast-path shape introduced for the O(prefixes) root rollup (public issue #77): a no-prefix
+     * request (the request shape whose open upper bound used to fall through to the O(prefixes)
+     * per-directory range walk even on the sorted store), many prefixes each spanning several row
+     * groups (tiny {@code manySmallGroups} row groups over 25 objects/prefix — the "prefix run spans
+     * row-group boundaries" case), small {@code max-keys} forcing a continuation-token resume mid the
+     * prefix sequence, and plain keys sorted after the very last delimiter-bearing prefix (no {@code /}
+     * at all — the "trailing plain keys" case). Also pins the fast path actually engaged for the
+     * no-prefix scenario, not merely that its output happens to match: a silent fallback to the range
+     * walk would still pass the byte-identical assertion below.
+     */
+    @Test
+    void wideNoPrefixRollupWithRowGroupSpanningPrefixesAndTrailingPlainKeysIsByteIdentical(@TempDir Path dir)
+            throws Exception {
+        List<byte[]> keys = new ArrayList<>();
+        for (int p = 0; p < 12; p++) {
+            for (int i = 0; i < 25; i++) {
+                keys.add(utf8(String.format("wide%02d/obj-%03d", p, i)));
+            }
+        }
+        for (int n = 0; n < 4; n++) {
+            keys.add(utf8("zzz-plain-" + n));   // sorts after every "wideNN/" prefix; no delimiter at all
+        }
+        Fixture fixture = writeSorted(dir, keys, manySmallGroups());
+        List<Scenario> scenarios = new ArrayList<>(projectionMatrix(null, utf8("/"), null, new int[]{1, 2, 3, 5}));
+        try (ReplayServer sorted = new ReplayServer(
+                "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.SORTED);
+             ReplayServer duck = new ReplayServer(
+                     "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.DUCKDB)) {
+            sorted.start();
+            duck.start();
+            assertThat(sorted.resolvedServingMode()).isEqualTo(ServingMode.SORTED);
+            assertThat(duck.resolvedServingMode()).isEqualTo(ServingMode.DUCKDB);
+
+            HttpClient client = HttpClient.newHttpClient();
+            for (Scenario scenario : scenarios) {
+                assertThat(walk(sorted, client, scenario))
+                        .as("sorted vs duckdb differ for %s", describe(scenario))
+                        .isEqualTo(walk(duck, client, scenario));
+            }
+            assertThat(sorted.metrics().registry().find("swath.replay.delimiter.path")
+                    .tag("path", ReplayMetrics.DELIMITER_PATH_ROLLUP).counter().count())
+                    .as("no-prefix delimiter requests must be served by the store's native rollup, "
+                            + "not silently fall back to the range walk")
+                    .isGreaterThan(0.0);
+        }
+    }
+
     @Test
     void multiByteDelimiterIsByteIdentical(@TempDir Path dir) throws Exception {
         List<byte[]> keys = new ArrayList<>();

--- a/swath-replay-server/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
+++ b/swath-replay-server/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
@@ -310,9 +310,9 @@ class SortedParquetStoreTest {
      * The exclusive upper bound for a scan prefix, for tests to pass directly to {@link
      * SortedParquetStore#delimitedRollup} (which — unlike the pager — never derives it itself). A
      * non-empty prefix uses the real {@link ByteKeys#prefixUpper} carry; the empty (root) prefix has
-     * no finite carry, so tests that want to exercise the skip-scan's root-level behaviour directly
-     * (bypassing the pager, which declines an open bound and range-walks instead — see {@link
-     * #delimitedRollupAnswersAnOpenUpperBoundAndDeclinesOnlyNonSlashDelimiters}) use a sentinel past every key this file's fixtures
+     * no finite carry — the store now serves that open bound natively (see {@link
+     * #delimitedRollupAnswersAnOpenUpperBoundAndDeclinesOnlyNonSlashDelimiters}), but tests that
+     * want a BOUNDED root-level scan use a sentinel past every key this file's fixtures
      * ever write.
      */
     private static ByteKey upperOf(String prefix) {

--- a/swath-replay-server/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
+++ b/swath-replay-server/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
@@ -225,16 +225,66 @@ class SortedParquetStoreTest {
         }
     }
 
+    /**
+     * The no-prefix root rollup's real shape — {@code toExclusive == null} and {@code prefix == null}
+     * (a genuinely open upper bound, {@link UpperBound.Open}) — must now be answered natively rather
+     * than declined (public issue #77: an open upper bound used to fall through to the pager's
+     * O(directories) range walk even on the sorted store). The only shape this store still declines is
+     * a delimiter it does not know how to skip-scan.
+     */
     @Test
-    void delimitedRollupDeclinesOutsideItsGatedShape(@TempDir Path dir) throws IOException {
+    void delimitedRollupAnswersAnOpenUpperBoundAndDeclinesOnlyNonSlashDelimiters(@TempDir Path dir)
+            throws IOException {
+        List<String> keys = List.of("a/1.txt", "b/1.txt");
         Fixture fixture = writeSorted(dir, manySmallGroups(), "a/1.txt", "b/1.txt");
 
         try (SortedParquetStore store = store(fixture)) {
+            List<ListingStore.DelimitedEntry> rootRollup =
+                    store.delimitedRollup(null, true, null, null, slash(), 1000, Projection.KEYS_ONLY);
+            assertThat(rootRollup).isNotNull();
+            assertThat(entryStrings(rootRollup)).isEqualTo(expectedRollup(keys, "", null, true, 1000));
+
             ByteKey upper = upperOf("");
-            assertThat(store.delimitedRollup(null, true, null, new byte[0], slash(), 1000, Projection.KEYS_ONLY))
-                    .isNull();   // open (unbounded) upper bound
             assertThat(store.delimitedRollup(null, true, upper, new byte[0], new byte[] {'/', '/'}, 1000,
-                    Projection.KEYS_ONLY)).isNull();   // multi-byte delimiter
+                    Projection.KEYS_ONLY)).isNull();   // multi-byte delimiter still declines
+        }
+    }
+
+    /**
+     * The regression this whole fast path exists to fix (public issue #77): a root {@code delimiter=/}
+     * rollup over a wide-flat keyspace must cost O(prefixes emitted), never O(keys under them). A
+     * dense fixture of 50 prefixes x 500 keys forces many row groups per prefix (tiny {@code
+     * manySmallGroups} row groups), so a naive per-row scan would open on the order of the fixture's
+     * row-group count once per key; the skip-scan's zero-I/O whole-group shortcut instead resolves most
+     * of each prefix's span without opening a single row group. No wall-clock assertion: the row-group-open
+     * counter pins the cost directly.
+     */
+    @Test
+    void delimitedRollupCostIsBoundedByPrefixesNotKeys(@TempDir Path dir) throws IOException {
+        int prefixCount = 50;
+        int keysPerPrefix = 500;
+        List<String> keys = new ArrayList<>(prefixCount * keysPerPrefix);
+        for (int p = 0; p < prefixCount; p++) {
+            for (int i = 0; i < keysPerPrefix; i++) {
+                keys.add(String.format("prefix-%03d/obj-%04d", p, i));
+            }
+        }
+        Fixture fixture = writeSorted(dir, manySmallGroups(), keys);
+        assertThat(fixture.index).hasSizeGreaterThan(prefixCount);   // many more row groups than prefixes
+
+        ReplayMetrics metrics = new ReplayMetrics();
+        try (SortedParquetStore store = new SortedParquetStore(fixture.files, fixture.index, metrics, 2)) {
+            List<ListingStore.DelimitedEntry> rollup =
+                    store.delimitedRollup(null, true, null, null, slash(), prefixCount + 10, Projection.KEYS_ONLY);
+            assertThat(rollup).hasSize(prefixCount);   // every prefix rolls up to exactly one CommonPrefix
+
+            double rowGroupOpens = metrics.registry()
+                    .find("swath.replay.delimiter.skipscan.row_group_opens").counter().count();
+            assertThat(rowGroupOpens)
+                    .as("row-group opens must scale with prefixes (%d), not with keys (%d)",
+                            prefixCount, keys.size())
+                    .isLessThan(prefixCount * 4.0)
+                    .isLessThan(keys.size() / 10.0);
         }
     }
 
@@ -262,7 +312,7 @@ class SortedParquetStoreTest {
      * non-empty prefix uses the real {@link ByteKeys#prefixUpper} carry; the empty (root) prefix has
      * no finite carry, so tests that want to exercise the skip-scan's root-level behaviour directly
      * (bypassing the pager, which declines an open bound and range-walks instead — see {@link
-     * #delimitedRollupDeclinesOutsideItsGatedShape}) use a sentinel past every key this file's fixtures
+     * #delimitedRollupAnswersAnOpenUpperBoundAndDeclinesOnlyNonSlashDelimiters}) use a sentinel past every key this file's fixtures
      * ever write.
      */
     private static ByteKey upperOf(String prefix) {


### PR DESCRIPTION
Fixes #77.

## What

A no-prefix (root) `delimiter=/` request has an open upper bound, which failed the pager's `Bounded`-only fast-path gate AND `SortedParquetStore.delimitedRollup`'s own `toExclusive`/`prefix` null gates — so the very shape the native skip-scan exists for (wide structure probes) fell into the range walk's one-store-query-per-CommonPrefix cost. On a fixture with ~1,000 dense date prefixes that was **70.3s of server compute per probe against a ~3s engine probe budget**: every probe timed out, and nine deep-nested fixtures were silently unmeasurable on every corpus panel (exit 75 at ~600s, `0/256 probes`).

The fix threads a nullable upper bound through `delimitedRollup`/`skipScan` (an open bound scans to end-of-fixture, same as `rows()`), lets `commonPrefixAfter` start at offset 0 for a null prefix, and has the pager always offer the store the rollup — a store that declines still falls back to the range walk (the DuckDB oracle deliberately never overrides it, so the walk stays the byte-identical reference).

## Evidence (noaa-urma-pds, 1.75M keys, SORTED mode, injection off)

| request | before | after |
|---|---|---|
| `list-type=2&max-keys=1000` | 0.090s | 0.091s |
| same + `delimiter=%2F` | **70.34s** | **0.054s** |

Responses byte-identical before/after on both requests. Full 45-page continuation walk (17,764 prefixes): 3.2s total.

**All nine previously-unmeasurable fixtures now complete panel runs on both engine arms** — 18/18 exit 0, zero key-set diffs between arms (openneuro.org 7.9M keys, geoglows-v2-forecasts 7.4M, ssl4eo-s12-landsat-combined 5.2M, noaa-rtma-pds 4.9M, allen-mouse-brain-atlas 4.6M, ecmwf-forecasts 4.2M, noaa-nws-fourcastnetgfs-pds 4.1M, noaa-ofs-pds 2.7M, noaa-urma-pds 1.75M). The engine run that previously died STUCK at ~600s with 24 API calls now finishes noaa-urma-pds in 22.5s with 2,484 calls.

Side observation from the unblocked class (not this PR's claim): noaa-nws-fourcastnetgfs-pds runs near-serial on the pre-0.2.0 arm (77.3s, 1.9 avg in-flight) and 2.0× faster under the shipped defaults (38.7s, 13.5 in-flight, splits 12→300) — a wide-flat-tail cure win on a bucket class that was invisible to every prior panel.

## Never again silent

The failure looked like an engine stall and cost a session of refuted hypotheses (see the retraction on #71). Now:
- `swath.replay.delimiter.path{path=rollup|walk}` counter + debug log says which implementation served each delimited request — a wide probe landing on `walk` is this cost profile.
- `swath.replay.delimiter.skipscan.row_group_opens` counter, pinned by a regression test (50 prefixes × 500 keys) to stay **O(prefixes emitted), never O(keys)** — no wall-clock assertions.
- New differential test pins byte parity vs the DuckDB oracle across row-group-spanning prefixes, trailing plain keys, and forced continuation resumes, and asserts the rollup path actually fired (a silent fallback to the walk would fail it even though bytes still match).
- `docs/swath-replay-server.md`: skip-scan gating text corrected (finite-bound requirement removed), both counters documented.

## Review

Independent deep review: no blockers; one stale javadoc `{@link}` found and fixed. Disclosed follow-up (not blocking, reviewer-flagged): no explicit `max-keys=0` edge for the open-bound shape, and continuation-token-exactly-on-prefix-boundary is covered incidentally by full pagination rather than by a named case. Full-tier CI (fast + deep + integration) green on this head (run 30437633047).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved sorted object listings using the `/` delimiter, including requests without a prefix or with an open-ended range.
  * Added fallback handling when optimized listing is unavailable.
  * Improved listing efficiency by limiting skip-scan work to relevant prefixes rather than individual keys.

* **Monitoring**
  * Added metrics and logging to identify optimized versus fallback listing paths and track skip-scan activity.

* **Documentation**
  * Clarified delimiter-based listing behavior, range handling, and related monitoring information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->