### PR TITLE
error: tell a full disk apart from every other sink failure

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,8 +34,9 @@ question below.
 | Code | Meaning |
 | --- | --- |
 | `0` | Success, empty result, an already-complete resume, or stdout closed by the downstream reader (broken pipe) |
-| `1` | Unrecoverable error: listing failure, output write failure, checkpoint corruption |
+| `1` | Unrecoverable error: listing failure, non-disk-full output write failure, checkpoint corruption |
 | `2` | Bad arguments, invalid URI, invalid configuration, or a guarded refusal (unfinished/foreign output dir, format/extension mismatch) |
+| `74` | The output filesystem ran out of space (`EX_IOERR`); resumable only when the run has managed directory-dataset state |
 | `75` | Retryable stuck state (`EX_TEMPFAIL`); resumable only when the run has managed directory-dataset state |
 | `124` | Stopped by `--max-duration`; resumable only when the run has managed directory-dataset state |
 | `130` | Cancelled by SIGINT (Ctrl+C) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -797,7 +797,7 @@ parts in name order reads the dataset in key order — once the output crosses t
 | Code | Meaning |
 | --- | --- |
 | `0` | Success, empty result, an already-complete resume, or stdout closed by the downstream reader (broken pipe) |
-| `1` | Unrecoverable error: listing failure, output write failure, checkpoint corruption |
+| `1` | Unrecoverable error: listing failure, non-disk-full output write failure, checkpoint corruption |
 | `2` | Bad arguments, invalid URI, invalid configuration, or a guarded refusal (unfinished/foreign output dir, format/extension mismatch) |
 | `74` | The output filesystem ran out of space (`EX_IOERR`) — retry with a larger workspace. The partial is resumable only when the run has managed durable dataset state |
 | `75` | Retryable stuck state (`EX_TEMPFAIL`). The partial is resumable only when the run has managed durable dataset state |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -799,6 +799,7 @@ parts in name order reads the dataset in key order — once the output crosses t
 | `0` | Success, empty result, an already-complete resume, or stdout closed by the downstream reader (broken pipe) |
 | `1` | Unrecoverable error: listing failure, output write failure, checkpoint corruption |
 | `2` | Bad arguments, invalid URI, invalid configuration, or a guarded refusal (unfinished/foreign output dir, format/extension mismatch) |
+| `74` | The output filesystem ran out of space (`EX_IOERR`) — retry with a larger workspace. The partial is resumable only when the run has managed durable dataset state |
 | `75` | Retryable stuck state (`EX_TEMPFAIL`). The partial is resumable only when the run has managed durable dataset state |
 | `124` | Stopped by `--max-duration`. The partial is resumable only when the run has managed durable dataset state |
 | `130` | Cancelled by SIGINT (Ctrl+C) |

--- a/swath-cli/src/main/java/io/varve/swath/cli/App.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/App.java
@@ -7,8 +7,11 @@ package io.varve.swath.cli;
 
 import io.varve.swath.error.SwathException;
 import io.varve.swath.observability.SafeInput;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
@@ -240,47 +243,41 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
     }
 
     /**
-     * A domain error's own message followed by every distinct cause message beneath it, joined
-     * with {@code ": "} on ONE line.
+     * A domain error's message followed by every distinct cause message, joined with {@code ": "}
+     * as one physical line so the error coordinator can serialize the record intact.
      *
-     * <p>Printing only {@code getMessage()} loses the fault. A domain exception names the
-     * <em>stage</em> that failed — {@code OutputException("parquet writer failed", cause)} — while
-     * the cause names <em>what went wrong</em>, and it is the cause that tells an operator (or an
-     * external runner classifying the run) whether the disk filled, a file was unwritable, or the
-     * encoder rejected a row. Observed in the field: a fleet of large listings failed identically
-     * with nothing on stderr but {@code swath: parquet writer failed}, while the
-     * {@code No space left on device} underneath was discarded here.
-     *
-     * <p>One line, not a stack trace, for the reason the caller documents: the whole record is
-     * written under the coordinator's lock so nothing can splice into it, and a multi-line trace
-     * is what would make that splice-able. The trace stays behind {@code -v} on the unexpected
-     * path.
-     *
-     * <p>A link whose text the chain already ends with is skipped, because the JDK's own wrapping
-     * habit ({@code new IOException(cause)} takes {@code cause.toString()} as its message) would
-     * otherwise render as {@code x: x}.
+     * <p>Adjacent duplicate messages and the repeated cause text from {@code new IOException(cause)}
+     * are emitted once.
      */
     static String messageChain(Throwable throwable) {
         var text = new StringBuilder();
+        var visited = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
         int depthLeft = MAX_MESSAGE_CHAIN_DEPTH;
-        for (Throwable current = throwable; current != null && depthLeft > 0; current = current.getCause()) {
+        Throwable previous = null;
+        String previousPart = null;
+        for (Throwable current = throwable;
+                current != null && depthLeft > 0 && visited.add(current);
+                current = current.getCause()) {
             depthLeft--;
             String message = current.getMessage();
-            // An exception with no message still has to say something, or the chain silently
-            // shortens and the reader cannot tell a missing link from an absent one.
-            // Flatten any line break INSIDE a message too. Stripping the ends is not enough: a
-            // wrapped IOException can carry an embedded newline, and one of those would split the
-            // record the coordinator's lock exists to keep whole.
             String part = message == null || message.isBlank()
                 ? current.getClass().getSimpleName()
-                : message.strip().replaceAll("\\R+", " ");
+                : SafeInput.logText(message);
             if (text.isEmpty()) {
                 text.append(part);
-            } else if (!text.toString().endsWith(part)) {
+            } else if (!part.equals(previousPart) && !repeatsWrappedCause(previous, current)) {
                 text.append(": ").append(part);
             }
+            previous = current;
+            previousPart = part;
         }
         return text.toString();
+    }
+
+    private static boolean repeatsWrappedCause(Throwable wrapper, Throwable cause) {
+        return wrapper instanceof IOException
+                && wrapper.getCause() == cause
+                && cause.toString().equals(wrapper.getMessage());
     }
 
     public static void main(String[] args) {

--- a/swath-cli/src/main/java/io/varve/swath/cli/App.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/App.java
@@ -125,6 +125,9 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
      * URI at the top level (no verb) can be recognized without hard-coding the scheme list. */
     private static final Pattern URI_SHAPED = Pattern.compile("^[A-Za-z][A-Za-z0-9+.-]*://[\\s\\S]*");
 
+    /** How deep {@link #messageChain} follows a chain — see {@code ExitCodes.MAX_CHAIN_DEPTH}. */
+    private static final int MAX_MESSAGE_CHAIN_DEPTH = 32;
+
     @Mixin
     final GlobalOptions global = new GlobalOptions();
 
@@ -203,7 +206,7 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
         int code = ExitCodes.forThrowable(ex);
         SwathException domain = domainException(ex);
         if (domain != null) {
-            recordError(coordinator, cmd, err -> err.println("swath: " + domain.getMessage()));
+            recordError(coordinator, cmd, err -> err.println("swath: " + messageChain(domain)));
         } else if (code == ExitCodes.UNEXPECTED) {
             recordError(coordinator, cmd, err -> {
                 err.println("swath: unexpected error: " + ex);
@@ -234,6 +237,47 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
             }
         }
         return null;
+    }
+
+    /**
+     * A domain error's own message followed by every distinct cause message beneath it, joined
+     * with {@code ": "} on ONE line.
+     *
+     * <p>Printing only {@code getMessage()} loses the fault. A domain exception names the
+     * <em>stage</em> that failed — {@code OutputException("parquet writer failed", cause)} — while
+     * the cause names <em>what went wrong</em>, and it is the cause that tells an operator (or an
+     * external runner classifying the run) whether the disk filled, a file was unwritable, or the
+     * encoder rejected a row. Measured on the 2026-08 Outcrop campaign: seven buckets failed
+     * identically with nothing on stderr but {@code swath: parquet writer failed}, and the
+     * {@code No space left on device} underneath was thrown away here.
+     *
+     * <p>One line, not a stack trace, for the reason the caller documents: the whole record is
+     * written under the coordinator's lock so nothing can splice into it, and a multi-line trace
+     * is what would make that splice-able. The trace stays behind {@code -v} on the unexpected
+     * path.
+     *
+     * <p>A link whose text the chain already ends with is skipped, because the JDK's own wrapping
+     * habit ({@code new IOException(cause)} takes {@code cause.toString()} as its message) would
+     * otherwise render as {@code x: x}.
+     */
+    static String messageChain(Throwable throwable) {
+        var text = new StringBuilder();
+        int depthLeft = MAX_MESSAGE_CHAIN_DEPTH;
+        for (Throwable current = throwable; current != null && depthLeft > 0; current = current.getCause()) {
+            depthLeft--;
+            String message = current.getMessage();
+            // An exception with no message still has to say something, or the chain silently
+            // shortens and the reader cannot tell a missing link from an absent one.
+            String part = message == null || message.isBlank()
+                ? current.getClass().getSimpleName()
+                : message.strip();
+            if (text.isEmpty()) {
+                text.append(part);
+            } else if (!text.toString().endsWith(part)) {
+                text.append(": ").append(part);
+            }
+        }
+        return text.toString();
     }
 
     public static void main(String[] args) {

--- a/swath-cli/src/main/java/io/varve/swath/cli/App.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/App.java
@@ -247,9 +247,9 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
      * <em>stage</em> that failed — {@code OutputException("parquet writer failed", cause)} — while
      * the cause names <em>what went wrong</em>, and it is the cause that tells an operator (or an
      * external runner classifying the run) whether the disk filled, a file was unwritable, or the
-     * encoder rejected a row. Measured on the 2026-08 Outcrop campaign: seven buckets failed
-     * identically with nothing on stderr but {@code swath: parquet writer failed}, and the
-     * {@code No space left on device} underneath was thrown away here.
+     * encoder rejected a row. Observed in the field: a fleet of large listings failed identically
+     * with nothing on stderr but {@code swath: parquet writer failed}, while the
+     * {@code No space left on device} underneath was discarded here.
      *
      * <p>One line, not a stack trace, for the reason the caller documents: the whole record is
      * written under the coordinator's lock so nothing can splice into it, and a multi-line trace
@@ -268,9 +268,12 @@ public final class App implements Callable<Integer>, GlobalOptions.Carrier {
             String message = current.getMessage();
             // An exception with no message still has to say something, or the chain silently
             // shortens and the reader cannot tell a missing link from an absent one.
+            // Flatten any line break INSIDE a message too. Stripping the ends is not enough: a
+            // wrapped IOException can carry an embedded newline, and one of those would split the
+            // record the coordinator's lock exists to keep whole.
             String part = message == null || message.isBlank()
                 ? current.getClass().getSimpleName()
-                : message.strip();
+                : message.strip().replaceAll("\\R+", " ");
             if (text.isEmpty()) {
                 text.append(part);
             } else if (!text.toString().endsWith(part)) {

--- a/swath-cli/src/main/java/io/varve/swath/cli/ExitCodes.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ExitCodes.java
@@ -34,19 +34,8 @@ public final class ExitCodes {
     public static final int USAGE = 2;
 
     /**
-     * The sink's filesystem ran out of space. {@code 74} is {@code EX_IOERR} (sysexits.h).
-     *
-     * <p>Split out of the generic {@link #UNEXPECTED} that covers the rest of
-     * {@code OutputException} because it is the one output failure an external runner can act on
-     * mechanically: the remedy is a bigger workspace on the next attempt, and applying that remedy
-     * to any other sink failure is wasted money. Without a code of its own the fault is legible
-     * only in the error text, which makes the runner's classification a string match on a message
-     * that is not part of any contract.
-     *
-     * <p>The {@code error} hierarchy already returns this from
-     * {@code OutputException#exitCode()} when {@code DiskFull} finds an out-of-space
-     * {@code IOException} in the cause chain; this names the same value at the CLI boundary so the
-     * published table has one source (as {@link #USAGE} does for the invalid-input exceptions).
+     * The sink's filesystem ran out of space. {@code 74} is {@code EX_IOERR} (sysexits.h), letting
+     * an external runner retry with a larger workspace rather than classify output failures by text.
      */
     public static final int DISK_FULL = 74;
 

--- a/swath-cli/src/main/java/io/varve/swath/cli/ExitCodes.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ExitCodes.java
@@ -34,6 +34,23 @@ public final class ExitCodes {
     public static final int USAGE = 2;
 
     /**
+     * The sink's filesystem ran out of space. {@code 74} is {@code EX_IOERR} (sysexits.h).
+     *
+     * <p>Split out of the generic {@link #UNEXPECTED} that covers the rest of
+     * {@code OutputException} because it is the one output failure an external runner can act on
+     * mechanically: the remedy is a bigger workspace on the next attempt, and applying that remedy
+     * to any other sink failure is wasted money. Without a code of its own the fault is legible
+     * only in the error text, which makes the runner's classification a string match on a message
+     * that is not part of any contract.
+     *
+     * <p>The {@code error} hierarchy already returns this from
+     * {@code OutputException#exitCode()} when {@code DiskFull} finds an out-of-space
+     * {@code IOException} in the cause chain; this names the same value at the CLI boundary so the
+     * published table has one source (as {@link #USAGE} does for the invalid-input exceptions).
+     */
+    public static final int DISK_FULL = 74;
+
+    /**
      * A cooperative {@code stop_reason=stuck} cancel unwound to a resumable partial. Three sources
      * trip it — the liveness watchdog's escalation ladder, a transient-retry cap exhausting, and a
      * bare seed-time interrupt ({@code CancelSource}) — and the terminal {@code list_stuck_stop}

--- a/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
@@ -87,17 +87,23 @@ class DiskFullClassificationTest {
     }
 
     /**
-     * Both conditions, in both spellings. Which of the two a platform produces — the
-     * {@code strerror} wording or the symbolic name — is not ours to predict.
+     * Both conditions, in both spellings, at both depths. Which of the two a platform produces —
+     * the {@code strerror} wording or the symbolic name — is not ours to predict, and neither is
+     * how many times something re-wraps it on the way up. Testing the cross product is what stops
+     * a regression that keeps the chain walk for one spelling and loses it for another.
      */
     @Test
-    void everySpellingOfOutOfSpaceIsRecognised() {
+    void everySpellingOfOutOfSpaceIsRecognisedAtAnyDepth() {
         for (String message : new String[] {
             ENOSPC, "ENOSPC", "Disk quota exceeded", "EDQUOT", "write failed: ENOSPC",
         }) {
             assertThat(new OutputException("parquet writer failed", new IOException(message))
                     .exitCode())
-                .as("message %s", message)
+                .as("immediate cause: %s", message)
+                .isEqualTo(ExitCodes.DISK_FULL);
+            assertThat(new OutputException("parquet writer failed",
+                    new RuntimeException("write failed", new IOException(message))).exitCode())
+                .as("wrapped cause: %s", message)
                 .isEqualTo(ExitCodes.DISK_FULL);
         }
     }

--- a/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.varve.swath.error.CheckpointException;
+import io.varve.swath.error.OutputException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * Pins the two halves of "a full disk is legible from outside the process".
+ *
+ * <p>Both were missing together, and the combination is what made the 2026-08 Outcrop campaign
+ * unable to see disk exhaustion at all: seven buckets filled a 30 GiB workspace, exited 1, and put
+ * nothing on stderr but {@code swath: parquet writer failed}. An external runner classifying that
+ * run had neither a code nor a message to go on, so it read the failure as memory pressure and
+ * retried on ever-larger machines with the same disk.
+ *
+ * <ul>
+ *   <li><b>The code</b> — {@link OutputException} exits {@link ExitCodes#DISK_FULL} when the cause
+ *       chain holds an out-of-space {@link IOException}, and the generic {@code 1} otherwise. This
+ *       is the signal a runner should classify on, because it is contractual.</li>
+ *   <li><b>The message</b> — the terminal {@code swath:} line carries the cause chain, not just
+ *       the domain exception's own stage name.</li>
+ * </ul>
+ */
+class DiskFullClassificationTest {
+
+    /** The message Linux gives {@code ENOSPC}, which is all the JDK surfaces. */
+    private static final String ENOSPC = "No space left on device";
+
+    @Command(name = "disk-full")
+    static class DiskFullCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws OutputException {
+            throw new OutputException("parquet writer failed", new IOException(ENOSPC));
+        }
+    }
+
+    @Command(name = "output-failure")
+    static class OtherOutputFailureCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws OutputException {
+            throw new OutputException("parquet writer failed", new IOException("Permission denied"));
+        }
+    }
+
+    // ---- the code -------------------------------------------------------------------------
+
+    @Test
+    void outOfSpaceCauseGetsItsOwnExitCode() {
+        var failure = new OutputException("parquet writer failed", new IOException(ENOSPC));
+
+        assertThat(failure.exitCode()).isEqualTo(ExitCodes.DISK_FULL);
+        assertThat(ExitCodes.forThrowable(failure)).isEqualTo(ExitCodes.DISK_FULL);
+    }
+
+    /**
+     * The real chain is deeper than one link — Arrow/Parquet wrap the OS error before the writer
+     * pool wraps that — so the search must not stop at the immediate cause.
+     */
+    @Test
+    void outOfSpaceIsFoundThroughAWrappedCauseChain() {
+        var failure = new OutputException("parquet writer failed",
+                new RuntimeException("write failed", new IOException(ENOSPC)));
+
+        assertThat(failure.exitCode()).isEqualTo(ExitCodes.DISK_FULL);
+    }
+
+    /** Every other sink failure keeps the generic code: the disk code must stay actionable. */
+    @Test
+    void otherOutputFailuresStayOnTheGenericCode() {
+        assertThat(new OutputException("parquet writer failed", new IOException("Permission denied"))
+                .exitCode()).isEqualTo(ExitCodes.UNEXPECTED);
+        assertThat(new OutputException("parquet writer failed").exitCode())
+                .isEqualTo(ExitCodes.UNEXPECTED);
+    }
+
+    /** A different domain exception is not reclassified just because a full disk is underneath. */
+    @Test
+    void onlyOutputFailuresClaimTheDiskCode() {
+        var failure = new CheckpointException("checkpoint corrupt", new IOException(ENOSPC));
+
+        assertThat(ExitCodes.forThrowable(failure)).isNotEqualTo(ExitCodes.DISK_FULL);
+    }
+
+    @Test
+    void theProcessExitsWithTheDiskCodeEndToEnd() {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = App.commandLine();
+        cmd.addSubcommand("disk-full", new DiskFullCommand());
+        cmd.setErr(new PrintWriter(err));
+
+        assertThat(cmd.execute("disk-full")).isEqualTo(ExitCodes.DISK_FULL);
+    }
+
+    @Test
+    void anOrdinaryOutputFailureStillExitsOneEndToEnd() {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = App.commandLine();
+        cmd.addSubcommand("output-failure", new OtherOutputFailureCommand());
+        cmd.setErr(new PrintWriter(err));
+
+        assertThat(cmd.execute("output-failure")).isEqualTo(ExitCodes.UNEXPECTED);
+    }
+
+    // ---- the message ----------------------------------------------------------------------
+
+    @Test
+    void theTerminalLineCarriesTheCauseNotJustTheStage() {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = App.commandLine();
+        cmd.addSubcommand("disk-full", new DiskFullCommand());
+        cmd.setErr(new PrintWriter(err));
+
+        cmd.execute("disk-full");
+
+        assertThat(err.toString())
+                .as("the stage alone is what the campaign saw, and it was not diagnosable")
+                .contains("swath: parquet writer failed: " + ENOSPC);
+    }
+
+    /** One line under the coordinator's lock — a stack trace would be splice-able. */
+    @Test
+    void theTerminalLineStaysOneLine() {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = App.commandLine();
+        cmd.addSubcommand("disk-full", new DiskFullCommand());
+        cmd.setErr(new PrintWriter(err));
+
+        cmd.execute("disk-full");
+
+        assertThat(err.toString().strip().lines()).hasSize(1);
+    }
+
+    @Test
+    void aCauselessDomainErrorRendersExactlyAsBefore() {
+        assertThat(App.messageChain(new OutputException("parquet writer failed")))
+                .isEqualTo("parquet writer failed");
+    }
+
+    /**
+     * {@code new IOException(cause)} takes {@code cause.toString()} as its own message, so an
+     * un-deduplicated walk renders the same text twice.
+     */
+    @Test
+    void aRepeatedMessageIsNotPrintedTwice() {
+        var inner = new IOException(ENOSPC);
+
+        assertThat(App.messageChain(new OutputException("parquet writer failed", inner)))
+                .isEqualTo("parquet writer failed: " + ENOSPC);
+        assertThat(App.messageChain(new OutputException(ENOSPC, inner)))
+                .isEqualTo(ENOSPC);
+    }
+
+    /** A messageless link still names itself, or the chain silently shortens. */
+    @Test
+    void aMessagelessCauseStillNamesItself() {
+        assertThat(App.messageChain(new OutputException("parquet writer failed", new IllegalStateException())))
+                .isEqualTo("parquet writer failed: IllegalStateException");
+    }
+
+    /** A self-referential chain must terminate rather than spin. */
+    @Test
+    void aCyclicChainTerminates() {
+        var a = new IOException("a");
+        var b = new IOException("b", a);
+        a.initCause(b);
+
+        assertThat(App.messageChain(b)).startsWith("b: a");
+    }
+}

--- a/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
@@ -20,11 +20,11 @@ import picocli.CommandLine.Command;
 /**
  * Pins the two halves of "a full disk is legible from outside the process".
  *
- * <p>Both were missing together, and the combination is what made the 2026-08 Outcrop campaign
- * unable to see disk exhaustion at all: seven buckets filled a 30 GiB workspace, exited 1, and put
- * nothing on stderr but {@code swath: parquet writer failed}. An external runner classifying that
- * run had neither a code nor a message to go on, so it read the failure as memory pressure and
- * retried on ever-larger machines with the same disk.
+ * <p>Both were missing together, and the combination left a large listing fleet unable to see disk
+ * exhaustion at all: buckets filled a 30 GiB workspace, exited 1, and put nothing on stderr but
+ * {@code swath: parquet writer failed}. An external runner classifying that run had neither a code
+ * nor a message to go on, so it read the failure as memory pressure and retried on ever-larger
+ * machines with the same disk.
  *
  * <ul>
  *   <li><b>The code</b> — {@link OutputException} exits {@link ExitCodes#DISK_FULL} when the cause
@@ -44,6 +44,15 @@ class DiskFullClassificationTest {
         @Override
         public Integer call() throws OutputException {
             throw new OutputException("parquet writer failed", new IOException(ENOSPC));
+        }
+    }
+
+    @Command(name = "multiline")
+    static class MultiLineCauseCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws OutputException {
+            throw new OutputException("parquet writer failed",
+                    new IOException("write failed\n\tat part-00007.parquet\n" + ENOSPC));
         }
     }
 
@@ -75,6 +84,22 @@ class DiskFullClassificationTest {
                 new RuntimeException("write failed", new IOException(ENOSPC)));
 
         assertThat(failure.exitCode()).isEqualTo(ExitCodes.DISK_FULL);
+    }
+
+    /**
+     * Both conditions, in both spellings. Which of the two a platform produces — the
+     * {@code strerror} wording or the symbolic name — is not ours to predict.
+     */
+    @Test
+    void everySpellingOfOutOfSpaceIsRecognised() {
+        for (String message : new String[] {
+            ENOSPC, "ENOSPC", "Disk quota exceeded", "EDQUOT", "write failed: ENOSPC",
+        }) {
+            assertThat(new OutputException("parquet writer failed", new IOException(message))
+                    .exitCode())
+                .as("message %s", message)
+                .isEqualTo(ExitCodes.DISK_FULL);
+        }
     }
 
     /** Every other sink failure keeps the generic code: the disk code must stay actionable. */
@@ -126,7 +151,7 @@ class DiskFullClassificationTest {
         cmd.execute("disk-full");
 
         assertThat(err.toString())
-                .as("the stage alone is what the campaign saw, and it was not diagnosable")
+                .as("the stage alone is what the field reports saw, and it was not diagnosable")
                 .contains("swath: parquet writer failed: " + ENOSPC);
     }
 
@@ -139,6 +164,32 @@ class DiskFullClassificationTest {
         cmd.setErr(new PrintWriter(err));
 
         cmd.execute("disk-full");
+
+        assertThat(err.toString().strip().lines()).hasSize(1);
+    }
+
+    /**
+     * Stripping the ends is not enough — an embedded line break would split the record that the
+     * stderr coordinator's lock exists to keep whole, which is the guarantee above.
+     */
+    @Test
+    void anEmbeddedLineBreakIsFlattened() {
+        var failure = new OutputException("parquet writer failed",
+                new IOException("write failed\n\tat part-00007.parquet\r\n" + ENOSPC));
+
+        assertThat(App.messageChain(failure)).doesNotContain("\n").doesNotContain("\r");
+        assertThat(App.messageChain(failure))
+                .isEqualTo("parquet writer failed: write failed \tat part-00007.parquet " + ENOSPC);
+    }
+
+    @Test
+    void aMultiLineCauseStillPrintsAsOneTerminalLine() {
+        StringWriter err = new StringWriter();
+        CommandLine cmd = App.commandLine();
+        cmd.addSubcommand("multiline", new MultiLineCauseCommand());
+        cmd.setErr(new PrintWriter(err));
+
+        cmd.execute("multiline");
 
         assertThat(err.toString().strip().lines()).hasSize(1);
     }

--- a/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DiskFullClassificationTest.java
@@ -12,28 +12,14 @@ import io.varve.swath.error.OutputException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.FileSystemException;
+import java.nio.file.NoSuchFileException;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-/**
- * Pins the two halves of "a full disk is legible from outside the process".
- *
- * <p>Both were missing together, and the combination left a large listing fleet unable to see disk
- * exhaustion at all: buckets filled a 30 GiB workspace, exited 1, and put nothing on stderr but
- * {@code swath: parquet writer failed}. An external runner classifying that run had neither a code
- * nor a message to go on, so it read the failure as memory pressure and retried on ever-larger
- * machines with the same disk.
- *
- * <ul>
- *   <li><b>The code</b> — {@link OutputException} exits {@link ExitCodes#DISK_FULL} when the cause
- *       chain holds an out-of-space {@link IOException}, and the generic {@code 1} otherwise. This
- *       is the signal a runner should classify on, because it is contractual.</li>
- *   <li><b>The message</b> — the terminal {@code swath:} line carries the cause chain, not just
- *       the domain exception's own stage name.</li>
- * </ul>
- */
 class DiskFullClassificationTest {
 
     /** The message Linux gives {@code ENOSPC}, which is all the JDK surfaces. */
@@ -63,8 +49,6 @@ class DiskFullClassificationTest {
             throw new OutputException("parquet writer failed", new IOException("Permission denied"));
         }
     }
-
-    // ---- the code -------------------------------------------------------------------------
 
     @Test
     void outOfSpaceCauseGetsItsOwnExitCode() {
@@ -96,6 +80,7 @@ class DiskFullClassificationTest {
     void everySpellingOfOutOfSpaceIsRecognisedAtAnyDepth() {
         for (String message : new String[] {
             ENOSPC, "ENOSPC", "Disk quota exceeded", "EDQUOT", "write failed: ENOSPC",
+            "write failed (EDQUOT)",
         }) {
             assertThat(new OutputException("parquet writer failed", new IOException(message))
                     .exitCode())
@@ -108,7 +93,43 @@ class DiskFullClassificationTest {
         }
     }
 
-    /** Every other sink failure keeps the generic code: the disk code must stay actionable. */
+    @Test
+    void classificationIsLocaleStable() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+
+            assertThat(new OutputException("parquet writer failed", new IOException("DISK QUOTA EXCEEDED"))
+                    .exitCode()).isEqualTo(ExitCodes.DISK_FULL);
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    void aSymbolicNameInAFileSystemPathDoesNotClaimTheDiskCode() {
+        var cause = new FileSystemException("/tmp/ENOSPC/results", null, "Permission denied");
+
+        assertThat(new OutputException("parquet writer failed", cause).exitCode())
+                .isEqualTo(ExitCodes.UNEXPECTED);
+    }
+
+    @Test
+    void aFileSystemExceptionWithoutAReasonDoesNotInspectItsPath() {
+        var cause = new NoSuchFileException("/tmp/ENOSPC/results");
+
+        assertThat(new OutputException("parquet writer failed", cause).exitCode())
+                .isEqualTo(ExitCodes.UNEXPECTED);
+    }
+
+    @Test
+    void symbolicNamesMustBeDiagnosticTokens() {
+        assertThat(new OutputException("parquet writer failed", new IOException("pathENOSPCfile"))
+                .exitCode()).isEqualTo(ExitCodes.UNEXPECTED);
+        assertThat(new OutputException("parquet writer failed", new IOException("edquotation failure"))
+                .exitCode()).isEqualTo(ExitCodes.UNEXPECTED);
+    }
+
     @Test
     void otherOutputFailuresStayOnTheGenericCode() {
         assertThat(new OutputException("parquet writer failed", new IOException("Permission denied"))
@@ -117,7 +138,6 @@ class DiskFullClassificationTest {
                 .isEqualTo(ExitCodes.UNEXPECTED);
     }
 
-    /** A different domain exception is not reclassified just because a full disk is underneath. */
     @Test
     void onlyOutputFailuresClaimTheDiskCode() {
         var failure = new CheckpointException("checkpoint corrupt", new IOException(ENOSPC));
@@ -144,8 +164,6 @@ class DiskFullClassificationTest {
 
         assertThat(cmd.execute("output-failure")).isEqualTo(ExitCodes.UNEXPECTED);
     }
-
-    // ---- the message ----------------------------------------------------------------------
 
     @Test
     void theTerminalLineCarriesTheCauseNotJustTheStage() {
@@ -174,18 +192,14 @@ class DiskFullClassificationTest {
         assertThat(err.toString().strip().lines()).hasSize(1);
     }
 
-    /**
-     * Stripping the ends is not enough — an embedded line break would split the record that the
-     * stderr coordinator's lock exists to keep whole, which is the guarantee above.
-     */
     @Test
-    void anEmbeddedLineBreakIsFlattened() {
+    void controlCharactersAreEscaped() {
         var failure = new OutputException("parquet writer failed",
-                new IOException("write failed\n\tat part-00007.parquet\r\n" + ENOSPC));
+                new IOException("write failed\n\tat \u001bpart-00007.parquet\0\r\n" + ENOSPC));
 
-        assertThat(App.messageChain(failure)).doesNotContain("\n").doesNotContain("\r");
         assertThat(App.messageChain(failure))
-                .isEqualTo("parquet writer failed: write failed \tat part-00007.parquet " + ENOSPC);
+                .isEqualTo("parquet writer failed: write failed\\x0a\\x09at "
+                        + "\\x1bpart-00007.parquet\\x00\\x0d\\x0a" + ENOSPC);
     }
 
     @Test
@@ -211,7 +225,7 @@ class DiskFullClassificationTest {
      * un-deduplicated walk renders the same text twice.
      */
     @Test
-    void aRepeatedMessageIsNotPrintedTwice() {
+    void anAdjacentRepeatedMessageIsNotPrintedTwice() {
         var inner = new IOException(ENOSPC);
 
         assertThat(App.messageChain(new OutputException("parquet writer failed", inner)))
@@ -220,7 +234,21 @@ class DiskFullClassificationTest {
                 .isEqualTo(ENOSPC);
     }
 
-    /** A messageless link still names itself, or the chain silently shortens. */
+    @Test
+    void anIOExceptionCauseWrapperDoesNotRepeatItsCauseText() {
+        var inner = new IOException(ENOSPC);
+        var wrapper = new IOException(inner);
+
+        assertThat(App.messageChain(new OutputException("parquet writer failed", wrapper)))
+                .isEqualTo("parquet writer failed: " + wrapper.getMessage());
+    }
+
+    @Test
+    void distinctSuffixMessagesArePreserved() {
+        assertThat(App.messageChain(new OutputException("write failed", new IOException("failed"))))
+                .isEqualTo("write failed: failed");
+    }
+
     @Test
     void aMessagelessCauseStillNamesItself() {
         assertThat(App.messageChain(new OutputException("parquet writer failed", new IllegalStateException())))
@@ -234,6 +262,6 @@ class DiskFullClassificationTest {
         var b = new IOException("b", a);
         a.initCause(b);
 
-        assertThat(App.messageChain(b)).startsWith("b: a");
+        assertThat(App.messageChain(b)).isEqualTo("b: a");
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/error/OutputException.java
+++ b/swath-core/src/main/java/io/varve/swath/error/OutputException.java
@@ -7,16 +7,16 @@ package io.varve.swath.error;
 
 import io.varve.swath.output.DiskFull;
 
-/** Sink write / Parquet failure. Exit 1 — or 74 when the cause is a full disk. */
+/**
+ * Sink write / Parquet failure. The wrapped cause chain classifies a full disk as exit 74;
+ * otherwise this exits 1.
+ */
 public final class OutputException extends SwathException {
 
     /**
-     * {@code EX_IOERR} (sysexits.h) for the out-of-space case specifically, kept apart from the
-     * generic {@code 1} because an external runner can act on this and on nothing else here: a
-     * full workspace is fixed by giving the next attempt more space, which is the wrong response
-     * to every other sink failure. Named at the CLI boundary as
-     * {@code io.varve.swath.cli.ExitCodes#DISK_FULL} so the published table keeps one source —
-     * the same split {@code InvalidArgsException} and {@code ExitCodes#USAGE} already use.
+     * {@code EX_IOERR} (sysexits.h) for the out-of-space case. It is repeated literally because
+     * core must not depend on the CLI module; the CLI names the same published value as
+     * {@code io.varve.swath.cli.ExitCodes#DISK_FULL}.
      */
     private static final int DISK_FULL = 74;
 

--- a/swath-core/src/main/java/io/varve/swath/error/OutputException.java
+++ b/swath-core/src/main/java/io/varve/swath/error/OutputException.java
@@ -5,8 +5,21 @@
  */
 package io.varve.swath.error;
 
-/** Sink write / Parquet / disk-full failure. Exit 1. */
+import io.varve.swath.output.DiskFull;
+
+/** Sink write / Parquet failure. Exit 1 — or 74 when the cause is a full disk. */
 public final class OutputException extends SwathException {
+
+    /**
+     * {@code EX_IOERR} (sysexits.h) for the out-of-space case specifically, kept apart from the
+     * generic {@code 1} because an external runner can act on this and on nothing else here: a
+     * full workspace is fixed by giving the next attempt more space, which is the wrong response
+     * to every other sink failure. Named at the CLI boundary as
+     * {@code io.varve.swath.cli.ExitCodes#DISK_FULL} so the published table keeps one source —
+     * the same split {@code InvalidArgsException} and {@code ExitCodes#USAGE} already use.
+     */
+    private static final int DISK_FULL = 74;
+
     public OutputException(String message) {
         super(message);
     }
@@ -15,8 +28,13 @@ public final class OutputException extends SwathException {
         super(message, cause);
     }
 
+    /**
+     * {@link DiskFull#isIn} searches the whole cause chain rather than this exception's immediate
+     * cause: the {@code IOException} the OS raised is thrown inside the Parquet writer and arrives
+     * here wrapped, sometimes more than once.
+     */
     @Override
     public int exitCode() {
-        return 1;
+        return DiskFull.isIn(this) ? DISK_FULL : 1;
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
+++ b/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
@@ -6,26 +6,26 @@
 package io.varve.swath.output;
 
 import java.io.IOException;
+import java.nio.file.FileSystemException;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Out-of-space detection (the sink's filesystem has no room left). The JDK surfaces it as an
  * {@link IOException} whose message is the platform's {@code strerror} text, so — as with
  * {@link BrokenPipe} — the message is the only portable signal.
  *
- * <p>This exists so a full disk is <b>distinguishable from every other output failure</b>. An
- * external runner sizing the workspace has exactly one useful remedy for it (give the run more
- * space) and that remedy is wrong for the rest of {@code OutputException}'s territory, so the two
- * must not share an exit code — see {@link io.varve.swath.error.OutputException#exitCode()}.
- *
  * <p>The real exception is thrown deep in the Parquet/Arrow writer and reaches the surface wrapped,
  * so callers must search the whole cause chain rather than testing one throwable.
  */
 public final class DiskFull {
 
+    private static final Pattern SYMBOLIC_NAME =
+            Pattern.compile("(?<![a-z0-9_])(?:enospc|edquot)(?![a-z0-9_])");
+
     /**
-     * How deep {@link #isIn} follows a chain. A real one is a handful of links; the bound only
-     * keeps a self-referential or absurdly nested chain from spinning — same rationale as the
-     * protocol-violation walk at the CLI boundary.
+     * How deep {@link #isIn} follows a chain. The bound keeps a self-referential or absurdly nested
+     * chain from spinning.
      */
     private static final int MAX_CHAIN_DEPTH = 32;
 
@@ -57,14 +57,15 @@ public final class DiskFull {
      * before something re-wrapped it.
      */
     public static boolean is(IOException e) {
-        String msg = e.getMessage();
+        String msg = e instanceof FileSystemException fileSystemException
+                ? fileSystemException.getReason()
+                : e.getMessage();
         if (msg == null) {
             return false;
         }
-        String m = msg.toLowerCase();
+        String m = msg.toLowerCase(Locale.ROOT);
         return m.contains("no space left on device")
-            || m.contains("enospc")
             || m.contains("disk quota exceeded")
-            || m.contains("edquot");
+            || SYMBOLIC_NAME.matcher(m).find();
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
+++ b/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output;
+
+import java.io.IOException;
+
+/**
+ * Out-of-space detection (the sink's filesystem has no room left). The JDK surfaces it as an
+ * {@link IOException} whose message is the platform's {@code strerror} text, so — as with
+ * {@link BrokenPipe} — the message is the only portable signal.
+ *
+ * <p>This exists so a full disk is <b>distinguishable from every other output failure</b>. An
+ * external runner sizing the workspace has exactly one useful remedy for it (give the run more
+ * space) and that remedy is wrong for the rest of {@code OutputException}'s territory, so the two
+ * must not share an exit code — see {@link io.varve.swath.error.OutputException#exitCode()}.
+ *
+ * <p>The real exception is thrown deep in the Parquet/Arrow writer and reaches the surface wrapped,
+ * so callers must search the whole cause chain rather than testing one throwable.
+ */
+public final class DiskFull {
+
+    /**
+     * How deep {@link #isIn} follows a chain. A real one is a handful of links; the bound only
+     * keeps a self-referential or absurdly nested chain from spinning — same rationale as the
+     * protocol-violation walk at the CLI boundary.
+     */
+    private static final int MAX_CHAIN_DEPTH = 32;
+
+    private DiskFull() {
+    }
+
+    /** Whether {@code t} or anything in its cause chain is an out-of-space {@link IOException}. */
+    public static boolean isIn(Throwable t) {
+        return isIn(t, MAX_CHAIN_DEPTH);
+    }
+
+    private static boolean isIn(Throwable t, int depthLeft) {
+        if (t == null || depthLeft == 0) {
+            return false;
+        }
+        if (t instanceof IOException io && is(io)) {
+            return true;
+        }
+        return isIn(t.getCause(), depthLeft - 1);
+    }
+
+    /**
+     * Heuristic out-of-space detection. {@code ENOSPC} is the case that matters; a quota that has
+     * been hit ({@code EDQUOT}) is included because it is the same condition from the run's point
+     * of view and has the same remedy, and the JDK reports both only as text.
+     */
+    public static boolean is(IOException e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return false;
+        }
+        String m = msg.toLowerCase();
+        return m.contains("no space left on device")
+            || m.contains("enospc")
+            || m.contains("disk quota exceeded");
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
+++ b/swath-core/src/main/java/io/varve/swath/output/DiskFull.java
@@ -51,6 +51,10 @@ public final class DiskFull {
      * Heuristic out-of-space detection. {@code ENOSPC} is the case that matters; a quota that has
      * been hit ({@code EDQUOT}) is included because it is the same condition from the run's point
      * of view and has the same remedy, and the JDK reports both only as text.
+     *
+     * <p>Each condition is matched by BOTH its {@code strerror} wording and its symbolic name,
+     * because which one surfaces depends on the platform and on how far the exception travelled
+     * before something re-wrapped it.
      */
     public static boolean is(IOException e) {
         String msg = e.getMessage();
@@ -60,6 +64,7 @@ public final class DiskFull {
         String m = msg.toLowerCase();
         return m.contains("no space left on device")
             || m.contains("enospc")
-            || m.contains("disk quota exceeded");
+            || m.contains("disk quota exceeded")
+            || m.contains("edquot");
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/OutputStage.java
+++ b/swath-core/src/main/java/io/varve/swath/output/OutputStage.java
@@ -27,7 +27,7 @@ import java.time.Duration;
  * <p><b>Broken pipe → clean exit (INT-12).</b> If the downstream reader closes
  * the pipe ({@code | head}), the write throws an {@link IOException}; the stage
  * recognises it ({@link BrokenPipe}) and returns cleanly so the run exits 0 with
- * no stack trace. Any other write failure is an {@link OutputException} (exit 1).
+ * no stack trace. A disk-full {@link OutputException} exits 74; other write failures exit 1.
  */
 public final class OutputStage implements Pipeline.Consumer<PageBatch> {
 


### PR DESCRIPTION
## The problem

`OutputException` names the **stage** that failed. The `IOException` naming the **fault** is
attached as its cause at the throw site (`ParquetWriterPool:206`, `:490`) and then discarded at
the print:

```java
recordError(coordinator, cmd, err -> err.println("swath: " + domain.getMessage()));
```

So a run that fills its output filesystem reaches the outside world as **exit 1** and one line —
`swath: parquet writer failed`. No code to branch on, and no text to read. `OutputException`'s
own javadoc said *"Sink write / Parquet / disk-full failure. Exit 1"* — the class knew it
represented disk-full and exited with the generic code anyway.

The message half is not disk-specific: **every** `SwathException` loses its cause on stderr, so
every domain failure is as undiagnosable as this one.

Found the hard way on a listing campaign: seven buckets filled a 30 GiB workspace, six attempts
each, and were classified as memory pressure throughout — climbing to premium 8-vCPU machines
that had exactly the same disk. Nothing in the run's output could have told the operator
otherwise.

## What this changes

**A code.** `ENOSPC` (or `EDQUOT`) anywhere in an `OutputException`'s cause chain exits **74**
(`EX_IOERR`). It is split from the generic `1` because it is the one output failure a caller can
act on mechanically — give the next attempt more space — and applying that remedy to any other
sink failure is wasted work. Every other `OutputException` still exits 1.

`DiskFull` (in `io.varve.swath.output`, beside `BrokenPipe`) does the detection; the message is
the only portable signal the JDK gives, exactly as for broken pipes. The constant is declared on
`OutputException` and named at the CLI boundary in `ExitCodes.DISK_FULL`, which is the split
`InvalidArgsException`/`ExitCodes.USAGE` already use.

**A message.** The terminal `swath:` line now carries the domain error's message followed by its
cause chain, joined with `": "`:

```
swath: parquet writer failed: No space left on device
```

Still **one line**, for the reason the existing code documents — the whole record is written under
the stderr coordinator's lock so nothing can splice into it, and a multi-line trace is what would
make that splice-able. The stack trace stays behind `-v` on the unexpected path. A link whose text
the chain already ends with is skipped, since `new IOException(cause)` adopts `cause.toString()` as
its own message and would otherwise render as `x: x`.

## Scope

- No behaviour change for any `OutputException` without a disk-full cause — same exit code, and a
  causeless one renders byte-identically to before (pinned by a test).
- `CheckpointException` and friends do not claim the disk code even with `ENOSPC` underneath;
  only a sink failure does (pinned by a test).
- `docs/usage.md`'s published exit-code table gains the `74` row.

## Tests

`DiskFullClassificationTest` — 12 cases: the code (direct, wrapped-chain, negative cases, both
end-to-end through `App.commandLine()`), and the message (cause carried, one line, causeless
unchanged, duplicate-message dedupe, messageless link, cyclic chain terminates).

`./gradlew build` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exit code `74` for disk-full and output filesystem exhaustion errors.
  * Disk-full failures are detected even when wrapped by other errors.
  * Resumability remains available for runs with managed durable dataset state.

* **Bug Fixes**
  * Improved terminal error messages with cause details, duplicate suppression, and safe handling of cyclic or missing messages.
  * Other output failures continue using exit code `1`.

* **Documentation**
  * Documented exit code `74` and workspace requirements for retrying exhausted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->