### PR TITLE
sort: tick liveness through the parallel merge's silent scan phases

### DIFF
--- a/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
@@ -628,7 +628,7 @@ public final class ListRunner {
         // thread; the channel/downstream hold the compact packed page). Uses the SAME comparator + payload
         // codec the drain-thread SortBuffer.admit pack used, so output + durability are behavior-preserving.
         producer.enableSortPacking(new SortPagePacker(comparator, sortConfig));
-        SortMetrics sortMetrics = ctx.metrics()::recordStealReason;
+        SortMetrics sortMetrics = new RunSortMetrics(ctx.metrics());
 
         if (reattach) {
             List<PartRef> segmentRows = sortedSegmentRows(store, runId);
@@ -826,7 +826,7 @@ public final class ListRunner {
                 stagedParts.stream().mapToLong(PartRef::rows).sum());
         List<Path> segments = stagedParts.stream().map(p -> stagingDir.resolve(p.path())).toList();
         Comparator<ListEntry> comparator = new ListEntryComparator();
-        SortMetrics sortMetrics = ctx.metrics()::recordStealReason;
+        SortMetrics sortMetrics = new RunSortMetrics(ctx.metrics());
         // Wrap the final-file writer factory so each row streamed into the merged output marks
         // liveness progress — during the k-way merge NO page completes, so without this the watchdog
         // would false-trip a long final merge. Throttled to every N rows in

--- a/swath-core/src/main/java/io/varve/swath/runtime/LivenessWatchdog.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/LivenessWatchdog.java
@@ -417,7 +417,15 @@ public final class LivenessWatchdog implements AutoCloseable {
         // real platform-thread blocking-I/O lanes this rung exists to wake.
         boolean worker = name.startsWith("ForkJoinPool-")
                 || name.contains("parquet-writer")
-                || name.contains("-encoder");
+                || name.contains("-encoder")
+                // swath-sort-range-<seq>-<n>: the parallel range merge's platform threads
+                // (ParallelRangeMerge). They are the textbook case for this rung -- when the merge
+                // trips the watchdog they are parked in blocking read0 on staged segments -- and
+                // they were simply never added when the parallel path landed. Without them the
+                // cooperative rung is a no-op for the threads that OWN the merge, so every trip ran
+                // the ladder straight to Runtime.halt: no unwind, no terminal summary, and a resume
+                // that re-runs the identical merge into the identical trip.
+                || name.contains("sort-range");
         boolean infra = name.equals("swath-liveness-watchdog") || name.equals("swath-max-duration")
                 || name.equals("swath-progress") || name.equals("swath-summary-json");
         return worker && !infra;

--- a/swath-core/src/main/java/io/varve/swath/runtime/RunSortMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/RunSortMetrics.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.runtime;
+
+import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.sort.SortMetrics;
+
+/**
+ * Wires the sort library's {@link SortMetrics} hook to the live {@link RunMetrics}.
+ *
+ * <p>This exists as a named class rather than the method reference it replaced
+ * ({@code ctx.metrics()::recordStealReason}) for one reason: {@link SortMetrics} is a
+ * {@code @FunctionalInterface}, so a method reference can only ever supply
+ * {@code recordStealReason} and silently inherits the no-op default for
+ * {@link SortMetrics#markProgress()}. That is precisely how the parallel range merge came to run
+ * its two pre-emission scan phases without advancing the liveness signal, and how a 120 s watchdog
+ * came to halt healthy billion-object listings.
+ *
+ * <p>A named bridge is testable, and {@code RunSortMetricsTest} asserts both methods forward — so
+ * adding a third hook to {@link SortMetrics} cannot quietly go unwired again.
+ */
+record RunSortMetrics(RunMetrics metrics) implements SortMetrics {
+
+    @Override
+    public void recordStealReason(String outcome, String reason) {
+        metrics.recordStealReason(outcome, reason);
+    }
+
+    @Override
+    public void markProgress() {
+        metrics.markProgress();
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/sort/ParallelRangeMerge.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/ParallelRangeMerge.java
@@ -291,6 +291,12 @@ final class ParallelRangeMerge {
                         // minKey() may hand back a buffer the reader owns; retain a copy.
                         distinct.add(frontier.minKey().clone());
                     }
+                    // This walk reads and CRC-verifies EVERY page of EVERY segment before any range
+                    // starts -- single-threaded, with nothing else running to advance the signal. It
+                    // emitted nothing, so the liveness watchdog's 120 s total-freeze tripwire halted
+                    // the JVM on any listing whose staging took longer than that to scan. The serial
+                    // merge never walks a whole segment, which is why only the parallel path tripped.
+                    metrics.markProgress();
                     frontier.advance();
                 }
             }
@@ -623,7 +629,7 @@ final class ParallelRangeMerge {
             private PageFrontierStream openScopedFrontier(Path segment) throws IOException {
                 long totalPages = PageRunSegmentReader.readTrailer(segment).totalRecords();
                 RangeScopedPageFrontier scoped = new RangeScopedPageFrontier(
-                        new PageFrontierReader(segment, metrics), lo, hi, totalPages);
+                        new PageFrontierReader(segment, metrics), lo, hi, totalPages, metrics);
                 pageFrontiers.add(scoped);
                 return scoped;
             }

--- a/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
@@ -60,6 +60,18 @@ final class RangeScopedPageFrontier implements PageFrontierStream {
     private final byte[] lo;   // inclusive, or null for -inf
     private final byte[] hi;   // exclusive, or null for +inf
 
+    /**
+     * Ticked once per page stepped over in {@link #skipToOverlapping()}.
+     *
+     * <p>The prefix walk reads and CRC-verifies roughly {@code r/R} of the staged bytes for range
+     * {@code r} before the merge emits its first row, and it emitted NOTHING while doing so. The
+     * liveness watchdog's total-freeze tripwire is a 120 s default, so on a billion-object listing
+     * this phase alone halted the JVM — the run was healthy and the signal was simply absent. The
+     * serial merge has no equivalent phase (it opens a bare frontier and reads one page per
+     * segment), which is why this only ever bit the parallel path.
+     */
+    private final SortMetrics metrics;
+
     /** Pages in the whole segment (trailer {@code totalRecords}) — the denominator for the signal. */
     private final long totalPages;
 
@@ -70,12 +82,13 @@ final class RangeScopedPageFrontier implements PageFrontierStream {
     /** True once the scan has passed {@code hi}; the underlying stream is left un-drained. */
     private boolean pastRange;
 
-    RangeScopedPageFrontier(PageFrontierStream inner, byte[] lo, byte[] hi, long totalPages)
-            throws IOException {
+    RangeScopedPageFrontier(PageFrontierStream inner, byte[] lo, byte[] hi, long totalPages,
+                            SortMetrics metrics) throws IOException {
         this.inner = inner;
         this.lo = lo;
         this.hi = hi;
         this.totalPages = totalPages;
+        this.metrics = metrics;
         try {
             skipToOverlapping();
         } catch (IOException | RuntimeException e) {
@@ -108,6 +121,11 @@ final class RangeScopedPageFrontier implements PageFrontierStream {
                 return;
             }
             pagesSkipped++;
+            // Every stepped-over page is a full read plus a CRC32C verify, so this is real work and
+            // the watchdog is entitled to see it. Ticking per page rather than per batch costs an
+            // AtomicLong increment against an I/O-bound loop, and removes any question of whether the
+            // cadence clears the stall window.
+            metrics.markProgress();
             inner.advance();
         }
     }

--- a/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
@@ -126,6 +126,12 @@ final class RangeScopedPageFrontier implements PageFrontierStream {
             // AtomicLong increment against an I/O-bound loop, and removes any question of whether the
             // cadence clears the stall window.
             metrics.markProgress();
+            // ...and this walk must be abandonable. When one range fails, the coordinator cancels its
+            // siblings and joins them before cleanup; a sibling that polls nothing walks its whole
+            // prefix first, so the join outlives the stall window, the watchdog re-traps the run, and
+            // the ORIGINAL classified failure is replaced by stuck_unknown. Polling here is what makes
+            // that cancel cooperative -- the constructor already closes the stream on the way out.
+            MergeCancellation.check();
             inner.advance();
         }
     }

--- a/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/RangeScopedPageFrontier.java
@@ -113,6 +113,10 @@ final class RangeScopedPageFrontier implements PageFrontierStream {
                 // its min), so it counts as skipped, not unread -- otherwise a segment lying wholly
                 // above hi would report a page as never-read despite having been read in full.
                 pagesSkipped++;
+                // Read and CRC-verified like any other, so it owes the watchdog a tick too. One page
+                // cannot move the 120 s window on its own, but a skipped tick on the path that
+                // ACCOUNTS for the page is the same class of gap this change exists to close.
+                metrics.markProgress();
                 pastRange = true;
                 return;
             }

--- a/swath-core/src/main/java/io/varve/swath/sort/SortMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortMetrics.java
@@ -26,4 +26,24 @@ public interface SortMetrics {
 
     /** Record one engagement-counter increment, exactly as {@code RunMetrics.recordStealReason}. */
     void recordStealReason(String outcome, String reason);
+
+    /**
+     * Advance the liveness progress signal, exactly as {@code RunMetrics.markProgress()}.
+     *
+     * <p><b>Call this from any loop that does real work without emitting a row.</b> The parallel
+     * range merge has two such loops — boundary sampling walks every page of every segment, and each
+     * range's frontier walks its own prefix — and both were silent. The liveness watchdog's
+     * total-freeze tripwire defaults to 120 s, so on a billion-object listing these phases halted a
+     * perfectly healthy JVM before the merge wrote its first row. The row-emitting path was never
+     * the problem; it ticks through a writer decorator.
+     *
+     * <p><b>The default is a no-op, and that is a trap worth naming.</b> This interface is a
+     * {@code @FunctionalInterface} wired in most places as a lambda or a method reference, which
+     * cannot supply a second method — so a caller that wires {@code metrics::recordStealReason} gets
+     * a silently non-ticking implementation. The pipeline must wire something that overrides this;
+     * {@code ListRunner} uses a named bridge with a test asserting both methods forward.
+     */
+    default void markProgress() {
+        // no-op: the null object and every test lambda record nothing.
+    }
 }

--- a/swath-core/src/test/java/io/varve/swath/runtime/LivenessWatchdogTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/LivenessWatchdogTest.java
@@ -375,6 +375,10 @@ final class LivenessWatchdogTest {
         // The real blocking-I/O lanes this rung exists to wake ARE matched.
         assertThat(LivenessWatchdog.isInterruptibleWorker("parquet-writer-1")).isTrue();
         assertThat(LivenessWatchdog.isInterruptibleWorker("seg-0000-encoder-2")).isTrue();
+        // The parallel range merge's threads. Omitted when the parallel path landed, which made the
+        // cooperative rung a no-op for the threads that own the merge: every trip went straight to
+        // Runtime.halt with no terminal summary. The exact name shape ParallelRangeMerge produces.
+        assertThat(LivenessWatchdog.isInterruptibleWorker("swath-sort-range-1-8")).isTrue();
         // The VT-scheduler carrier match is kept (harmless best-effort).
         assertThat(LivenessWatchdog.isInterruptibleWorker("ForkJoinPool-3-worker-7")).isTrue();
         // Infra daemons are never interrupted.

--- a/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.runtime;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.varve.swath.observability.RunMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every hook on {@code SortMetrics} must actually reach {@link RunMetrics}.
+ *
+ * <p>A regression test for a shipped outage, not a formality. {@code SortMetrics} is a
+ * {@code @FunctionalInterface}, and the pipeline used to wire it as
+ * {@code metrics::recordStealReason} — a method reference binds ONE method and silently inherits
+ * the no-op default for every other. So when {@code markProgress()} arrived, the parallel range
+ * merge's two pre-emission scan phases advanced nothing, and the 120 s liveness watchdog halted
+ * healthy billion-object listings before the merge wrote its first row.
+ *
+ * <p>The point is not that a record forwards a call. It is that adding a hook and forgetting to
+ * wire it here fails the build, instead of failing in production nineteen minutes into a listing.
+ */
+class RunSortMetricsTest {
+
+    @Test
+    void markProgressReachesTheLivenessSignalTheWatchdogReads() {
+        var metrics = new RunMetrics(new SimpleMeterRegistry());
+        var before = metrics.progressSignal();
+
+        new RunSortMetrics(metrics).markProgress();
+
+        assertTrue(metrics.progressSignal() > before,
+            "markProgress must advance progressSignal(); a no-op here IS the outage");
+    }
+
+    @Test
+    void recordStealReasonStillReaches() {
+        var metrics = new RunMetrics(new SimpleMeterRegistry());
+
+        new RunSortMetrics(metrics).recordStealReason("SORT", "merge_range_sample_capped");
+
+        assertTrue(metrics.progressSignal() >= 0, "wiring must not throw");
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
@@ -5,6 +5,7 @@
  */
 package io.varve.swath.runtime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -39,10 +40,15 @@ class RunSortMetricsTest {
 
     @Test
     void recordStealReasonStillReaches() {
-        var metrics = new RunMetrics(new SimpleMeterRegistry());
+        var registry = new SimpleMeterRegistry();
 
-        new RunSortMetrics(metrics).recordStealReason("SORT", "merge_range_sample_capped");
+        new RunSortMetrics(new RunMetrics(registry)).recordStealReason("SORT", "merge_range_sample_capped");
 
-        assertTrue(metrics.progressSignal() >= 0, "wiring must not throw");
+        // Read the counter back off the registry, not "it did not throw": the first draft of this
+        // test asserted progressSignal() >= 0, which passes for a delegate that does nothing at all.
+        assertEquals(1.0, registry.get("swath.steal_reason")
+            .tag("outcome", "SORT")
+            .tag("reason", "merge_range_sample_capped")
+            .counter().count());
     }
 }

--- a/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/RunSortMetricsTest.java
@@ -5,11 +5,11 @@
  */
 package io.varve.swath.runtime;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.varve.swath.observability.RunMetrics;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Every hook on {@code SortMetrics} must actually reach {@link RunMetrics}.


### PR DESCRIPTION
## The incident

0.2.2's default-on parallel range merge halts healthy billion-object listings.

Nine ran on 2026-08-09 against public buckets on 16-vCPU arm64 (so `merge-parallelism` resolved to R=8). Enumeration completed — `its-live-data` reached 1,913,718,551 objects, the **identical count on every retry** — and then:

```
list_stuck_abort stop_reason=stuck error_class=stuck_unknown stall_ms=120000 exit_code=75
```

followed by `Runtime.halt`. The thread dump at halt shows all eight `swath-sort-range-1-*` threads `RUNNABLE`, top frames in `UnixFileDispatcherImpl.read0` and `ZstdOutputStreamNoFinalizer.compressStream`. **They were working.** The run was healthy; the liveness signal simply wasn't advancing.

Deterministic and size-ordered: a 1.04B-object bucket completed; every bucket ≥1.9B died, ~19 minutes in (≈17 min listing, then 120 s of silence), re-listing from scratch each retry.

## Why

Not the row-emitting loop — that ticks on **both** paths through the `ProgressMarkingSortedFileWriter` decorator `ListRunner` injects, every 1000 rows. `RunMetrics.progressSignal()`'s javadoc claim about "every merge-write stride" is true for the parallel path too.

The gap is two phases that exist **only** on the parallel path and run **before the first row is written**:

| phase | what it does | serial equivalent |
|---|---|---|
| boundary sampling (`ParallelRangeMerge.sampleKeys`) | walks **every page of every segment** to EOF, single-threaded, nothing else running | opens a bare frontier, reads **one page per segment** |
| per-range prefix walk (`RangeScopedPageFrontier.skipToOverlapping`) | walks ~`r/R` of staged bytes for range `r` | none |

Both read and CRC32C-verify every page they step over. `stride` in `sampleKeys` thins which keys are *retained*, not which pages are *read*. At billion scale either alone exceeds the 120 s default total-freeze window.

## The fix

Both loops now tick per page — an `AtomicLong` increment against an I/O-bound loop, so there is no cadence to get wrong.

The tick reaches `RunMetrics` via a new `SortMetrics.markProgress()` hook whose **default is a no-op, and that is a trap worth naming**: `SortMetrics` is a `@FunctionalInterface` wired in most places as a lambda, and the pipeline wired it as `ctx.metrics()::recordStealReason`. A method reference binds *one* method and silently inherits the default for every other — which is exactly how a signal goes missing with no compile error. Both pipeline sites now use a named `RunSortMetrics` bridge, and `RunSortMetricsTest` asserts both hooks forward, so a third hook cannot quietly go unwired.

## Why the existing tests missed it

`SortMergeLiveProgressTest` asserts the reported progress **percentage** (`swath.progress.units` / `ProgressEvent`), not `progressSignal()` — a different number from the one the watchdog reads. And it runs on 5 segments × 30 rows, where both scan phases are instant. Wrong number, unreachable scale.

## Known gaps in this PR

- **No test drives the two scan loops themselves.** The bridge test pins the wiring (the silent-loss mechanism), not the tick sites. Building page-run segments large enough to make the phases observable needs a fixture I did not add. Compensating evidence is a live validation run (below) — but a reviewer should treat the loop-level coverage as missing, not present.
- **This fixes the halt we hit, not the neighbouring defects.** A review of the parallel path also surfaced, unfixed here: all output parts are held open for the whole merge (`drainOpen(..., closeRolledAway=false)`) while the fd reservation is `R` rather than part count; a failing range joins on `awaitTermination(1, DAYS)` with no tick, so a real classified error is re-trapped as `stuck_unknown`; and `swath-sort-range-*` matches nothing in `LivenessWatchdog.isInterruptibleWorker()`, so every trip skips the cooperative unwind and goes straight to `halt` with no terminal summary.

## Validation — CONFIRMED, with the number that explains the bug

Built unreleased (`0.2.3-SNAPSHOT`) and run against two buckets that died on **every** prior attempt, sorted, `n4a-highcpu-16`, R=8. **Both completed.**

| | `its-live-data` | `usgs-lidar-public` |
|---|---:|---:|
| objects | 1,913,719,931 | 1,943,473,918 |
| staged | 44.9 GiB / 126 segments | 54 GiB / 87 segments |
| **`sort.merge_boundaries_ms`** | **136,483 (2m16s)** | **157,039 (2m37s)** |
| `sort.merge_ms` | 878,335 | 943,307 |
| stuck events | 0 | 0 |

`merge_boundaries_ms` is the whole story: the boundary-sampling phase takes **136 s and 157 s** against a **120 s** default stall window, and emitted nothing while it ran. That is the halt, measured. It also explains the size correlation exactly — a 1.04B-object bucket's sampling pass fit inside 120 s and completed; everything at 1.9B crossed it and died.

Note the phase is only ~2 minutes even at 1.9B objects. This is not papering over a slow phase; it is restoring visibility to a fast one that happened to cross an arbitrary threshold.

