### PR TITLE
Harden launch surface and release integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,21 +12,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  source:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Release guard self-tests
+        run: |
+          ./scripts/ci/release-assets.sh --self-test
+          ./scripts/ci/verify-release-source.sh --self-test
+          ./scripts/ci/verify-release-notes.sh --self-test
+
+      # A release tag may point at main's parent because `just release` pushes the
+      # tagged release commit and the following SNAPSHOT commit together. Ancestor,
+      # rather than equality with origin/main, captures that intended topology.
+      - name: Verify tag SHA and origin/main ancestry
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+${GITHUB_REF}:refs/remotes/release/event-tag" \
+            +refs/heads/main:refs/remotes/origin/main
+          ./scripts/ci/verify-release-source.sh \
+            "$GITHUB_SHA" refs/remotes/release/event-tag refs/remotes/origin/main
+
+  fast-tests:
+    needs: source
     runs-on: ubuntu-latest
     timeout-minutes: 35
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Assert exact tag SHA checkout
+        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+      - name: Instrumentation-drift guard (§5)
+        run: ./scripts/ci/check-instrumentation-drift.sh
+
+      - name: Instrumentation-drift guard self-test (§5)
+        run: ./scripts/ci/check-instrumentation-drift.sh --self-test
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
         with:
           distribution: temurin
           java-version: "25"
 
+      # gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
+
       # gradle/actions/setup-gradle@v4
       - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
+        with:
+          cache-disabled: true
 
       # -PnoIntegration matches ci.yml's fast-tests EXACTLY, and that is the point: this
       # must be an invocation CI runs on every PR and every merge, so a release cannot
@@ -40,19 +86,32 @@ jobs:
       # release build flaky by construction: the first two v0.1.0 attempts failed on two
       # DIFFERENT timing assertions that both pass on main. See issue #62.
       #
-      # Integration coverage for the released commit comes from ci.yml's integration-tests
-      # job on main, and deep coverage from deep-tests — neither of which the release build
-      # ran even before this change.
+      # The sibling jobs below independently run integration and deep coverage on the
+      # same tag SHA; publish names all three jobs in its mechanical `needs` gate.
       - name: Verify tag and build the release once
         run: |
           ./gradlew verifyReleaseVersion build -PnoIntegration \
             :swath-cli:shadowJar :swath-cli:distZip :swath-cli:distTar \
             -PreleaseTag="${GITHUB_REF_NAME}" --no-daemon --stacktrace
 
+      - name: License compliance gate (allow-list)
+        run: ./gradlew checkLicense --no-daemon --stacktrace
+
       - id: version
         name: Read canonical version
         run: |
-          echo "version=$(./gradlew -q properties | sed -n 's/^version: //p' | head -1)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          version=$(./gradlew -q properties | sed -n 's/^version: //p')
+          if [[ -z "$version" || "$version" == *$'\n'* ]]; then
+            echo "expected exactly one non-empty canonical Gradle version" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify human release-note summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/ci/verify-release-notes.sh "$VERSION" docs/ops/dev/RELEASE_NOTES.md
 
       - name: Prepare container-promotion payload
         run: ./scripts/ci/prepare-container-promotion.sh promote
@@ -60,15 +119,9 @@ jobs:
       - name: Stage release assets
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          mkdir -p release-assets
-          # Versioned asset name: a bare swath.jar collides across releases in a
-          # download folder and makes SHA256SUMS lines ambiguous once several
-          # releases exist. The build output keeps its fixed name — the container
-          # promotion path depends on it (see the Dockerfile COPY).
-          cp swath-cli/build/libs/swath.jar "release-assets/swath-${VERSION}.jar"
-          cp swath-cli/build/distributions/swath-*.zip release-assets/
-          cp swath-cli/build/distributions/swath-*.tar.gz release-assets/
+        # Copies named application outputs only. Shadow's similarly named
+        # distributions are intentionally outside the public asset contract (#65).
+        run: ./scripts/ci/release-assets.sh stage "$VERSION" release-assets
 
       - name: Generate SPDX SBOM from the shipped jar
         # anchore/sbom-action@v0
@@ -79,7 +132,9 @@ jobs:
           output-file: release-assets/swath-${{ steps.version.outputs.version }}.spdx.json
 
       - name: Write SHA256SUMS for release assets
-        run: (cd release-assets && sha256sum swath-*.jar swath-*.zip swath-*.tar.gz *.spdx.json > SHA256SUMS)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/ci/release-assets.sh checksums "$VERSION" release-assets
 
       # actions/upload-artifact@v4
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -95,8 +150,98 @@ jobs:
           path: promote
           if-no-files-found: error
 
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: test-reports-release-fast
+          path: "*/build/reports/tests/"
+          if-no-files-found: ignore
+
+  integration-tests:
+    needs: source
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Assert exact tag SHA checkout
+        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      # gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
+        with:
+          cache-disabled: true
+
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          echo "efd0fccdb1a28d9ec7a6ebfcde59900068b8ba43a846c9b553c0fd2bbe4acf43  /tmp/duckdb.zip" | sha256sum --check -
+          unzip -o /tmp/duckdb.zip -d /tmp/duckdb
+          sudo install /tmp/duckdb/duckdb /usr/local/bin/duckdb
+          duckdb --version
+
+      - name: Integration tests only (Docker/LocalStack tier)
+        run: ./gradlew test -PonlyIntegration --no-daemon --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: test-reports-release-integration
+          path: "*/build/reports/tests/"
+          if-no-files-found: ignore
+
+  deep-tests:
+    needs: source
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Assert exact tag SHA checkout
+        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "${GITHUB_SHA}^{commit}")"
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      # gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
+        with:
+          cache-disabled: true
+
+      - name: Deep tier (schedule-sensitive + latency tests, serial)
+        run: ./gradlew test -Pdeep -PtestMaxParallelForks=1 --no-daemon --stacktrace
+
+      - name: Real kill -9 -> --resume exactly-once
+        run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeProcessIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Real kill -9 matrix -> --resume identical-to-clean
+        run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeMatrixIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: test-reports-release-deep
+          path: "*/build/reports/tests/"
+          if-no-files-found: ignore
+
   publish:
-    needs: build
+    needs: [source, fast-tests, integration-tests, deep-tests]
     # Publishing requires the repository to be public AND the PUBLIC_RELEASE_ENABLED
     # variable, which stays in place as an emergency kill-switch: unset it and tags
     # build assets without publishing anything, no code change required.
@@ -115,6 +260,12 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Assert exact tag SHA checkout
+        run: test "$(git rev-parse HEAD)" = "$(git rev-parse "${GITHUB_SHA}^{commit}")"
 
       # actions/download-artifact@v4
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -130,10 +281,10 @@ jobs:
 
       - name: Verify promoted artifacts
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ needs.fast-tests.outputs.version }}
         run: |
           ./scripts/ci/verify-container-promotion.sh promote "release-assets/swath-${VERSION}.jar"
-          (cd release-assets && sha256sum --check SHA256SUMS)
+          ./scripts/ci/release-assets.sh verify-unsigned "$VERSION" release-assets
 
       # docker/setup-buildx-action@v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -153,7 +304,7 @@ jobs:
       - id: kind
         name: Classify the release
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ needs.fast-tests.outputs.version }}
         run: |
           set -euo pipefail
           if [[ "$VERSION" == *-rc.* ]]; then
@@ -186,7 +337,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           labels: |
-            org.opencontainers.image.version=${{ needs.build.outputs.version }}
+            org.opencontainers.image.version=${{ needs.fast-tests.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           sbom: true
@@ -224,7 +375,7 @@ jobs:
           ARGS=()
           for tag in $TAGS; do ARGS+=(--tag "$tag"); done
           docker buildx imagetools create "${ARGS[@]}" "ghcr.io/${GITHUB_REPOSITORY}@${DIGEST}"
-          docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${{ needs.build.outputs.version }}"
+          docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${{ needs.fast-tests.outputs.version }}"
 
       - name: Install cosign
         # sigstore/cosign-installer@v3
@@ -238,14 +389,17 @@ jobs:
       # No COSIGN_EXPERIMENTAL: keyless has been GA since cosign 2.0 (2023) and the
       # variable is a no-op that only misleads readers.
       - name: Keylessly sign release assets and the image digest
+        env:
+          VERSION: ${{ needs.fast-tests.outputs.version }}
         run: |
           set -euo pipefail
-          for asset in release-assets/swath-*.jar release-assets/swath-*.zip \
-                       release-assets/swath-*.tar.gz release-assets/*.spdx.json \
-                       release-assets/SHA256SUMS; do
+          asset_list=$(./scripts/ci/release-assets.sh list-signable "$VERSION" release-assets)
+          mapfile -t assets <<< "$asset_list"
+          for asset in "${assets[@]}"; do
             cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
           done
           cosign sign --yes "ghcr.io/${GITHUB_REPOSITORY}@${{ steps.image.outputs.digest }}"
+          ./scripts/ci/release-assets.sh verify-signed "$VERSION" release-assets
 
       # Attestations answer a different question from the signatures above: not "are
       # these the bytes that were signed" but "which workflow, in which repo, at which
@@ -256,9 +410,9 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: |
-            release-assets/swath-*.jar
-            release-assets/swath-*.zip
-            release-assets/swath-*.tar.gz
+            release-assets/swath-${{ needs.fast-tests.outputs.version }}.jar
+            release-assets/swath-${{ needs.fast-tests.outputs.version }}.zip
+            release-assets/swath-${{ needs.fast-tests.outputs.version }}.tar.gz
             release-assets/SHA256SUMS
 
       # actions/attest-build-provenance@v4
@@ -273,8 +427,8 @@ jobs:
       - name: Attest the SBOM
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e
         with:
-          subject-path: release-assets/swath-${{ needs.build.outputs.version }}.jar
-          sbom-path: release-assets/swath-${{ needs.build.outputs.version }}.spdx.json
+          subject-path: release-assets/swath-${{ needs.fast-tests.outputs.version }}.jar
+          sbom-path: release-assets/swath-${{ needs.fast-tests.outputs.version }}.spdx.json
 
       # Created as a DRAFT. `gh release create` publishes the release and then uploads
       # assets, so a failure mid-upload would otherwise leave a live, incomplete
@@ -283,13 +437,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PRERELEASE: ${{ steps.kind.outputs.prerelease }}
+          VERSION: ${{ needs.fast-tests.outputs.version }}
         run: |
           set -euo pipefail
-          ARGS=(--draft --title "swath ${{ needs.build.outputs.version }}" --generate-notes)
+          release_notes=$(<docs/ops/dev/RELEASE_NOTES.md)
+          ARGS=(--draft --verify-tag --title "swath ${VERSION}" --generate-notes \
+                --notes "$release_notes")
           if [[ "$PRERELEASE" == "true" ]]; then
             ARGS+=(--prerelease)
           fi
-          gh release create "$GITHUB_REF_NAME" release-assets/* "${ARGS[@]}"
+          asset_list=$(./scripts/ci/release-assets.sh list-release "$VERSION" release-assets)
+          mapfile -t assets <<< "$asset_list"
+          gh release create "$GITHUB_REF_NAME" "${assets[@]}" "${ARGS[@]}"
 
       # Run the exact commands the docs tell users to run. If verification would fail
       # in a user's terminal, the release should be red here instead — a signature
@@ -301,6 +460,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           DIGEST: ${{ steps.image.outputs.digest }}
           IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+          VERSION: ${{ needs.fast-tests.outputs.version }}
         run: |
           set -euo pipefail
           # Verify what GitHub actually STORED, not the local copies we uploaded from.
@@ -309,6 +469,8 @@ jobs:
           # to catch. Download the draft's assets into a fresh directory and verify there.
           rm -rf release-verify
           gh release download "$GITHUB_REF_NAME" --dir release-verify
+
+          ./scripts/ci/release-assets.sh verify-signed "$VERSION" release-verify
 
           echo "::group::checksums (downloaded copies)"
           (cd release-verify && sha256sum --check SHA256SUMS)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,18 @@ submit changes.
 
 ## Building and testing
 
-swath is a multi-module Gradle build on **Java 25**. The Gradle wrapper pins the
-toolchain, so you do not need a matching JDK installed globally.
+swath is a multi-module Gradle build that requires **JDK 25**. The Gradle wrapper
+selects the project's toolchain, but you must have JDK 25 available to Gradle.
 
 ```sh
-./gradlew build          # compile + run the fast test tier + assemble artifacts
-./gradlew test           # fast test tier only
-./gradlew spotlessApply  # apply the SPDX license header to new/changed sources
+./gradlew build -PnoIntegration  # Docker-free fast contributor gate
+./gradlew build                  # ordinary integration gate (requires Docker/LocalStack)
+./gradlew test                   # fast test tier only
+./gradlew spotlessApply          # apply the SPDX license header to new/changed sources
 ```
 
 Some tests are gated behind opt-in tiers (`-Pdeep`, `-Pperf`, integration tests
-via Testcontainers). The fast tier is what runs per commit; see
+via Testcontainers). The Docker-free contributor gate is what to run per commit; see
 `docs/ops/dev/TESTING.md` for the full tier map.
 
 ## License headers
@@ -64,5 +65,5 @@ By contributing, you agree that your contributions are licensed under the
 
 1. Fork the repository and create a topic branch.
 2. Make your change with tests; keep commits focused and signed off (`-s`).
-3. Run `./gradlew build` and confirm it is green.
+3. Run `./gradlew build -PnoIntegration` and confirm the per-commit Docker-free gate is green.
 4. Open a pull request describing what changed and why.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,9 +51,14 @@ actually work.
 
 ## Cutting a release
 
-1. Make sure `main` is green and you are on a clean checkout of the commit you want to
+1. Draft the human summary in
+   [`docs/ops/dev/RELEASE_NOTES.md`](docs/ops/dev/RELEASE_NOTES.md): replace the version
+   in its title, fill all three sections, and commit it. Lead with what users will notice,
+   then the evidence for the release and its honest limits. The release recipe and workflow
+   reject an untouched or incomplete template.
+2. Make sure `main` is green and you are on a clean checkout of the commit you want to
    release.
-2. Prepare the release commits and tag:
+3. Prepare the release commits and tag:
    ```sh
    just release 0.2.0
    ```
@@ -66,16 +71,18 @@ actually work.
    second argument (`just release 0.2.0 0.3.0`); after an `-rc.N` the default returns to the
    same `X.Y.Z-SNAPSHOT`, since development continues toward that release. It does **not**
    push — review both commits first.
-3. Push to trigger the release pipeline — this sends both commits and the tag together:
-   ```
+4. Push to trigger the release pipeline — this sends both commits and the tag together:
+   ```sh
    git push origin main v0.2.0
    ```
-4. The `Release` workflow builds the assets once, generates checksums and an SBOM, and
-   then waits on the protected `public-release` environment. **Approve it.** The publish
-   job then pushes the image by digest, smokes that digest, tags it, signs and attests
-   everything, creates the GitHub release as a **draft**, runs the verification commands
-   below against what it just published, and only then un-drafts it. If verification
-   fails the release stays a draft — fix and re-tag rather than publishing by hand.
+5. The `Release` workflow first proves the tag commit is an ancestor of `origin/main`,
+   then runs the fast, integration, and deep tiers on that exact tag SHA. It builds the
+   assets once, generates checksums and an SBOM, and then waits on the protected
+   `public-release` environment. **Approve it.** The publish job then pushes the image by
+   digest, smokes that digest, tags it, signs and attests everything, creates the GitHub
+   release as a **draft**, runs the verification commands below against what it just
+   published, and only then un-drafts it. If verification fails the release stays a draft
+   — fix and re-tag rather than publishing by hand.
 
 ## What the pipeline produces
 
@@ -86,12 +93,14 @@ For each `vX.Y.Z` tag, once the environment is approved:
 - a `SHA256SUMS` file plus a per-asset keyless (cosign) signature bundle;
 - a multi-arch (`linux/amd64,linux/arm64`) container image built from the exact tested
   jar, signed and attested;
-- a GitHub release with auto-generated notes from the merged pull requests.
+- a GitHub release led by the repository-owned human summary, followed by generated notes
+  from the merged pull requests.
 
 ## Notes
 
-- Release notes are generated from merged PRs (`--generate-notes`); write PR titles with
-  that in mind.
+- GitHub appends generated merged-PR notes (`--generate-notes`) after the human summary;
+  write PR titles with that in mind, but do not use them as a substitute for the summary's
+  user-facing changes, evidence, and limits.
 - Choosing the version is manual by design (the canonical version lives in
   `gradle.properties`); `just release` wraps the mechanical steps so the tag and version
   cannot drift, and reopens the next `-SNAPSHOT` cycle in the same invocation.

--- a/docs/ops/dev/RELEASE_NOTES.md
+++ b/docs/ops/dev/RELEASE_NOTES.md
@@ -1,0 +1,19 @@
+<!--
+This is the tag-owned release summary template. Before `just release X.Y.Z`, replace
+X.Y.Z below, write concise user-facing content under every heading, and commit the file.
+The release recipe and workflow reject an untouched or incomplete template. GitHub puts
+this summary before its generated pull-request notes.
+-->
+# swath X.Y.Z
+
+## User-facing changes
+
+<!-- Describe observable improvements and any migration/action users need. -->
+
+## Evidence
+
+<!-- State the tests, benchmarks, or production evidence that support the release. -->
+
+## Limits and known issues
+
+<!-- Be explicit; "None known." is valid when that is the honest answer. -->

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,6 +199,18 @@ arbitrary SQLite path.
   is in flight. It is deleted on clean completion, so a finished dataset carries no
   checkpoint bookkeeping — only the artifacts above.
 
+Any pre-existing dataset root or `data/`, `_staging/`, and `.swath/` entry must
+not be a symbolic link; those three managed child entries must also be
+directories when present. swath's fixed checkpoint, marker, and
+atomic-temporary files must not be symbolic links. swath checks these paths
+without following links and refuses a link planted before startup, before it
+validates, creates, opens, lists, truncates, or deletes managed contents; remove
+the link or choose another output directory. Directory datasets use a
+single-process ownership model: concurrently replacing entries while swath is
+running is outside the supported threat model, so this startup refusal is not a
+claim of race safety against a hostile process mutating the dataset at the same
+time.
+
 **The output is a directory of parts — read it as one dataset.** The files
 under `data/` plus `manifest.json` *are* the deliverable, in the standard
 multi-part columnar layout every query engine reads transparently

--- a/justfile
+++ b/justfile
@@ -138,6 +138,7 @@ release VERSION NEXT="":
     if [[ ! "$next" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
         echo "error: NEXT must be a stable X.Y.Z (the -SNAPSHOT suffix is added for you); got '$next'" >&2; exit 2
     fi
+    ./scripts/ci/verify-release-notes.sh "{{VERSION}}" docs/ops/dev/RELEASE_NOTES.md
     sed -i -E 's/^version=.*/version={{VERSION}}/' gradle.properties
     git add gradle.properties
     git commit -m "Release v{{VERSION}}"

--- a/scripts/ci/release-assets.sh
+++ b/scripts/ci/release-assets.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Stage and verify the exact public release asset set. No release-facing glob belongs here:
+# Shadow also creates distributions, and a broad swath-* copy can silently publish them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+usage() {
+  echo "usage: $0 stage|checksums|verify-unsigned|verify-signed|list-signable|list-release <version> <asset-directory>" >&2
+  echo "       $0 --self-test" >&2
+  exit 2
+}
+
+validate_version() {
+  [[ $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]] || {
+    echo "invalid release version: $1" >&2
+    exit 2
+  }
+}
+
+payload_names() {
+  local version=$1
+  printf '%s\n' \
+    "swath-${version}.jar" \
+    "swath-${version}.spdx.json" \
+    "swath-${version}.tar.gz" \
+    "swath-${version}.zip"
+}
+
+unsigned_names() {
+  local version=$1
+  payload_names "$version"
+  printf '%s\n' SHA256SUMS
+}
+
+signed_names() {
+  local version=$1 name
+  while IFS= read -r name; do
+    printf '%s\n' "$name" "${name}.sigstore.json"
+  done < <(unsigned_names "$version")
+}
+
+assert_exact() {
+  local version=$1 directory=$2 set_name=$3 expected actual name
+  [[ -d $directory ]] || { echo "release asset directory does not exist: $directory" >&2; exit 1; }
+
+  case "$set_name" in
+    payload) expected=$(payload_names "$version" | LC_ALL=C sort) ;;
+    unsigned) expected=$(unsigned_names "$version" | LC_ALL=C sort) ;;
+    signed) expected=$(signed_names "$version" | LC_ALL=C sort) ;;
+    *) usage ;;
+  esac
+  actual=$(
+    shopt -s nullglob dotglob
+    entries=("$directory"/*)
+    ((${#entries[@]} == 0)) || printf '%s\n' "${entries[@]##*/}"
+  )
+  actual=$(printf '%s\n' "$actual" | LC_ALL=C sort)
+  if [[ $actual != "$expected" ]]; then
+    echo "release asset set is not exact ($set_name expected)" >&2
+    diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
+    exit 1
+  fi
+
+  while IFS= read -r name; do
+    [[ -f "$directory/$name" && ! -L "$directory/$name" && -s "$directory/$name" ]] || {
+      echo "release asset is not a non-empty regular file: $name" >&2
+      exit 1
+    }
+  done <<< "$expected"
+}
+
+stage() {
+  local version=$1 directory=$2 root=${SWATH_RELEASE_ROOT:-$REPO_ROOT}
+  local jar="$root/swath-cli/build/libs/swath.jar"
+  local zip="$root/swath-cli/build/distributions/swath-${version}.zip"
+  local tar="$root/swath-cli/build/distributions/swath-${version}.tar.gz"
+  [[ ! -e $directory ]] || { echo "release asset directory already exists: $directory" >&2; exit 1; }
+  for source in "$jar" "$zip" "$tar"; do
+    [[ -f $source && -s $source ]] || { echo "release build output missing or empty: $source" >&2; exit 1; }
+  done
+  mkdir -p "$directory"
+  cp -- "$jar" "$directory/swath-${version}.jar"
+  cp -- "$zip" "$directory/swath-${version}.zip"
+  cp -- "$tar" "$directory/swath-${version}.tar.gz"
+}
+
+self_test() {
+  local scratch version=1.2.3 assets=assets name
+  scratch=$(mktemp -d)
+  SELF_TEST_SCRATCH=$scratch
+  trap 'rm -rf -- "${SELF_TEST_SCRATCH:?}"' EXIT
+  mkdir -p "$scratch/swath-cli/build/libs" "$scratch/swath-cli/build/distributions"
+  printf jar > "$scratch/swath-cli/build/libs/swath.jar"
+  printf zip > "$scratch/swath-cli/build/distributions/swath-${version}.zip"
+  printf tar > "$scratch/swath-cli/build/distributions/swath-${version}.tar.gz"
+  # This is the issue #65 regression fixture: it must remain outside the staged set.
+  printf shadow > "$scratch/swath-cli/build/distributions/swath-cli-shadow-${version}.zip"
+  SWATH_RELEASE_ROOT=$scratch "$0" stage "$version" "$scratch/$assets"
+  printf sbom > "$scratch/$assets/swath-${version}.spdx.json"
+  "$0" checksums "$version" "$scratch/$assets"
+  "$0" verify-unsigned "$version" "$scratch/$assets"
+  while IFS= read -r name; do
+    printf bundle > "${name}.sigstore.json"
+  done < <("$0" list-signable "$version" "$scratch/$assets")
+  "$0" verify-signed "$version" "$scratch/$assets"
+  printf unwanted > "$scratch/$assets/swath-${version}-shadow.zip"
+  if "$0" verify-signed "$version" "$scratch/$assets" >/dev/null 2>&1; then
+    echo "self-test failed: an unexpected asset was accepted" >&2
+    exit 1
+  fi
+  echo "release asset self-test passed"
+}
+
+[[ $# -gt 0 ]] || usage
+if [[ $1 == --self-test ]]; then
+  [[ $# -eq 1 ]] || usage
+  self_test
+  exit
+fi
+[[ $# -eq 3 ]] || usage
+command=$1 version=$2 directory=$3
+validate_version "$version"
+
+case "$command" in
+  stage)
+    stage "$version" "$directory"
+    ;;
+  checksums)
+    assert_exact "$version" "$directory" payload
+    (cd "$directory" && sha256sum \
+      "swath-${version}.jar" "swath-${version}.spdx.json" \
+      "swath-${version}.tar.gz" "swath-${version}.zip" > SHA256SUMS)
+    assert_exact "$version" "$directory" unsigned
+    ;;
+  verify-unsigned)
+    assert_exact "$version" "$directory" unsigned
+    (cd "$directory" && sha256sum --check --status SHA256SUMS) || {
+      echo "release asset checksum verification failed" >&2
+      exit 1
+    }
+    ;;
+  verify-signed)
+    assert_exact "$version" "$directory" signed
+    (cd "$directory" && sha256sum --check --status SHA256SUMS) || {
+      echo "release asset checksum verification failed" >&2
+      exit 1
+    }
+    ;;
+  list-signable)
+    assert_exact "$version" "$directory" unsigned
+    while IFS= read -r name; do printf '%s/%s\n' "$directory" "$name"; done < <(unsigned_names "$version")
+    ;;
+  list-release)
+    assert_exact "$version" "$directory" signed
+    while IFS= read -r name; do printf '%s/%s\n' "$directory" "$name"; done < <(signed_names "$version")
+    ;;
+  *) usage ;;
+esac

--- a/scripts/ci/verify-release-notes.sh
+++ b/scripts/ci/verify-release-notes.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Require a tag-bound human summary before generated pull-request notes are appended.
+set -euo pipefail
+
+verify() {
+  local version=$1 notes=$2
+  [[ -f $notes ]] || { echo "release notes file does not exist: $notes" >&2; return 1; }
+  awk -v title="# swath ${version}" '
+    BEGIN {
+      required[1] = "## User-facing changes"
+      required[2] = "## Evidence"
+      required[3] = "## Limits and known issues"
+    }
+    {
+      line = $0
+      visible = ""
+      while (length(line)) {
+        if (in_comment) {
+          comment_end = index(line, "-->")
+          if (!comment_end) { line = ""; break }
+          line = substr(line, comment_end + 3)
+          in_comment = 0
+        }
+        comment_start = index(line, "<!--")
+        if (!comment_start) { visible = visible line; break }
+        visible = visible substr(line, 1, comment_start - 1)
+        line = substr(line, comment_start + 4)
+        in_comment = 1
+      }
+      $0 = visible
+    }
+    /^# / && !saw_title++ { if ($0 != title) error = "first H1 must be exactly: " title }
+    /^## / {
+      section++
+      if (section > 3 || $0 != required[section]) error = "required H2 sections are missing or out of order"
+      next
+    }
+    section > 0 && $0 !~ /^[[:space:]]*$/ && $0 !~ /^[[:space:]]*<!--/ { content[section] = 1 }
+    END {
+      if (!saw_title) error = "release notes need an H1 title"
+      if (section != 3) error = "release notes need exactly the three required H2 sections"
+      for (i = 1; i <= 3; i++) if (!content[i]) error = required[i] " has no human-authored content"
+      if (error) { print error > "/dev/stderr"; exit 1 }
+    }
+  ' "$notes"
+}
+
+self_test() {
+  local scratch
+  scratch=$(mktemp -d)
+  SELF_TEST_SCRATCH=$scratch
+  trap 'rm -rf -- "${SELF_TEST_SCRATCH:?}"' EXIT
+  printf '%s\n' '# swath 1.2.3' '' '## User-facing changes' '- Faster listing.' '' \
+    '## Evidence' '- Benchmarked on representative data.' '' '## Limits and known issues' '- None known.' > "$scratch/good.md"
+  verify 1.2.3 "$scratch/good.md"
+  printf '%s\n' '# swath X.Y.Z' '' '## User-facing changes' '<!-- write this -->' '' \
+    '## Evidence' '<!-- write this -->' '' '## Limits and known issues' '<!-- write this -->' > "$scratch/template.md"
+  if verify 1.2.3 "$scratch/template.md" >/dev/null 2>&1; then
+    echo "self-test failed: untouched template was accepted" >&2
+    exit 1
+  fi
+  printf '%s\n' '# swath 1.2.3' '' '## User-facing changes' '<!--' 'placeholder text' '-->' '' \
+    '## Evidence' '<!--' 'placeholder text' '-->' '' '## Limits and known issues' '<!--' 'placeholder text' '-->' > "$scratch/multiline-comments.md"
+  if verify 1.2.3 "$scratch/multiline-comments.md" >/dev/null 2>&1; then
+    echo "self-test failed: text inside multi-line comments counted as release-note content" >&2
+    exit 1
+  fi
+  echo "release notes self-test passed"
+}
+
+if [[ ${1:-} == --self-test ]]; then
+  [[ $# -eq 1 ]] || { echo "usage: $0 --self-test | <version> <notes-file>" >&2; exit 2; }
+  self_test
+elif [[ $# -eq 2 ]]; then
+  [[ $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.[1-9][0-9]*)?$ ]] || {
+    echo "invalid release version: $1" >&2
+    exit 2
+  }
+  verify "$1" "$2"
+else
+  echo "usage: $0 --self-test | <version> <notes-file>" >&2
+  exit 2
+fi

--- a/scripts/ci/verify-release-source.sh
+++ b/scripts/ci/verify-release-source.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Prove that a release job is testing the tag commit itself and that it belongs to main.
+set -euo pipefail
+
+verify() {
+  local expected=$1 tag_ref=$2 main_ref=$3 head tag_commit
+  head=$(git rev-parse --verify 'HEAD^{commit}')
+  expected=$(git rev-parse --verify "${expected}^{commit}")
+  tag_commit=$(git rev-parse --verify "${tag_ref}^{commit}")
+  [[ $head == "$expected" ]] || {
+    echo "checkout HEAD $head does not equal event SHA $expected" >&2
+    return 1
+  }
+  [[ $tag_commit == "$expected" ]] || {
+    echo "tag $tag_ref resolves to $tag_commit, not event SHA $expected" >&2
+    return 1
+  }
+  git rev-parse --verify "${main_ref}^{commit}" >/dev/null
+  git merge-base --is-ancestor "$expected" "$main_ref" || {
+    echo "tag commit $expected is not an ancestor of $main_ref" >&2
+    return 1
+  }
+  echo "release source verified: $tag_ref -> $expected; ancestor of $main_ref"
+}
+
+self_test() {
+  local scratch release
+  scratch=$(mktemp -d)
+  SELF_TEST_SCRATCH=$scratch
+  trap 'rm -rf -- "${SELF_TEST_SCRATCH:?}"' EXIT
+  git -C "$scratch" init -q -b main
+  git -C "$scratch" config user.name test
+  git -C "$scratch" config user.email test@example.invalid
+  git -C "$scratch" commit -q --allow-empty -m base
+  git -C "$scratch" commit -q --allow-empty -m release
+  release=$(git -C "$scratch" rev-parse HEAD)
+  git -C "$scratch" tag -a v1.2.3 -m v1.2.3
+  git -C "$scratch" commit -q --allow-empty -m snapshot
+  git -C "$scratch" checkout -q --detach "$release"
+  (cd "$scratch" && verify "$release" refs/tags/v1.2.3 refs/heads/main) >/dev/null
+  if (cd "$scratch" && verify HEAD^ refs/tags/v1.2.3 refs/heads/main) >/dev/null 2>&1; then
+    echo "self-test failed: mismatched event SHA was accepted" >&2
+    exit 1
+  fi
+  git -C "$scratch" branch unrelated HEAD^
+  git -C "$scratch" checkout -q unrelated
+  git -C "$scratch" commit -q --allow-empty -m unrelated
+  git -C "$scratch" checkout -q --detach "$release"
+  if (cd "$scratch" && verify "$release" refs/tags/v1.2.3 refs/heads/unrelated) >/dev/null 2>&1; then
+    echo "self-test failed: tag outside main ancestry was accepted" >&2
+    exit 1
+  fi
+  echo "release source self-test passed"
+}
+
+if [[ ${1:-} == --self-test ]]; then
+  [[ $# -eq 1 ]] || { echo "usage: $0 --self-test | <expected-sha> <tag-ref> <main-ref>" >&2; exit 2; }
+  self_test
+elif [[ $# -eq 3 ]]; then
+  verify "$1" "$2" "$3"
+else
+  echo "usage: $0 --self-test | <expected-sha> <tag-ref> <main-ref>" >&2
+  exit 2
+fi

--- a/swath-cli/src/main/java/io/varve/swath/cli/App.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/App.java
@@ -31,6 +31,7 @@ import picocli.CommandLine.UnmatchedArgumentException;
         mixinStandardHelpOptions = true,
         versionProvider = App.VersionProvider.class,
         description = "High-performance object-store lister.",
+        footer = "Built by Varve: https://varve.io",
         subcommands = {
                 ListCommand.class,
                 ResumeCommand.class,
@@ -39,7 +40,10 @@ import picocli.CommandLine.UnmatchedArgumentException;
         })
 public final class App implements Callable<Integer>, GlobalOptions.Carrier {
 
-    /** Keeps {@code --version} aligned with the Gradle archive manifest. */
+    /**
+     * Provides the five factual {@code --version} lines: stable name/version, Varve attribution,
+     * source repository, commit, and Java runtime.
+     */
     public static final class VersionProvider implements CommandLine.IVersionProvider {
         /** Manifest attribute stamped by the build (see {@code swath.java-conventions.gradle.kts}). */
         private static final String COMMIT_ATTRIBUTE = "Implementation-Commit";
@@ -47,26 +51,43 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
         /** Displayed commit length — enough to be unambiguous, short enough to read. */
         private static final int SHORT_COMMIT_LENGTH = 12;
 
+        private static final String BRAND_LINE = "Built by Varve: https://varve.io";
+        private static final String SOURCE_LINE = "Source: https://github.com/varveio/swath";
+
         @Override
         public String[] getVersion() {
-            return new String[] {
-                format(App.class.getPackage().getImplementationVersion(), readCommit())
-            };
+            return format(App.class.getPackage().getImplementationVersion(), readCommit(), runtimeVersion());
         }
 
         /**
-         * Renders the version line. Package-private and pure so the formatting is testable
-         * without a packaged jar to read a manifest from.
+         * Renders the five version-information lines. The first is stable ASCII {@code swath
+         * X.Y.Z}; a missing commit is rendered as {@code Commit: unavailable}. Package-private
+         * and pure so the formatting is testable without a packaged jar to read a manifest from.
          *
          * @param version the manifest's {@code Implementation-Version}, or null outside a jar
          * @param commit the manifest's {@code Implementation-Commit}, or null when unavailable
+         * @param runtime the current Java runtime version
          */
-        static String format(String version, String commit) {
+        static String[] format(String version, String commit, String runtime) {
             String line = "swath " + (version == null ? "development" : version);
+            return new String[] {
+                line,
+                BRAND_LINE,
+                SOURCE_LINE,
+                "Commit: " + displayCommit(commit),
+                "Runtime: " + runtime,
+            };
+        }
+
+        private static String displayCommit(String commit) {
             if (commit == null || commit.isBlank() || commit.equals("unknown")) {
-                return line;
+                return "unavailable";
             }
-            return line + " (" + commit.substring(0, Math.min(SHORT_COMMIT_LENGTH, commit.length())) + ")";
+            return commit.substring(0, Math.min(SHORT_COMMIT_LENGTH, commit.length()));
+        }
+
+        private static String runtimeVersion() {
+            return System.getProperty("java.runtime.version", System.getProperty("java.version"));
         }
 
         /**
@@ -74,8 +95,8 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
          *
          * <p>{@code Package.getImplementationVersion()} only exposes the standard version
          * attribute, so the manifest is opened directly. Running from a classes directory
-         * (development, tests) has no jar and yields null, which {@link #format} renders as a
-         * bare version line — so this degrades rather than failing.
+         * (development, tests) has no jar and yields null, which {@link #format} renders as
+         * {@code Commit: unavailable}; version reporting therefore degrades rather than failing.
          */
         private static String readCommit() {
             try {

--- a/swath-cli/src/main/java/io/varve/swath/cli/DatasetDirGuard.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/DatasetDirGuard.java
@@ -10,7 +10,11 @@ import io.varve.swath.output.parquet.DatasetLayout;
 import io.varve.swath.output.parquet.Manifest;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -50,6 +54,7 @@ import org.slf4j.LoggerFactory;
 final class DatasetDirGuard {
 
     private static final Logger log = LoggerFactory.getLogger(DatasetDirGuard.class);
+    private static final String ATOMIC_WRITE_TMP_SUFFIX = ".tmp";
 
     private DatasetDirGuard() {
     }
@@ -78,10 +83,11 @@ final class DatasetDirGuard {
      */
     static void guardFreshRunDatasetDir(Path outputDir, boolean overwrite, boolean restart)
             throws InvalidArgsException, IOException {
-        if (!Files.exists(outputDir)) {
+        requireNoManagedSymlinks(outputDir);
+        if (!Files.exists(outputDir, LinkOption.NOFOLLOW_LINKS)) {
             return;   // absent -> created + run
         }
-        if (!Files.isDirectory(outputDir)) {
+        if (!Files.isDirectory(outputDir, LinkOption.NOFOLLOW_LINKS)) {
             throw new InvalidArgsException("-o " + outputDir + " is a file, not a dataset directory; "
                     + "point -o at a new or empty directory (or a .parquet single-file destination)");
         }
@@ -123,6 +129,97 @@ final class DatasetDirGuard {
         throw new InvalidArgsException(outputDir + " is not empty and holds no swath dataset (no "
                 + "valid manifest.json or .swath-state.json); refusing to write into it — point -o at "
                 + "a new or empty directory, or remove its contents first");
+    }
+
+    /**
+     * Refuse a pre-existing symbolic link at the managed dataset root, at a managed directory, or
+     * at a fixed file path that swath may open or truncate. The attributes are deliberately read
+     * with {@link LinkOption#NOFOLLOW_LINKS}: following first and checking the target would turn a
+     * link to a directory into an apparently-valid dataset and let validation, checkpoint creation, or a
+     * lifecycle sweep escape the requested root.
+     *
+     * <p>This is the common precondition for every managed-path entry point in this class and for
+     * {@link ListCommand}'s checkpoint opening. It protects the supported case of links planted
+     * before swath starts. It is not a claim that a concurrently-hostile process cannot swap a
+     * checked directory entry afterward; directory datasets have a single-process ownership model.
+     */
+    static void requireNoManagedSymlinks(Path outputDir)
+            throws InvalidArgsException, IOException {
+        BasicFileAttributes rootAttributes = readAttributesNoFollowIfExists(outputDir);
+        if (rootAttributes == null) {
+            return;
+        }
+        if (rootAttributes.isSymbolicLink()) {
+            throw symlinkRefusal(outputDir, "dataset root");
+        }
+        if (!rootAttributes.isDirectory()) {
+            return;   // guardFreshRunDatasetDir supplies the more specific file-vs-directory steer
+        }
+        DatasetLayout layout = DatasetLayout.of(outputDir);
+        List<Path> managedDirectories = List.of(
+                layout.dataDir(),
+                outputDir.resolve(ListCommand.SORT_STAGING_DIR),
+                outputDir.resolve(CheckpointOptions.COLOCATED_DIR));
+        for (Path managedPath : managedDirectories) {
+            BasicFileAttributes attributes = readAttributesNoFollowIfExists(managedPath);
+            if (attributes != null && attributes.isSymbolicLink()) {
+                throw symlinkRefusal(managedPath, "managed dataset directory");
+            }
+            if (attributes != null && !attributes.isDirectory()) {
+                throw new InvalidArgsException("managed dataset path " + managedPath
+                        + " is not a directory; refusing to use it as swath-managed storage — "
+                        + "remove the file and restore a real directory, or choose a different -o directory");
+            }
+        }
+
+        Path checkpoint = CheckpointOptions.CheckpointMode.colocatedCheckpoint(outputDir);
+        for (Path sqliteFile : List.of(
+                checkpoint,
+                withSuffix(checkpoint, "-wal"),
+                withSuffix(checkpoint, "-shm"),
+                withSuffix(checkpoint, "-journal"))) {
+            requireNotSymlink(sqliteFile, "managed checkpoint file");
+        }
+
+        // Atomic writers truncate their fixed .tmp path before renaming it over the final marker.
+        // The final manifest/state markers are also read during validation and resume. Check both
+        // forms without following them so neither read nor truncate can escape the dataset root.
+        List<Path> rootArtifacts = List.of(
+                layout.manifest(), layout.state(), layout.success(), layout.symlink());
+        for (Path artifact : rootArtifacts) {
+            requireNotSymlink(artifact, "managed dataset artifact");
+            requireNotSymlink(withSuffix(artifact, ATOMIC_WRITE_TMP_SUFFIX),
+                    "managed dataset atomic-write temporary file");
+        }
+        requireNotSymlink(
+                outputDir.resolve(OutputOptions.DEFAULT_SUMMARY_JSON_NAME + ATOMIC_WRITE_TMP_SUFFIX),
+                "managed dataset summary temporary file");
+    }
+
+    private static void requireNotSymlink(Path path, String role)
+            throws InvalidArgsException, IOException {
+        BasicFileAttributes attributes = readAttributesNoFollowIfExists(path);
+        if (attributes != null && attributes.isSymbolicLink()) {
+            throw symlinkRefusal(path, role);
+        }
+    }
+
+    private static Path withSuffix(Path path, String suffix) {
+        return path.resolveSibling(path.getFileName().toString() + suffix);
+    }
+
+    private static BasicFileAttributes readAttributesNoFollowIfExists(Path path) throws IOException {
+        try {
+            return Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        } catch (NoSuchFileException e) {
+            return null;
+        }
+    }
+
+    private static InvalidArgsException symlinkRefusal(Path path, String role) {
+        return new InvalidArgsException(role + " " + path + " is a symbolic link; refusing to "
+                + "access it as swath-managed storage — remove the link and restore a real directory, "
+                + "or choose a different -o directory");
     }
 
     private static boolean isEmptyDir(Path dir) throws IOException {
@@ -172,11 +269,19 @@ final class DatasetDirGuard {
     }
 
     private static boolean dataDirHoldsOnlyOwnedParts(Path dataDir) throws IOException {
-        if (!Files.isDirectory(dataDir)) {
+        BasicFileAttributes dataAttributes = readAttributesNoFollowIfExists(dataDir);
+        if (dataAttributes == null || !dataAttributes.isDirectory()) {
             return false;   // data/ is a plain file -> foreign
         }
         try (Stream<Path> parts = Files.list(dataDir)) {
-            return parts.allMatch(p -> isSwathOwnedPart(p.getFileName().toString()));
+            for (Path part : parts.toList()) {
+                BasicFileAttributes attributes = readAttributesNoFollowIfExists(part);
+                if (attributes == null || attributes.isSymbolicLink()
+                        || !isSwathOwnedPart(part.getFileName().toString())) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 
@@ -192,7 +297,8 @@ final class DatasetDirGuard {
      * sort path owns it). The foreign/damaged-dir refusal ({@link #guardFreshRunDatasetDir}) has
      * already run for a genuine CLI invocation, so by here the dataset is swath-owned or empty.
      */
-    static void clearDatasetForFreshRun(Path outputDir) throws IOException {
+    static void clearDatasetForFreshRun(Path outputDir) throws IOException, InvalidArgsException {
+        requireNoManagedSymlinks(outputDir);
         DatasetLayout layout =
                 DatasetLayout.of(outputDir);
         Files.deleteIfExists(layout.success());
@@ -251,6 +357,12 @@ final class DatasetDirGuard {
             return;
         }
         Path outputDir = Path.of(destination);
+        try {
+            requireNoManagedSymlinks(outputDir);
+        } catch (InvalidArgsException | IOException e) {
+            log.warn("colocated_checkpoint_delete_refused path={} message={}", dbPath, e.getMessage());
+            return;
+        }
         Path colocated = CheckpointOptions.CheckpointMode.colocatedCheckpoint(outputDir)
                 .toAbsolutePath().normalize();
         if (!colocated.equals(dbPath.toAbsolutePath().normalize()) || !isCompletedDataset(outputDir)) {

--- a/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
@@ -587,6 +587,20 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
         // first LIST is otherwise invisible, since RunProgressReporter only starts once ListRunner's
         // engine dispatch is entered (well after seeding).
         long runStartedNs = System.nanoTime();
+        // A managed directory's co-located checkpoint is the first path runWithCheckpoint touches.
+        // Refuse a pre-existing link at the root/data/_staging/.swath boundary before mode.resolve
+        // derives <dir>/.swath/checkpoint.sqlite and before createDirectories/open can follow it.
+        // swath resume supplies the run handle explicitly even though its output destination is
+        // restored later from the checkpoint.
+        Path preCheckpointDatasetDir = resumeCommandRunHandle;
+        if (preCheckpointDatasetDir == null && resolved == OutputFormat.PARQUET
+                && output.resolvedKind == OutputOptions.DestinationKind.DIRECTORY
+                && output.destination != null) {
+            preCheckpointDatasetDir = Path.of(output.destination);
+        }
+        if (preCheckpointDatasetDir != null) {
+            DatasetDirGuard.requireNoManagedSymlinks(preCheckpointDatasetDir);
+        }
         Path dbPath = mode.resolve(output.destination, output.resolvedKind);
         boolean ephemeral = dbPath == null;
         // The start marker now carries W (max_parallel_listings) and whether every engine
@@ -704,6 +718,15 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
                                 && output.resolvedKind != OutputOptions.DestinationKind.STDOUT)) {
                     output.echoResolvedOutput(new OutputOptions.Resolved(resolved, output.resolvedKind),
                             System.err, quiet);
+                }
+                // An explicit checkpoint can restore its output directory only after the DB opens.
+                // It is not managed checkpoint storage, but its restored dataset paths still are:
+                // reject them before summary, staging, part validation, or output access.
+                if (resumeCommandRunHandle == null
+                        && resolved == OutputFormat.PARQUET
+                        && output.resolvedKind == OutputOptions.DestinationKind.DIRECTORY
+                        && output.destination != null) {
+                    DatasetDirGuard.requireNoManagedSymlinks(Path.of(output.destination));
                 }
             }
             // Build config AFTER any resume-context restore (region/profile/no-sign), and BEFORE the
@@ -1326,10 +1349,14 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
         // Sample free space on the volume that takes the write load — sort-staging segments +
         // Parquet parts both live under outputDir (a prior incident crashed on sort-segment disk exhaustion).
         ctx.metrics().registerDiskFreeGauge(outputDir);
+        Path stagingDir = outputDir.resolve(SORT_STAGING_DIR);
         if (!run.resumed()) {
             DatasetDirGuard.clearDatasetForFreshRun(outputDir);   // never inherit a stale dataset's markers/parts
+            // A fresh/--restart run owns no prior staging entry. Unlink the old run's immediate
+            // entries before deterministic segment writers can open any name with TRUNCATE_EXISTING;
+            // this is deliberately fresh-only, so resume retains checkpoint-finalized segments.
+            clearSortStagingContents(outputDir, stagingDir);
         }
-        Path stagingDir = outputDir.resolve(SORT_STAGING_DIR);
         Files.createDirectories(stagingDir);
         ListRunner.ParquetSpec parquetSpec = parquetSpec(s3uri, channelCapacity, pageMax, filterChain, argsHash, config);
         SortConfig sortConfig = SortConfig.fromSystemProperties();
@@ -1423,19 +1450,32 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
     }
 
     /**
-     * PUBLISHED re-entry clean-up (contract §6): a crash between the manifest write and the staging
-     * deletion leaves double data — remove the staging segments and any stale {@code part-*.tmp}.
-     * The sorter only ever deletes content it owns inside the staging dir. The stale
-     * {@code *.tmp} finals live under {@code <root>/data/} (the pure-parquet subdir).
+     * Unlink every immediate entry in the sorter-owned staging directory. A fresh/--restart run
+     * calls this before any deterministic segment name can be opened; a PUBLISHED re-entry uses it
+     * to remove the prior run's durable segments. Resume-mid-listing does not call it because its
+     * checkpoint-finalized segments must survive.
      */
-    static void cleanSortStagingAndStaleTmp(Path outputDir,
-                                            Path stagingDir) throws IOException {
+    private static void clearSortStagingContents(Path outputDir, Path stagingDir)
+            throws IOException, InvalidArgsException {
+        DatasetDirGuard.requireNoManagedSymlinks(outputDir);
         if (Files.isDirectory(stagingDir)) {
             try (Stream<Path> entries = Files.list(stagingDir)) {
                 for (Path p : entries.toList()) {
                     Files.deleteIfExists(p);
                 }
             }
+        }
+    }
+
+    /**
+     * PUBLISHED re-entry clean-up (contract §6): a crash between the manifest write and the staging
+     * deletion leaves double data — remove staging and any stale {@code part-*.tmp} finals under the
+     * pure-parquet {@code <root>/data/} directory.
+     */
+    static void cleanSortStagingAndStaleTmp(Path outputDir,
+                                            Path stagingDir) throws IOException, InvalidArgsException {
+        clearSortStagingContents(outputDir, stagingDir);
+        if (Files.isDirectory(stagingDir)) {
             Files.deleteIfExists(stagingDir);
         }
         Path dataDir = DatasetLayout.of(outputDir).dataDir();

--- a/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ResumeCommand.java
@@ -129,6 +129,10 @@ public final class ResumeCommand implements Callable<Integer>, GlobalOptions.Car
         }
 
         if (directory != null) {
+            // The run handle and its .swath/ child are managed storage. Refuse a pre-existing
+            // symbolic link before even deriving/probing checkpoint.sqlite, so resume never reads
+            // a checkpoint outside the requested dataset through either link.
+            DatasetDirGuard.requireNoManagedSymlinks(directory);
             Path colocated = CheckpointOptions.CheckpointMode.colocatedCheckpoint(directory);
             if (!Files.isRegularFile(colocated) || Files.size(colocated) == 0L) {
                 // No live checkpoint under the run handle: a COMPLETE dataset (its checkpoint was

--- a/swath-cli/src/test/java/io/varve/swath/cli/AppCliTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/AppCliTest.java
@@ -37,7 +37,11 @@ class AppCliTest {
         int[] exit = new int[1];
         String text = run(exit, "--version");
         assertThat(exit[0]).isZero();
-        assertThat(text).isEqualTo("swath development" + System.lineSeparator());
+        assertThat(text).startsWith("swath development" + System.lineSeparator())
+                .contains("Built by Varve: https://varve.io")
+                .contains("Source: https://github.com/varveio/swath")
+                .contains("Commit: unavailable")
+                .contains("Runtime: ");
     }
 
     @Test
@@ -108,6 +112,7 @@ class AppCliTest {
         assertThat(exit[0]).isZero();
         assertThat(text).contains("list").contains("resume");
         assertThat(text).doesNotContain("completion");
+        assertThat(text).endsWith("Built by Varve: https://varve.io" + System.lineSeparator());
     }
 
     @Test

--- a/swath-cli/src/test/java/io/varve/swath/cli/DatasetSymlinkSafetyTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DatasetSymlinkSafetyTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.varve.swath.checkpoint.NodeSpec;
+import io.varve.swath.checkpoint.PageCommit;
+import io.varve.swath.checkpoint.RunKey;
+import io.varve.swath.checkpoint.RunMeta;
+import io.varve.swath.checkpoint.RunStatus;
+import io.varve.swath.checkpoint.SoftRestoreContext;
+import io.varve.swath.checkpoint.SqliteCheckpointStore;
+import io.varve.swath.error.InvalidArgsException;
+import io.varve.swath.model.ListingMode;
+import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.parquet.Manifest;
+import io.varve.swath.runtime.ArgsHashFields;
+import io.varve.swath.testkit.MockPageFetcher;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Adversarial pre-existing-link checks for swath-managed dataset paths. */
+final class DatasetSymlinkSafetyTest {
+
+    private static final String BUCKET = "bucket";
+    private static final String PREFIX = "data/";
+    private static final String NO_FILTER_SPEC =
+            FilterSpecCodec.encode(null, null, null, null, null, null, null);
+
+    private static ListCommand restartCommand(Path outputDir, Path checkpoint) {
+        ListCommand cmd = new ListCommand();
+        cmd.uri = "s3://bucket/data/";
+        cmd.connection.region = "us-east-1";
+        cmd.connection.noSignRequest = true;
+        cmd.output.format = OutputFormat.PARQUET;
+        cmd.output.destination = outputDir.toString();
+        cmd.checkpoint.restart = true;
+        if (checkpoint != null) {
+            cmd.checkpoint.location = checkpoint.toString();
+        }
+        cmd.fetcherOverride = MockPageFetcher.builder().keys(List.<byte[]>of()).build();
+        return cmd;
+    }
+
+    @Test
+    void symlinkedDatasetRootIsRefusedWithoutTouchingItsExternalTarget(@TempDir Path root)
+            throws Exception {
+        Path externalDataset = Files.createDirectories(root.resolve("external-dataset"));
+        Path externalData = Files.createDirectories(externalDataset.resolve("data"));
+        Path externalPart = externalData.resolve("part-w0-00000.parquet");
+        Files.writeString(externalPart, "must survive root-link refusal");
+        Path externalSwath = Files.createDirectories(externalDataset.resolve(".swath"));
+        Path externalCheckpoint = externalSwath.resolve("checkpoint.sqlite");
+        Files.writeString(externalCheckpoint, "not a SQLite checkpoint; must never be parsed");
+        Path outputLink = root.resolve("output");
+        Files.createSymbolicLink(outputLink, externalDataset);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+
+        assertSymlinkRefusal(restartCommand(outputLink, checkpoint), outputLink);
+        assertResumeSymlinkRefusal(outputLink, outputLink);
+
+        assertThat(externalPart).hasContent("must survive root-link refusal");
+        assertThat(externalCheckpoint)
+                .hasContent("not a SQLite checkpoint; must never be parsed");
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void symlinkedDataDirIsRefusedBeforeRestartCanDeleteAnExternalPart(@TempDir Path root)
+            throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Path externalData = Files.createDirectories(root.resolve("external-data"));
+        Path externalPart = externalData.resolve("part-w0-00000.parquet");
+        Files.writeString(externalPart, "must survive data-link refusal");
+        Path dataLink = outputDir.resolve("data");
+        Files.createSymbolicLink(dataLink, externalData);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+
+        assertSymlinkRefusal(restartCommand(outputDir, checkpoint), dataLink);
+
+        assertThat(externalPart).hasContent("must survive data-link refusal");
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void symlinkedStagingDirIsRefusedBeforeSortedRestartCanDeleteExternalSegments(
+            @TempDir Path root) throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Path externalStaging = Files.createDirectories(root.resolve("external-staging"));
+        Path externalSegment = externalStaging.resolve("seg-1-0.pageseg");
+        Files.writeString(externalSegment, "must survive staging-link refusal");
+        Path stagingLink = outputDir.resolve(ListCommand.SORT_STAGING_DIR);
+        Files.createSymbolicLink(stagingLink, externalStaging);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+        ListCommand cmd = restartCommand(outputDir, checkpoint);
+        cmd.sorting.sort = true;
+        cmd.sorting.forceSort = true;
+
+        assertSymlinkRefusal(cmd, stagingLink);
+
+        assertThat(externalSegment).hasContent("must survive staging-link refusal");
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void freshSortedRunUnlinksPlantedSegmentSymlinkWithoutTouchingExternalTarget(
+            @TempDir Path root) throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Path stagingDir = Files.createDirectories(outputDir.resolve(ListCommand.SORT_STAGING_DIR));
+        Path externalTarget = root.resolve("external-segment-target");
+        Files.writeString(externalTarget, "must survive fresh sorted staging cleanup");
+        Path plantedSegment = stagingDir.resolve("seg-0-0.pageseg");
+        Files.createSymbolicLink(plantedSegment, externalTarget);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+        ListCommand cmd = restartCommand(outputDir, checkpoint);
+        cmd.sorting.sort = true;
+        cmd.sorting.forceSort = true;
+
+        assertThat(cmd.call()).isEqualTo(ExitCodes.SUCCESS);
+
+        assertThat(externalTarget).hasContent("must survive fresh sorted staging cleanup");
+        assertThat(plantedSegment).doesNotExist();
+    }
+
+    @Test
+    void symlinkedSwathDirIsRefusedBeforeAutoCheckpointCreation(@TempDir Path root)
+            throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Path externalSwath = Files.createDirectories(root.resolve("external-swath"));
+        Path sentinel = externalSwath.resolve("keep.txt");
+        Files.writeString(sentinel, "must remain in external storage");
+        Path externalCheckpoint = externalSwath.resolve("checkpoint.sqlite");
+        Files.writeString(externalCheckpoint, "not a SQLite checkpoint; must never be parsed");
+        Path swathLink = outputDir.resolve(".swath");
+        Files.createSymbolicLink(swathLink, externalSwath);
+
+        assertSymlinkRefusal(restartCommand(outputDir, null), swathLink);
+        assertResumeSymlinkRefusal(outputDir, swathLink);
+
+        assertThat(sentinel).hasContent("must remain in external storage");
+        assertThat(externalCheckpoint)
+                .hasContent("not a SQLite checkpoint; must never be parsed");
+    }
+
+    @Test
+    void managedDirectoryEntriesThatArePlainFilesAreRefusedBeforeCheckpointCreation(
+            @TempDir Path root) throws Exception {
+        for (String name : List.of(
+                Manifest.DATA_DIR, ListCommand.SORT_STAGING_DIR, CheckpointOptions.COLOCATED_DIR)) {
+            Path caseRoot = Files.createDirectories(root.resolve(name.replace('.', '_')));
+            Path outputDir = Files.createDirectories(caseRoot.resolve("output"));
+            Path managedPath = outputDir.resolve(name);
+            Files.writeString(managedPath, "not a managed directory");
+            Path checkpoint = caseRoot.resolve("checkpoint.sqlite");
+
+            assertThatThrownBy(restartCommand(outputDir, checkpoint)::call)
+                    .isInstanceOf(InvalidArgsException.class)
+                    .hasMessageContaining(managedPath.toString())
+                    .hasMessageContaining("not a directory")
+                    .hasMessageContaining("remove the file");
+            assertThat(checkpoint).doesNotExist();
+        }
+    }
+
+    @Test
+    void markerlessDataPartSymlinkIsForeignAndItsExternalTargetRemainsUntouched(
+            @TempDir Path root) throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Path dataDir = Files.createDirectories(outputDir.resolve(Manifest.DATA_DIR));
+        Path externalTarget = root.resolve("external-part-target");
+        Files.writeString(externalTarget, "must survive markerless ownership validation");
+        Path plantedPart = dataDir.resolve("part-w0-00000.parquet");
+        Files.createSymbolicLink(plantedPart, externalTarget);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+
+        assertThatThrownBy(restartCommand(outputDir, checkpoint)::call)
+                .isInstanceOf(InvalidArgsException.class)
+                .hasMessageContaining("not empty")
+                .hasMessageContaining("refusing to write into it");
+
+        assertThat(externalTarget).hasContent("must survive markerless ownership validation");
+        assertThat(plantedPart).isSymbolicLink();
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void symlinkedCheckpointAndSqliteSidecarsAreRefusedBeforeExternalTargetsAreOpened(
+            @TempDir Path root) throws Exception {
+        for (String name : List.of(
+                CheckpointOptions.COLOCATED_FILE,
+                CheckpointOptions.COLOCATED_FILE + "-wal",
+                CheckpointOptions.COLOCATED_FILE + "-shm",
+                CheckpointOptions.COLOCATED_FILE + "-journal")) {
+            Path caseRoot = Files.createDirectories(root.resolve(name.replace('-', '_')));
+            Path outputDir = Files.createDirectories(caseRoot.resolve("output"));
+            Path swathDir = Files.createDirectories(
+                    outputDir.resolve(CheckpointOptions.COLOCATED_DIR));
+            Path externalTarget = caseRoot.resolve("external-target");
+            Files.writeString(externalTarget, "must survive " + name + " refusal");
+            Path plantedLink = swathDir.resolve(name);
+            Files.createSymbolicLink(plantedLink, externalTarget);
+
+            assertSymlinkRefusal(restartCommand(outputDir, null), plantedLink);
+
+            assertThat(externalTarget).hasContent("must survive " + name + " refusal");
+            assertThat(plantedLink).isSymbolicLink();
+        }
+    }
+
+    @Test
+    void manifestAtomicTempSymlinkIsRefusedBeforeExternalTargetIsTruncated(
+            @TempDir Path root) throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("output"));
+        Files.writeString(outputDir.resolve(".swath-state.json"),
+                "{\"args_hash\":\"prior\",\"run_id\":1}");
+        Path externalTarget = root.resolve("external-manifest-target");
+        Files.writeString(externalTarget, "must survive manifest temp refusal");
+        Path manifestTemp = outputDir.resolve("manifest.json.tmp");
+        Files.createSymbolicLink(manifestTemp, externalTarget);
+        Path checkpoint = root.resolve("checkpoint.sqlite");
+
+        assertSymlinkRefusal(restartCommand(outputDir, checkpoint), manifestTemp);
+
+        assertThat(externalTarget).hasContent("must survive manifest temp refusal");
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void explicitCheckpointResumeRefusesSymlinkRestoredWithDatasetBeforeOutputAccess(
+            @TempDir Path root) throws Exception {
+        Path outputDir = Files.createDirectories(root.resolve("restored-output"));
+        Path externalTarget = root.resolve("external-restored-manifest-target");
+        Files.writeString(externalTarget, "must survive restored-output refusal");
+        Path manifestTemp = outputDir.resolve("manifest.json.tmp");
+        Files.createSymbolicLink(manifestTemp, externalTarget);
+        Path checkpoint = root.resolve("explicit-checkpoint.sqlite");
+        seedCompletedRun(checkpoint, outputDir);
+
+        ListCommand cmd = new ListCommand();
+        cmd.uri = "s3://" + BUCKET + "/" + PREFIX;
+        cmd.checkpoint.location = checkpoint.toString();
+        cmd.checkpoint.resume = true;
+
+        assertSymlinkRefusal(cmd, manifestTemp);
+
+        assertThat(externalTarget).hasContent("must survive restored-output refusal");
+        assertThat(checkpoint).exists();
+    }
+
+    private static void seedCompletedRun(Path checkpoint, Path outputDir) throws Exception {
+        String argsHash = ArgsHashFields.forListing("s3", "", BUCKET, PREFIX).hash();
+        RunKey key = new RunKey(
+                "s3", null, BUCKET, PREFIX.getBytes(StandardCharsets.UTF_8), argsHash,
+                "auto", ListingMode.OBJECTS, NO_FILTER_SPEC, OutputFormat.PARQUET.name(),
+                new SoftRestoreContext(
+                        true, null, "us-east-1", false, false, outputDir.toString(), false,
+                        null, null),
+                false);
+        try (SqliteCheckpointStore store = SqliteCheckpointStore.open(checkpoint)) {
+            RunMeta run = store.openRun(key, false, false);
+            long node = store.insertNode(NodeSpec.rootRange(run.id()));
+            store.commitPage(new PageCommit(node, "k9".getBytes(StandardCharsets.UTF_8), true));
+            store.markOutputComplete(run.id());
+            store.markRunFinished(run.id(), RunStatus.COMPLETED);
+        }
+    }
+
+    private static void assertSymlinkRefusal(ListCommand cmd, Path refusedPath) {
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidArgsException.class)
+                .hasMessageContaining(refusedPath.toString())
+                .hasMessageContaining("symbolic link")
+                .hasMessageContaining("remove the link");
+    }
+
+    private static void assertResumeSymlinkRefusal(Path runHandle, Path refusedPath) {
+        ResumeCommand cmd = new ResumeCommand();
+        cmd.directory = runHandle;
+        assertThatThrownBy(cmd::call)
+                .isInstanceOf(InvalidArgsException.class)
+                .hasMessageContaining(refusedPath.toString())
+                .hasMessageContaining("symbolic link")
+                .hasMessageContaining("remove the link");
+    }
+}

--- a/swath-cli/src/test/java/io/varve/swath/cli/VersionProviderFormatTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/VersionProviderFormatTest.java
@@ -10,44 +10,58 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /**
- * {@code --version} rendering. The commit half of the line comes from a manifest attribute that
+ * {@code --version} rendering. The commit value comes from a manifest attribute that
  * only exists in a packaged jar, so the formatting is tested directly rather than through a
  * built artifact — {@link AppCliTest} already covers the end-to-end invocation.
  *
  * <p>The absent/blank/"unknown" cases are the ones that matter: they are what a development
  * build, a source-archive build with no git, and a test run actually produce, and each must
- * degrade to a clean version line rather than rendering an empty or bogus commit.
+ * degrade to an explicit unavailable marker rather than rendering an empty or bogus commit.
  */
 class VersionProviderFormatTest {
 
     @Test
-    void rendersVersionAndShortenedCommit() {
-        assertThat(App.VersionProvider.format("0.1.0", "50933dc2b9bf085df6fc0945874fa8071673e37f"))
-                .isEqualTo("swath 0.1.0 (50933dc2b9bf)");
+    void rendersStableVersionLineAndAttribution() {
+        assertThat(App.VersionProvider.format("0.1.0", "50933dc2b9bf085df6fc0945874fa8071673e37f", "25.0.3"))
+                .containsExactly(
+                        "swath 0.1.0",
+                        "Built by Varve: https://varve.io",
+                        "Source: https://github.com/varveio/swath",
+                        "Commit: 50933dc2b9bf",
+                        "Runtime: 25.0.3");
     }
 
     @Test
-    void omitsCommitWhenUnavailable() {
-        assertThat(App.VersionProvider.format("0.1.0", null)).isEqualTo("swath 0.1.0");
-        assertThat(App.VersionProvider.format("0.1.0", "   ")).isEqualTo("swath 0.1.0");
+    void rendersUnavailableCommitWhenUnavailable() {
+        assertThat(App.VersionProvider.format("0.1.0", null, "25.0.3"))
+                .containsExactly(
+                        "swath 0.1.0",
+                        "Built by Varve: https://varve.io",
+                        "Source: https://github.com/varveio/swath",
+                        "Commit: unavailable",
+                        "Runtime: 25.0.3");
+        assertThat(App.VersionProvider.format("0.1.0", "   ", "25.0.3")[3])
+                .isEqualTo("Commit: unavailable");
     }
 
     @Test
-    void omitsTheUnknownSentinelRatherThanPrintingIt() {
+    void rendersUnavailableForTheUnknownCommitSentinel() {
         // The build writes "unknown" when neither GITHUB_SHA nor git is available; it is a
         // build-side placeholder and must never surface to a user as if it were a commit.
-        assertThat(App.VersionProvider.format("0.1.0", "unknown")).isEqualTo("swath 0.1.0");
+        assertThat(App.VersionProvider.format("0.1.0", "unknown", "25.0.3")[3])
+                .isEqualTo("Commit: unavailable");
     }
 
     @Test
     void fallsBackToDevelopmentWithoutAManifestVersion() {
-        assertThat(App.VersionProvider.format(null, null)).isEqualTo("swath development");
-        assertThat(App.VersionProvider.format(null, "50933dc2b9bf085df6fc0945874fa8071673e37f"))
-                .isEqualTo("swath development (50933dc2b9bf)");
+        assertThat(App.VersionProvider.format(null, null, "25.0.3")[0]).isEqualTo("swath development");
+        assertThat(App.VersionProvider.format(null, "50933dc2b9bf085df6fc0945874fa8071673e37f", "25.0.3")[3])
+                .isEqualTo("Commit: 50933dc2b9bf");
     }
 
     @Test
     void doesNotOverrunAShorterCommitString() {
-        assertThat(App.VersionProvider.format("0.1.0", "abc123")).isEqualTo("swath 0.1.0 (abc123)");
+        assertThat(App.VersionProvider.format("0.1.0", "abc123", "25.0.3")[3])
+                .isEqualTo("Commit: abc123");
     }
 }

--- a/swath-cli/src/test/resources/help/swath.txt
+++ b/swath-cli/src/test/resources/help/swath.txt
@@ -11,3 +11,4 @@ Commands:
   list    List a bucket or prefix.
   resume  Resume a run by its output directory: swath resume <dir>.
   help    Display help information about the specified command.
+Built by Varve: https://varve.io


### PR DESCRIPTION
## What changed

- add restrained Varve attribution to root help and richer provenance to `swath --version`
- refuse pre-existing links at dataset-managed directories, checkpoint/SQLite sidecars, markers, and atomic temporary files before swath can follow or truncate them
- safely clear fresh-sort staging entries before deterministic segment names are opened
- bind releases to the exact pushed tag SHA and gate publication on fast, integration, deep, kill-9 resume, license, and instrumentation checks
- publish an exact, tested asset set with human-authored release notes, checksums, signatures, SBOMs, and attestations
- clarify JDK 25 and Docker-free contributor commands

## Why

This closes the remaining launch-preparation gaps: attribution was absent from the executable surface, managed dataset paths could escape through pre-planted links, broad release globs admitted shadow distributions, and the tag pipeline did not independently prove that every published byte came from the exact source revision that passed all release gates.

## Impact and boundaries

- Existing scripts that parse the first line of `swath --version` remain compatible; additional provenance is emitted on following lines.
- The symlink checks cover pre-existing managed paths. Concurrent hostile path replacement remains outside the documented single-process ownership model.
- The release workflow changes take effect on the next release tag; the checked-in notes template intentionally fails closed until a maintainer fills it for that version.

## Validation

- `./gradlew build --no-daemon --stacktrace`
- focused CLI help/version, directory lifecycle, resume-context, and adversarial symlink suites
- release guard self-tests, ShellCheck, workflow YAML parsing, and `git diff --check`
- independent review/fix cycles completed with no remaining findings

Closes #65
Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed CLI version information, including source, commit, runtime, and Varve attribution.
  * Added safety checks that reject symbolic links and invalid dataset-managed paths.

* **Bug Fixes**
  * Prevented unsafe checkpoint, staging, cleanup, and resume operations involving symlinked paths.

* **Documentation**
  * Expanded contributor and release guidance.
  * Added a release-notes template and documented dataset safety behavior.

* **Release Improvements**
  * Strengthened release validation, asset verification, signing, and post-publication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->