### PR TITLE
chore: close the serial-tail review punch list, and stop the toggles line calling the documented rollback unsupported

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ the managed co-located checkpoint and does not accept an arbitrary SQLite path.
 | `--metrics-endpoint` | unset (or `SWATH_OTLP_ENDPOINT`) |
 | `--no-metrics` | off |
 | `--trace` | off |
-| `--engine-toggle` | every toggle defaults `on` except `readahead` (`off`); see [`usage.md`](usage.md#diagnostic-tier-ablation---engine-toggle) — diagnostic tier, not a supported configuration |
+| `--engine-toggle` | every toggle defaults `on` except `readahead` (`off`); see [`usage.md`](usage.md#diagnostic-tier-ablation---engine-toggle) — diagnostic tier, not a supported configuration, except the documented `rate_anchored_sensing=off` + `tail_floor=current` rollback |
 
 `--trace` is available with every checkpoint mode, including `--checkpoint
 none`. Trace JSONL contains real key bounds and pivots; the JSON run summary can

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -570,11 +570,10 @@ below. To restore pre-0.2.0 engine behaviour exactly, pass both
 `--engine-toggle rate_anchored_sensing=off --engine-toggle tail_floor=current`. Output is
 unaffected either way — the pair changes scheduling, not the key set.
 
-> Note: that rollback is a *deviation from the defaults*, so it trips the
-> `engine_toggles_effective` startup line, whose text ends "…not a supported configuration".
-> That wording is about the ablation surface as a whole; the two-toggle rollback above is
-> documented and supported. The log text is pinned by a test that guards the
-> operator-visible token, so it is deliberately left alone here.
+> Note: that rollback is a *deviation from the defaults*, so it prints the
+> `engine_toggles_effective` startup line. As of 0.2.0 that line names the pair as a supported
+> rollback rather than calling the whole non-default surface unsupported — the warning is about
+> the other toggles, not this one.
 
 | Name | Default | Change from default when |
 | --- | --- | --- |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -519,13 +519,15 @@ slip — is rejected outright (exit 2) rather than silently signing with SigV4.
 
 #### Diagnostic-tier ablation (`--engine-toggle`)
 
-**EXPERIMENTAL / DIAGNOSTIC — a measurement tool, not a supported configuration.** `--engine-toggle
+**EXPERIMENTAL / DIAGNOSTIC — a measurement tool, not a supported configuration, with one
+documented exception: the 0.2.0 rollback pair described below.** `--engine-toggle
 NAME=VALUE` (repeatable) is a single ablation namespace so a per-mechanism A/B measurement of the
 `WorkStealingScan` engine runs from one binary instead of a bespoke flag per experiment. Every
 structure toggle defaults to `on` (`readahead` defaults to `off`; `mass_aware_seed` and
 `rate_anchored_sensing` are default ON, opt-out `NAME=off`; `tail_floor` is the one
 value-taking toggle, default `reach_floored`); **the defaults are the only supported
-configuration** —
+configuration, except for the documented `rate_anchored_sensing=off` + `tail_floor=current`
+rollback below** —
 toggling never changes correctness (I2/I3 tiling holds either way), only which optimization
 mechanisms engage. An unknown name, a malformed value (not `on`/`off` — or, for `tail_floor`, not
 one of its modes), or a contradictory combination

--- a/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
@@ -1855,8 +1855,9 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
                         + "structure_probes={} far_ahead={} alphabet_pivots={} reflect={} confetti_feedback={} "
                         + "reflect_lift={} fanout_tiling={} mass_aware_seed={} readahead={} "
                         + "rate_anchored_sensing={} tail_floor={} "
-                        + "(EXPERIMENTAL/DIAGNOSTIC ablation surface — measurement only, not a supported "
-                        + "configuration)",
+                        + "(non-default engine configuration — the rate_anchored_sensing/tail_floor pair is a "
+                        + "documented, supported rollback; every other toggle is an EXPERIMENTAL/DIAGNOSTIC "
+                        + "ablation surface, measurement only)",
                 engine.toggles.ownerSplit(), engine.toggles.densityEwma(), engine.toggles.radixBands(),
                 engine.toggles.structureProbes(), engine.toggles.farAhead(), engine.toggles.alphabetPivots(),
                 engine.toggles.reflect(), engine.toggles.confettiFeedback(), engine.toggles.reflectLift(),

--- a/swath-cli/src/test/java/io/varve/swath/cli/EngineTogglesEffectiveLogIdentityTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/EngineTogglesEffectiveLogIdentityTest.java
@@ -32,8 +32,9 @@ class EngineTogglesEffectiveLogIdentityTest {
                     + "structure_probes={} far_ahead={} alphabet_pivots={} reflect={} confetti_feedback={} "
                     + "reflect_lift={} fanout_tiling={} mass_aware_seed={} readahead={} "
                     + "rate_anchored_sensing={} tail_floor={} "
-                    + "(EXPERIMENTAL/DIAGNOSTIC ablation surface — measurement only, not a supported "
-                    + "configuration)";
+                    + "(non-default engine configuration — the rate_anchored_sensing/tail_floor pair is a "
+                    + "documented, supported rollback; every other toggle is an EXPERIMENTAL/DIAGNOSTIC "
+                    + "ablation surface, measurement only)";
 
     @Test
     void engineTogglesEffectiveEmitsUnderTheListCommandLoggerWithUnchangedMessageAndArgs() throws Exception {

--- a/swath-core/src/main/java/io/varve/swath/engine/EngineToggles.java
+++ b/swath-core/src/main/java/io/varve/swath/engine/EngineToggles.java
@@ -20,7 +20,9 @@ import java.util.Map;
  * runs from one binary instead of a bespoke flag per experiment.
  *
  * <p><b>EXPERIMENTAL / DIAGNOSTIC — not a supported configuration.</b> {@link #DEFAULT} is the
- * only supported configuration: the ten ablation toggles below default {@code true}, {@code
+ * only supported configuration, with one documented exception: {@code rate_anchored_sensing=off}
+ * together with {@code tail_floor=current} is the supported rollback to pre-0.2.0 engine behaviour
+ * ({@code docs/usage.md}). The ten ablation toggles below default {@code true}, {@code
  * readahead} is opt-in/default-off, and {@code mass_aware_seed} is opt-out/default-on. Turning a
  * mechanism off silences its own counters and fires an explicit {@code TOGGLE.<name>_off} mark
  * (§5 discipline, {@code docs/internals/metrics-internals.md}), so post-hoc analysis never has to
@@ -170,8 +172,9 @@ public record EngineToggles(
     }
 
     /**
-     * The only supported configuration: every ablation toggle on, {@code readahead} off, {@code
-     * mass_aware_seed} and {@code rate_anchored_sensing} on, {@code tail_floor} at {@link
+     * The only supported configuration — bar the documented {@code rate_anchored_sensing=off} +
+     * {@code tail_floor=current} rollback — every ablation toggle on, {@code readahead} off,
+     * {@code mass_aware_seed} and {@code rate_anchored_sensing} on, {@code tail_floor} at {@link
      * TailFloorMode#REACH_FLOORED}.
      *
      * <p>The sensing/tail-floor pair became the default in 0.2.0. Both had shipped opt-in so a

--- a/swath-core/src/main/java/io/varve/swath/engine/TailFloorMode.java
+++ b/swath-core/src/main/java/io/varve/swath/engine/TailFloorMode.java
@@ -18,7 +18,11 @@ import java.util.Locale;
  *
  * <p>An arm here changes only <em>whether</em> an owner carves, never how the split transaction
  * tiles (I2/I3 hold under every mode — the pivot math and the CAS are untouched), so this is a
- * measurement surface exactly like {@code rate_anchored_sensing}, not a supported configuration.
+ * measurement surface exactly like {@code rate_anchored_sensing}.
+ *
+ * <p>One exception to that framing, since 0.2.0: {@link #CURRENT} paired with {@code
+ * rate_anchored_sensing=off} is the <b>documented, supported rollback</b> to pre-0.2.0 engine
+ * behaviour ({@code docs/usage.md}). Every other mode here remains measurement-only.
  */
 public enum TailFloorMode {
 

--- a/swath-core/src/test/java/io/varve/swath/engine/GoldenTrace.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/GoldenTrace.java
@@ -86,6 +86,25 @@ final class GoldenTrace {
         }
     }
 
+    /**
+     * A numeric field, JSON <b>null</b> when non-finite — the same convention {@code JsonlTraceSink}
+     * writes with, so a golden fixture stays strictly parseable JSON (JSONL has no {@code NaN}/
+     * {@code Infinity} literal, and both occur here: a not-computed gate input, an open-frontier
+     * estimate).
+     *
+     * <p>{@code JsonlTraceSink} keeps its own private copy of this rule rather than calling here:
+     * it is production code and cannot depend on a test source set. The duplication is deliberate
+     * and the two must stay in step — a golden recorded under a different non-finite convention
+     * would no longer describe what the shipped sink writes.
+     */
+    static void putNum(ObjectNode node, String field, double v) {
+        if (Double.isFinite(v)) {
+            node.put(field, v);
+        } else {
+            node.putNull(field);
+        }
+    }
+
     // ---- probe log: every MockPageFetcher call issued during one decision-site invocation -----
 
     /** Ordered log of {@code (request, response)} pairs a single decision-site call issued. */

--- a/swath-core/src/test/java/io/varve/swath/engine/OwnerSplitConfettiCasLossTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/OwnerSplitConfettiCasLossTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.varve.swath.engine.policy.OwnerSplitGovernor;
+import io.varve.swath.engine.policy.OwnerSplitSkipReason;
+import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.testkit.StubCheckpointStore;
+import io.varve.swath.testkit.WorkerStates;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * <b>The executor-level half of the confetti probe claim, on the path where the claim LOSES.</b>
+ *
+ * <p>{@link OwnerSplitGovernor} decides {@code PROBE} purely from the {@code probeSeq} its view was
+ * built from, so every owner that snapshotted the same value decides {@code PROBE} and returns a
+ * {@code Carve} whose terminal reason is {@code confetti_probe}. Exactly one of them may actually
+ * carve, so {@link OwnerSelfSplit} resolves the claim against the run-scoped gate
+ * ({@code ConfettiFeedbackGate#claimProbeSlot}, a single {@code compareAndSet}) and suppresses the
+ * losers — issue #31.
+ *
+ * <p>That leaves a deliberate divergence on the losing path, which this pins: the metric says
+ * {@code OWNER_SPLIT.confetti_suppressed} (what the executor did), while the decision trace carries
+ * the <em>carve</em> the governor decided (what the policy layer saw). Both are correct about their
+ * own layer and the two are read together, so neither may drift into agreeing with the other by
+ * accident. Only the governor-level half of this was pinned before — see {@code
+ * DecisionTraceGoldenTest} scenario 9, which pins the WINNING probe and the suppressed call after
+ * it, both of which take the claim uncontended.
+ *
+ * <p>The traced reason is asserted as "the same reason the winner traced, and not the suppression
+ * code" rather than as a literal string. A carve's terminal reason is the LAST gate its path
+ * engaged, so on this victim shape it is {@code pivot_reflect_clamped}, with {@code confetti_probe}
+ * recorded alongside it as an engagement (visible in the {@code owner-split-gates} golden's
+ * scenario-9 deltas). Which pivot gate fires last is a property of the fixture; that the loser
+ * traces a carve while its metric says suppressed is the property of the mechanism.
+ *
+ * <p><b>Why this is deterministic and not a hopeful race.</b> {@link OwnerSelfSplit} snapshots the
+ * gate BEFORE it reads {@code outstanding} to build the view, so an {@code outstanding} supplier
+ * that blocks both callers on a barrier guarantees both have snapshotted the same {@code probeSeq}
+ * before either reaches its claim. The {@code compareAndSet} then decides the winner — the real
+ * mechanism, exercised at the real seam, with the interleaving that makes it interesting forced
+ * rather than waited for.
+ */
+class OwnerSplitConfettiCasLossTest {
+
+    private static final long RUN_ID = 7L;
+    private static final int MAX_KEYS = 100;
+
+    /** {@code PROBE_K - 1}: the over-threshold calls that carry probeSeq to the probe boundary. */
+    private static final int CALLS_TO_PROBE_BOUNDARY = 15;
+
+    @Test
+    void theLoserOfTheProbeClaimIsSuppressedWhileItsTraceStillNamesTheCarveItDecided() throws Exception {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        AtomicBoolean racing = new AtomicBoolean(false);
+        CyclicBarrier bothSnapshotted = new CyclicBarrier(2);
+        // Read AFTER the gate snapshot and BEFORE the claim — the one seam that can hold both callers
+        // between the two, without touching the code under test.
+        LongSupplier outstanding = () -> {
+            if (racing.get()) {
+                try {
+                    bothSnapshotted.await(30, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new AssertionError("the two racers never met at the claim", e);
+                }
+            }
+            return 0L;
+        };
+        // workerCount/maxKeys as DecisionTraceGoldenTest scenario 9, the pinned scenario this extends:
+        // the pivot gates ahead of the confetti branch read them, and a different fleet size lands the
+        // carve on a different terminal reason before the probe claim is ever reached.
+        OwnerSelfSplit gov = new OwnerSelfSplit(RUN_ID, 1, MAX_KEYS, StubCheckpointStore.returning(999L),
+                EngineToggles.DEFAULT, metrics, new RecordingTraceSink(), null, outstanding, () -> 1,
+                (childId, lo, hi) -> { });
+
+        driveGateOverThreshold(gov);
+        for (int i = 0; i < CALLS_TO_PROBE_BOUNDARY; i++) {
+            attempt(gov, 300 + i);
+        }
+        assertThat(gov.confettiSnapshot().probeSeq())
+                .as("the next over-threshold call is the one that lands on PROBE")
+                .isEqualTo(CALLS_TO_PROBE_BOUNDARY);
+
+        // Deltas across the race only: the warm-up above already drove CALLS_TO_PROBE_BOUNDARY
+        // suppressions through this same counter.
+        Map<String, Long> before = reasons(metrics);
+        racing.set(true);
+        List<OwnerSelfSplit.OwnerSplitTrace> results = raceTwoOwners(gov);
+        Map<String, Long> after = reasons(metrics);
+
+        List<OwnerSelfSplit.OwnerSplitTrace> published = results.stream().filter(r -> r.split()).toList();
+        List<OwnerSelfSplit.OwnerSplitTrace> suppressed = results.stream().filter(r -> !r.split()).toList();
+        assertThat(published).as("exactly one owner may carve on a claimed probe slot").hasSize(1);
+        assertThat(suppressed).as("and the other is suppressed, not carved").hasSize(1);
+
+        // The divergence itself, on the losing side: the trace carries the CARVE the governor decided
+        // from its view, while the metric carries the suppression the executor applied to it.
+        assertThat(suppressed.getFirst().gateInputs().reason())
+                .as("the loser's trace names the same carve the winner's does — both decided from the "
+                        + "same snapshot, and the claim is resolved after the decision, not inside it")
+                .isEqualTo(published.getFirst().gateInputs().reason());
+        assertThat(suppressed.getFirst().gateInputs().reason())
+                .as("so the loser's trace does NOT name the gate that actually stopped it")
+                .isNotEqualTo(OwnerSplitSkipReason.CONFETTI_SUPPRESSED.code());
+        assertThat(delta(before, after, OwnerSplitSkipReason.CONFETTI_SUPPRESSED.code()))
+                .as("while the metric names exactly that — one suppression, for the one loser")
+                .isEqualTo(1L);
+        assertThat(delta(before, after, "self_published"))
+                .as("exactly one carve was published").isEqualTo(1L);
+        assertThat(delta(before, after, "confetti_probe"))
+                .as("the probe engagement is credited once, to the winner — the loser returns before "
+                        + "applyEngagements, so a carve that never happened is never credited")
+                .isEqualTo(1L);
+
+        // The sequence advanced twice: the winner's CAS and the loser's consumed slot (issue #31 —
+        // N racers at s leave the counter at s + N, exactly as the pre-#22 fused increment did).
+        assertThat(gov.confettiSnapshot().probeSeq())
+                .as("winner and loser each consumed a slot")
+                .isEqualTo(CALLS_TO_PROBE_BOUNDARY + 2);
+    }
+
+    /** Both owners enter {@code maybeOwnerSelfSplit} and are held until each has snapshotted the gate. */
+    private static List<OwnerSelfSplit.OwnerSplitTrace> raceTwoOwners(OwnerSelfSplit gov) throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            List<Future<OwnerSelfSplit.OwnerSplitTrace>> futures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                long nodeId = 400 + i;
+                futures.add(pool.submit(() -> attempt(gov, nodeId)));
+            }
+            List<OwnerSelfSplit.OwnerSplitTrace> results = new ArrayList<>();
+            for (Future<OwnerSelfSplit.OwnerSplitTrace> f : futures) {
+                results.add(f.get(60, TimeUnit.SECONDS));
+            }
+            return results;
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * The tag/classify cycle a real run drives, until the observed confetti rate trips the gate: each
+     * warm-up carve's child completes fresh, never-split and small-tallied, which classifies as
+     * confetti.
+     */
+    private static void driveGateOverThreshold(OwnerSelfSplit gov) throws Exception {
+        for (int i = 0; i < ConfettiFeedbackGate.MIN_SAMPLE; i++) {
+            OwnerSelfSplit.OwnerSplitTrace warm = attempt(gov, 100 + i);
+            gov.onNodeCompleted(warm.childId(),
+                    WorkerStates.of(warm.childId(), warm.pivot(), warm.pivot(), warm.hi()));
+        }
+    }
+
+    /** One owner-split attempt on a dense victim — the shape every scenario here carves from. */
+    private static OwnerSelfSplit.OwnerSplitTrace attempt(OwnerSelfSplit gov, long nodeId) throws Exception {
+        WorkerState ws = WorkerStates.of(nodeId, b("d/00"), b("d/00"), b("d/05"));
+        ws.addKeysEmitted(50_000);
+        ws.recordPage(b("d/00"), b("d/05"), 50_000);
+        long[] selfSplit = {0, -OwnerSplitGovernor.SELF_SPLIT_MIN_PAGES_BETWEEN};
+        return gov.maybeOwnerSelfSplit(nodeId, ws, b("d/002500"), selfSplit);
+    }
+
+    private static Map<String, Long> reasons(RunMetrics metrics) {
+        return metrics.diagnostics(Duration.ZERO).stealReasons();
+    }
+
+    /** What {@code OWNER_SPLIT.<code>} moved by across the race — the warm-up drove this counter too. */
+    private static long delta(Map<String, Long> before, Map<String, Long> after, String code) {
+        String key = "OWNER_SPLIT." + code;
+        return after.getOrDefault(key, 0L) - before.getOrDefault(key, 0L);
+    }
+
+    private static byte[] b(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/engine/RecordingTraceSink.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/RecordingTraceSink.java
@@ -93,12 +93,12 @@ final class RecordingTraceSink implements TraceSink {
         e.put("worker_id", workerId);
         e.put("node_id", nodeId);
         e.put("reason", reason);
-        putNum(e, "est", est);
+        GoldenTrace.putNum(e, "est", est);
         e.put("pages_since_last_self_split", pagesSinceLastSelfSplit);
         e.put("outstanding", outstanding);
         e.put("worker_count", workerCount);
-        putNum(e, "far_ahead_fraction", farAheadFraction);
-        putNum(e, "density_ratio", densityRatio);
+        GoldenTrace.putNum(e, "far_ahead_fraction", farAheadFraction);
+        GoldenTrace.putNum(e, "density_ratio", densityRatio);
         e.put("keys_emitted", keysEmitted);
         events.add(e);
     }
@@ -114,23 +114,9 @@ final class RecordingTraceSink implements TraceSink {
         e.put("skipped_paced", skippedPaced);
         e.put("skipped_no_span", skippedNoSpan);
         e.put("chosen_node_id", chosenNodeId);
-        putNum(e, "best_est", bestEst);
+        GoldenTrace.putNum(e, "best_est", bestEst);
         e.put("reason", reason);
         events.add(e);
-    }
-
-    /**
-     * A numeric field, JSON <b>null</b> when non-finite — the same convention {@code JsonlTraceSink}
-     * writes with, so a golden fixture stays strictly parseable JSON (JSONL has no {@code NaN}/
-     * {@code Infinity} literal, and both occur here: a not-computed gate input, an open-frontier
-     * estimate).
-     */
-    private static void putNum(ObjectNode e, String field, double v) {
-        if (Double.isFinite(v)) {
-            e.put(field, v);
-        } else {
-            e.putNull(field);
-        }
     }
 
     @Override

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/ProbeToPageRatioTailTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/ProbeToPageRatioTailTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.varve.swath.sim.fixture.ListingFixtureStore;
 import io.varve.swath.sim.kernel.SimEventLog;
+import io.varve.swath.sim.model.LatencyModel;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,7 +49,9 @@ import org.junit.jupiter.api.Test;
  * The arm is {@code RATE_ANCHORED_FLOOR_QUARTER}, the promoted sensor, at all four
  * {@link SensingRaceProtocol#SEEDS}. Each threshold is stated with the reading it holds at and the
  * reading the same fixture, seed and arm produce at the bench ratio — the falsification run, which
- * fails every one of them:
+ * fails every one of them. That run is not just recorded here: {@link
+ * #atTheBenchProbeToPageRatioTheSameFixtureHandsTheLeafToTheFleet} executes it and asserts each
+ * threshold inverts, so the table below is pinned rather than remembered.
  *
  * <table border="1">
  *   <caption>live 121/223 (asserted) against bench 35/110 (pre-fix), four seeds</caption>
@@ -155,10 +158,71 @@ class ProbeToPageRatioTailTest {
         rows.forEach(System.out::println);
     }
 
+    /**
+     * <b>The falsification run, asserted rather than described.</b> Same fixture, same four seeds, same
+     * arm, same fleet, same 1,000-key page — the only thing that moves is the probe:page ratio, from the
+     * live 121/223 to the bench 35/110. Every threshold the leg above holds at must fail here, and this
+     * pins that inversion mechanically so the table in this class's javadoc cannot quietly become
+     * folklore: a change that made the live thresholds pass for some reason other than the ratio would
+     * keep passing there and start failing here.
+     *
+     * <p>Asserted as the negation of each live threshold rather than against the recorded bench bands
+     * (0.402–0.572 share, 39–61 splits, and so on). The claim being protected is "these readings are a
+     * property of the ratio", which is a claim about which side of each threshold a run lands on; the
+     * bands themselves are one instrument's readings and would make this brittle against any
+     * scheduling-visible change without saying anything more.
+     */
+    @Test
+    void atTheBenchProbeToPageRatioTheSameFixtureHandsTheLeafToTheFleet() {
+        List<byte[]> keys = SensingRaceProtocol.bench().get();
+        List<String> rows = new ArrayList<>();
+        for (long seed : SensingRaceProtocol.SEEDS) {
+            PolicyRunResult result = run(keys, seed, PolicyRunFixtures.MEASURED_TAIL_LATENCY);
+            String leg = SensingRaceProtocol.label(ARM) + "/seed " + seed + " @bench";
+            SensingRaceProtocol.requireCompleted(result, leg);
+            assertThat(result.keysEmitted()).as("%s: every key emitted", leg).isEqualTo(keys.size());
+
+            long victim = tailVictim(result);
+            Map<Long, Long> keysByNode = keysCommittedByNode(result);
+            double victimShare = (double) keysByNode.getOrDefault(victim, 0L)
+                    / SensingRaceProtocol.BENCH_HEAVIEST_LEAF_FILES;
+            long stolenKeys = keysDrainedByThiefChildrenOf(result, victim, keysByNode);
+            long splits = result.ownerSplitChildren() + result.thiefChildren();
+            double lossShare = (double) result.splitsLostAtRevalidation()
+                    / (result.splitsLostAtRevalidation() + result.thiefChildren());
+
+            rows.add(String.format(Locale.ROOT,
+                    "probe_page_ratio_bench arm=%s seed=%d victim=%d victim_share=%.4f stolen_keys=%d "
+                            + "splits=%d loss_share=%.4f serial=%.4f",
+                    SensingRaceProtocol.label(ARM), seed, victim, victimShare, stolenKeys, splits,
+                    lossShare, result.timeline().serialFraction()));
+
+            assertThat(victimShare)
+                    .as("%s: the fleet took the heavy leaf off the victim", leg)
+                    .isLessThan(VICTIM_SHARE_FLOOR);
+            assertThat(stolenKeys)
+                    .as("%s: what the thief carved off it actually drained", leg)
+                    .isPositive();
+            assertThat(lossShare)
+                    .as("%s: proposals survive re-validation here", leg)
+                    .isLessThan(PROPOSAL_LOSS_FLOOR);
+            assertThat(splits).as("%s: the fleet published more than the live ceiling", leg)
+                    .isGreaterThan(SPLITS_CEILING);
+            assertThat(result.timeline().serialFraction())
+                    .as("%s: the tail is not spent as one worker", leg)
+                    .isLessThan(SERIAL_FRACTION_FLOOR);
+        }
+        rows.forEach(System.out::println);
+    }
+
     private static PolicyRunResult run(List<byte[]> keys, long seed) {
+        return run(keys, seed, PolicyRunFixtures.LIVE_S3_LATENCY);
+    }
+
+    private static PolicyRunResult run(List<byte[]> keys, long seed, LatencyModel latency) {
         PolicyScenario scenario = PolicyRunFixtures
                 .scenario(SensingRaceProtocol.WORKERS, PolicyRunFixtures.MEASURED_TAIL_PAGE_SIZE,
-                        PolicyRunFixtures.LIVE_S3_LATENCY, PolicyRunFixtures.measuredCost())
+                        latency, PolicyRunFixtures.measuredCost())
                 .withSeed(seed)
                 .withEventLog(true);
         return SimExecutor.run(scenario, new ListingFixtureStore(keys),

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/SensingVariantParityTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/SensingVariantParityTest.java
@@ -105,12 +105,20 @@ class SensingVariantParityTest {
     }
 
     /**
-     * <b>The control leg installs no estimator, and decides exactly as an unsteered chain does.</b>
-     * {@code CURRENT} installs no estimator at all — the executor passes {@code null} and the engine
-     * keeps its own {@code WINDOW} reading — and this is the pin that the convergence of the two
-     * construction paths changed nothing there: the chain steered by this module's incumbent
-     * delegate decides identically to the chain nobody steered, on every view and every pool of the
-     * battery, down to the gate inputs.
+     * <b>The incumbent delegate decides exactly as an unsteered chain does.</b> This is the pin that
+     * the convergence of the two construction paths changed nothing there: the chain steered by this
+     * module's incumbent delegate decides identically to the chain nobody steered, on every view and
+     * every pool of the battery, down to the gate inputs.
+     *
+     * <p>Precisely what is compared: {@link SensingVariant#CURRENT} resolves to a
+     * {@code WindowEstimator}, so the steered leg here holds that delegate, not a literal
+     * {@code null}. That is the equivalence worth pinning — {@code WindowEstimator} forwards every
+     * method to {@link io.varve.swath.engine.StealMath}, the same arithmetic the engine falls back to
+     * when its seam is empty, so a drift in either would surface as a decision difference here. The
+     * <em>wiring</em> claim — that a shipped run really does leave the seam {@code null} rather than
+     * installing the incumbent under another name — is a different claim, and belongs to
+     * {@link #aRunsCountersNameTheSensorItsDecisionsWereTakenThrough}, which reads it off the run's
+     * own route counters.
      *
      * <p>Both legs are held at {@code tail_floor=current}, which since the 0.2.0 default flip is the
      * rollback arm rather than the shipped one. This is therefore a fixed-legacy-floor control for

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/SingleLegArmParsingTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/SingleLegArmParsingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sim.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link SingleLegRunTest#parseArm} in isolation — the perf harness itself is {@code @Tag("perf")}
+ * and skips without its {@code -D} properties, so its argument handling would otherwise never be
+ * exercised by a normal build.
+ *
+ * <p>The behaviour under test is a diagnostic-ergonomics fix: a mistyped arm used to surface as the
+ * bare {@code IllegalArgumentException} from {@link Enum#valueOf}, whose message names the bad input
+ * but none of the valid alternatives.
+ */
+class SingleLegArmParsingTest {
+
+    @Test
+    void aMistypedArmNamesEveryValidAlternative() {
+        assertThatThrownBy(() -> SingleLegRunTest.parseArm("RATE_ANCHORED_FLOOR_QUARTERR"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(SingleLegRunTest.ARM_PROPERTY)
+                .hasMessageContaining("RATE_ANCHORED_FLOOR_QUARTERR")
+                // the point of the fix: every alternative is offered, not just the rejection
+                .satisfies(e -> {
+                    for (SensingVariant v : SensingVariant.values()) {
+                        assertThat(e).hasMessageContaining(v.name());
+                    }
+                })
+                // the original cause stays reachable rather than being swallowed
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void aValidArmParsesAfterTrimmingAndCaseFolding() {
+        SensingVariant expected = SensingVariant.values()[0];
+        assertThat(SingleLegRunTest.parseArm("  " + expected.name().toLowerCase(Locale.ROOT) + "  "))
+                .isEqualTo(expected);
+    }
+}

--- a/swath-sim/src/test/java/io/varve/swath/sim/executor/SingleLegRunTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/executor/SingleLegRunTest.java
@@ -14,7 +14,9 @@ import io.varve.swath.sim.store.SimStoreConfig;
 import io.varve.swath.sim.store.SimStoreFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +63,7 @@ class SingleLegRunTest {
 
         Path fixture = Path.of(configured);
         assertThat(Files.exists(fixture)).as("fixture at %s", fixture).isTrue();
-        SensingVariant arm = SensingVariant.valueOf(armName.trim().toUpperCase(Locale.ROOT));
+        SensingVariant arm = parseArm(armName);
         long seed = Long.parseLong(System.getProperty(SEED_PROPERTY, "1"));
         int workers = Integer.parseInt(
                 System.getProperty(RealListingRunTest.WORKERS_PROPERTY,
@@ -87,6 +89,24 @@ class SingleLegRunTest {
                     arm, seed, workers, opened.resolvedBackend(), result.describe());
         } finally {
             store.close();
+        }
+    }
+
+    /**
+     * {@link SensingVariant#valueOf} on a mistyped arm throws {@code "No enum constant ..."}, which
+     * names what was wrong but not what would have been right. This harness is driven entirely by
+     * hand-typed {@code -D} properties at a shell, so the arm name is the likeliest thing to get
+     * wrong and the alternatives are the only thing worth printing.
+     */
+    static SensingVariant parseArm(String raw) {
+        String name = raw.trim().toUpperCase(Locale.ROOT);
+        try {
+            return SensingVariant.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "unknown -D%s=%s; valid arms: %s".formatted(ARM_PROPERTY, raw.trim(),
+                            Arrays.stream(SensingVariant.values()).map(Enum::name).collect(Collectors.joining(", "))),
+                    e);
         }
     }
 }


### PR DESCRIPTION
Closes the serial-tail campaign's housekeeping queue: punch-list rows 1–5, plus the
owner-decided `engine_toggles_effective` re-pin. No engine behaviour changes; one
operator-visible string does.

## ⚠️ Operator-visible: the `engine_toggles_effective` startup line

`logEngineTogglesIfNonDefault()` fires whenever any engine toggle deviates from its
default, and its text ended `not a supported configuration`. That was true when every
toggle was a research knob — but 0.2.0 flipped `rate_anchored_sensing` and `tail_floor`
to on-by-default, and the **documented** rollback to pre-0.2.0 behaviour is itself a
deviation. An operator following the supported downgrade path was told at startup that
their configuration is unsupported.

The line now scopes the warning to what it is actually about:

```
(non-default engine configuration — the rate_anchored_sensing/tail_floor pair is a
documented, supported rollback; every other toggle is an EXPERIMENTAL/DIAGNOSTIC
ablation surface, measurement only)
```

`EngineTogglesEffectiveLogIdentityTest` pins that template and moves with it in the same
commit. The `docs/usage.md` note that existed only to excuse the old wording is rewritten
— the line still prints, so operators will still ask why, but it no longer contradicts the
docs.

Anyone alerting on the literal trailing text will need to update their matcher.

## Punch-list rows

| # | Row | What landed |
|---|---|---|
| 1 | Executor-level confetti CAS-loss path untested | `OwnerSplitConfettiCasLossTest` |
| 2 | `RecordingTraceSink.putNum` duplicates `JsonlTraceSink.putNum` | consolidated into `GoldenTrace` |
| 3 | CURRENT-parity javadoc overstates | corrected to what the test drives |
| 4 | `SingleLegRunTest` bad arm name message | enumerates every valid arm + test |
| 5 | `ProbeToPageRatioTailTest` falsification documented, not run | it now runs |

**Row 1** — the governor decides PROBE purely from the `probeSeq` its view was built
from, so every owner sharing that snapshot returns a `Carve`; the executor resolves the
claim against the run-scoped gate and lets exactly one through (#31). Only the
uncontended half was pinned (`DecisionTraceGoldenTest` scenario 9). The losing path now
is: the loser's trace carries the **carve** the governor decided while its metric carries
`OWNER_SPLIT.confetti_suppressed` — correct at both layers, read together, so neither may
drift into agreeing with the other.

Deterministic rather than a hopeful race: `maybeOwnerSelfSplit` snapshots the gate
*before* it reads `outstanding`, so a supplier that barriers both callers between those
two points guarantees both snapshot the same `probeSeq` before either claims. The
`compareAndSet` then picks the winner — real mechanism, real seam, forced interleaving.

> **Row 1's premise was slightly wrong, and is corrected in the notes.** The finding said
> the loser's reason "stays `confetti_probe`". It does not — a carve's terminal reason is
> the *last* gate its path engaged, which on this shape is `pivot_reflect_clamped`, with
> `confetti_probe` recorded beside it as an engagement. The `owner-split-gates` golden's
> own scenario-9 deltas show both. The divergence the row is about survives intact; the
> test asserts it as "the same reason the winner traced, and not the suppression code", so
> it can't be invalidated by which pivot gate fires last on a given fixture.

**Row 2** — `JsonlTraceSink` keeps its own private copy, now with a note saying why: it is
production code and cannot depend on a test source set. That duplication is deliberate,
not missed, and the two must stay in step.

**Row 5** — same fixture, same four seeds, same arm, same fleet, same 1,000-key page; only
the latency profile moves, from the live 121/223 to the bench 35/110. Each live threshold
is asserted to *invert*, rather than pinning the recorded bands: the claim being protected
is that these readings are a property of the ratio, which is a claim about which side of a
threshold a run lands on. The run reproduced the documented table exactly — victim share
0.4025–0.5725 (documented 0.402–0.572), stolen keys 1001–1003, splits 39–61, loss share
0.7595–0.8226, serial fraction 0.0880–0.2114.

## Still open (deliberately not in scope)

- Rows 15 and 27 — `max-keys=0` rollup edge, all-bounded zero-case test. Disclosed
  coverage gaps, unchanged.
- Rows 23–26 — gate-masking diagnosis, non-linearizable `CarveMassRing`, split-blind mass
  signal, retracted load-independence claim. Redesign inputs, not housekeeping.

## Verification

`:swath-core:test :swath-sim:test :swath-cli:test` green locally. Row 5's leg is
`@Tag("perf")` and was run opt-in (`-PonlyPerf -PsimTestHeap=6g`) — both its methods pass.
Full-tier CI dispatch to follow **after** the PR run finishes, not alongside it (see #85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified CLI startup messages to distinguish the documented, supported rollback from experimental or diagnostic engine toggle combinations.
  * Improved simulator arm selection errors by trimming input, accepting case-insensitive values, and listing all valid arm options when an invalid value is provided.

* **Documentation**
  * Updated usage guidance to accurately explain expected engine toggle output and warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->