### PR TITLE
test: make the max-duration-with-progress test cancel after real progress

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/runtime/MaxDurationNoProgressTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/MaxDurationNoProgressTest.java
@@ -7,6 +7,7 @@ package io.varve.swath.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ import java.io.StringWriter;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -92,12 +94,38 @@ final class MaxDurationNoProgressTest {
     @Test
     void maxDurationWithProgress_staysPlainMaxDuration(@TempDir Path dir) throws Exception {
         RunContext ctx = RunContext.create();
+        // "The first bulk page succeeded" is a property of THIS fetcher, not of the global call
+        // index: a thief's 1-key pivot probe / delimiter structure probe also consumes call indices,
+        // so `idx > 0` does not mean "a bulk page already went out". A CAS on the first bulk page
+        // says exactly what is meant, and — because the winner is never gated below — cannot deadlock.
+        AtomicBoolean firstBulkPageServed = new AtomicBoolean();
         MockPageFetcher fetcher = MockPageFetcher.builder()
                 .keys(Keyspaces.exactly(500))
                 .maxKeysCap(50)
                 .interceptor((req, idx, page) -> {
                     // Let the first bulk page succeed (real progress), then cancel.
-                    if (req.maxKeys() > 1 && idx > 0) {
+                    //
+                    // The cancel must not fire until that page's objects are COUNTED, which happens
+                    // on the OUTPUT stage (OutputStage#writeBatch -> recordEntriesEmitted), several
+                    // hand-offs downstream of this fetch: the owner still has to await its durable
+                    // page commit and hand the batch to the channel. Cancelling as soon as a SECOND
+                    // page was fetched raced all of that — an idle worker sees the token first, its
+                    // CancelledException fails the engine's Scope, and shutdownNow() interrupts the
+                    // owner while it is still parked in awaitCommit, so the first page's keys never
+                    // reach the output stage and the run reports objects=0 (i.e. the summary refines
+                    // to max_duration_no_progress and this test's own premise evaporates).
+                    //
+                    // So gate on the run's own committed-progress reading — sessionObjectsEmitted(),
+                    // the EXACT quantity ListRunner#attributedStatus keys the max_duration /
+                    // max_duration_no_progress split on. It is monotonic, so once it is positive the
+                    // classification and the assertions below are pinned no matter how the workers
+                    // interleave afterwards. Holding this fetch open until then also keeps the run
+                    // from finishing before the cancel lands. Bounded (a failsafe, not a timing
+                    // assumption): a run that never emits fails here loudly instead of hanging.
+                    if (req.maxKeys() > 1 && !firstBulkPageServed.compareAndSet(false, true)) {
+                        await().pollDelay(Duration.ZERO).pollInterval(Duration.ofMillis(1))
+                                .atMost(Duration.ofSeconds(30))
+                                .until(() -> ctx.metrics().sessionObjectsEmitted() > 0L);
                         ctx.cancellation().cancel(StopReason.MAX_DURATION);
                     }
                     return page;


### PR DESCRIPTION
`MaxDurationNoProgressTest.maxDurationWithProgress_staysPlainMaxDuration` is flaky and is currently red on `main`.

**It is a flake, and the commit mapping proves it.** It failed on `0689733a` and `aef3a5fe` — each changing exactly one line of `gradle.properties` — while `2e23a6db`, which carried a substantial code change, passed. Code that passed cannot be broken by a version-string edit. A nightly on `548bfae` was already failing before any of it.

## The race

Not "the cancel beats the progress" — the first page *is* fetched and durably committed. The test cancels **upstream of everything that makes `objects` positive**, so its own premise never gets established:

1. Worker 0 fetches page 1, advances its cursor and enqueues the durable commit under `ws.lock` — which is also what makes it steal-eligible — then parks in `awaitCommit` (`WorkStealingScan.java:730`). The batch has **not** reached the channel yet (`channel.send` is at `:766`, past the await).
2. A thief sees the now-eligible victim, splits it, and claims the child.
3. The child's first bulk fetch trips the test's cancel.
4. Idle workers polling the token in `nextClaim` (`:549`) throw `CancelledException`; the Scope fails and `shutdownNow()` interrupts workers still parked in `awaitCommit`.

Nothing reaches `OutputStage`, so `swath.entries.emitted` stays 0, and `ListRunner#attributedStatus` (`:1252`) correctly refines the stop to `max_duration_no_progress`. Confirmed in a 300-iteration repro: every failure had `objects=0` **and an empty output writer** — page fetched and committed, never emitted.

## The fix — test-only, assertions untouched

The interceptor now holds the second bulk page until `ctx.metrics().sessionObjectsEmitted() > 0` — the **exact** quantity `attributedStatus` keys the `max_duration` / `max_duration_no_progress` split on. That value is monotonic, so once positive both assertions are pinned regardless of later interleaving. Holding the fetch open also stops the run finishing before the cancel lands.

The first bulk page is identified by **CAS, not call index** — a thief's 1-key pivot probe and delimiter structure probe also consume indices, so `idx > 0` does not mean "a bulk page already went out". The CAS winner is never gated, so the emission the gate waits on can always proceed: no deadlock. The bound is `Awaitility` at 30s purely as a failsafe (a run that never emits fails loudly rather than hanging), matching the repo's existing idiom in `ThrottledRunCancelsPromptlyTest:111`.

No sleeps, no retries, no loosened assertions, no production change.

## Evidence of determinism, not reduced probability

- 500 in-JVM iterations: 0 failures. Repeated with 12 CPU spinners saturating an 18-core box: 0 failures.
- `--tests '*MaxDurationNoProgressTest*' --rerun-tasks` × 25 (15 idle, 10 under 14 spinners): all pass. Independently re-run × 5 by the author of this PR: all pass.
- Baseline pre-fix: 3 failures in 300 in-JVM iterations, and 1 in 8 Gradle invocations.
- Full `:swath-core:test` green; `spotlessApply` produced no changes.

## Worth keeping in mind

This is a test fault, but it documents real production behaviour: a `--max-duration` cancel can discard a page that was durably committed but not yet emitted, and the summary then honestly reports `max_duration_no_progress`. That is the existing at-most-once contract for the text sink, not something this PR papers over.

Checked and left alone: `maxDurationWithZeroObjectsEmitted_isDistinctFromALegitPartial` pre-cancels before the scan forks; `NoProgressBackstopContractTest` never boots the engine; the other work-stealing cancel tests either pre-cancel, run one worker, or assert equality rather than "objects > 0 after a mid-run cancel".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for long-running operations.
  * Ensured operations are classified as `max_duration` only after measurable output progress has been recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->