### PR TITLE
metrics: scope listing-phase figures to the listing phase, and give consumers the fields to do the rest

### DIFF
--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -42,12 +42,18 @@ aspect of a run's shape or trajectory from one artifact, without a separate metr
 join. All are omitted (not null-valued) on the construction paths where they never computed.
 
 **`sort.merge_ms` times the WHOLE post-listing tail, not the merge proper alone.** It comes from
-`swath.sort.merge.latency`, started at the listing→merge boundary and stopped once the run finishes
-— so it covers boundary sampling (broken out below as `merge_boundaries_ms`), every merge pass, the
-final output writing/finalize, and publish, not just the k-way merge itself. It is the same span the
-top-level run clocks measure as `duration_ms - listing_duration_ms` (§2/§3 of
-[`metrics-and-observability.md`](../metrics-and-observability.md)) — `listing_duration_ms` ends where
-`merge_ms` begins.
+`swath.sort.merge.latency`, started once the listing→merge boundary has already been crossed and
+stopped once the k-way merge/publish work itself returns — so it covers boundary sampling (broken out
+below as `merge_boundaries_ms`), every merge pass, the final output writing/finalize, and publish, not
+just the k-way merge itself. It is **approximately**, not exactly, the same span the top-level run
+clocks measure as `duration_ms - listing_duration_ms` (§2/§3 of
+[`metrics-and-observability.md`](../metrics-and-observability.md)): the timer starts a little AFTER
+the listing→merge boundary (the staged-segment read and merge setup that run between them), and stops
+a little BEFORE `duration_ms` does (publish's phase-latch writes and the terminal summary assembly run
+after the timer stops, not before) — so `duration_ms - listing_duration_ms` is systematically a bit
+larger than `merge_ms`. On a FAILED merge `merge_ms` never records at all (the timer's stop call sits
+on the success path only), while `duration_ms - listing_duration_ms` still measures whatever wall time
+the failing attempt spent.
 
 **`sort.merge_boundaries_ms`** is the run-total duration read from
 `swath.sort.merge.boundaries.latency`, recorded around `ParallelRangeMerge.boundaries` before any
@@ -137,8 +143,13 @@ on BOTH ends of the ratio on a `--sort` run:** the window end and the wall-time 
 by both freeze at the listing→merge boundary, rather than running to the summary's build time. A
 whole-run denominator would otherwise let the post-listing merge sit inside both the window and the
 denominator on a sorted run, so the gauge mostly reported the merge instead of a genuine serial tail.
-`avg_in_flight` needed no equivalent fix — in-flight is inherently zero once the merge begins, so it
-was already listing-scoped by construction. **Resume semantics:** a `--sort --resume`
+`avg_in_flight` needed no equivalent fix, for a different reason: the sampler only ever records a
+sample on a page emit (the same `recordEntriesEmitted` seam above), and the merge emits no keys, so no
+sample lands during it regardless of which elapsed value the query is handed — the window itself is
+selected purely by cumulative emit-index (`TailOccupancySampler#windowStats`), never by elapsed time.
+The elapsed argument's only role in `avgInFlightForWindow` is a not-yet-positive guard; it is
+`wallShareForWindow`'s own ratio, not `avgInFlightForWindow`'s window selection, that actually divides
+by it — which is exactly why only `wall_share` needed the freeze above. **Resume semantics:** a `--sort --resume`
 reattach's pre-crash backfill (`recordRecoveredObjects`) is folded into the sampler's own baseline
 rather than left to pollute the emitted-keys count it derives the two windows from, so both windows
 stay scoped to THIS process's own relisted span — the same "this process's own view, not the
@@ -320,8 +331,8 @@ Fields:
 | `divergence_depth_histogram[]` | the LCP depth where each split's pivot diverges from its range's cursor (the byte the split turns on), from `recordPivotByteRegion` | the depth distribution of splits; the last bucket is depth `>= 15`. Shallow = splitting near the root; deep = splitting inside long shared prefixes. |
 | `mass_skew_gini` | Gini over the `CHILD_MASS.{empty,tiny,small,large}` distribution | inequality of per-child emitted mass; a **coarse 4-bucket approximation** (raw per-child masses are never retained). High = bimodal empty/large = the zero-transfer-split fingerprint. |
 | `delimiter_fanout.{max,total,probes}` | `commonPrefixes().size()` at each seed + thief `delimiter=/` structure probe | the widest / total delimiter-child count observed and how many probes saw it — the bucket's branching factor. **Thief contributions saturate at `ThiefPolicy.STRUCTURE_PROBE_MAX_KEYS`**, so on a bucket whose structure is discovered at steal time rather than at seed time this under-reads the true branching factor; `STRUCTURE.fanout_capped` says how often that happened. Seed probes are unaffected (they use the full `PROBE_PAGE`). |
-| `regime.api_latency_p50_ms` / `_p99_ms` | client-side percentiles of `swath.api.latency` (now `publishPercentiles(0.5, 0.99)`) | the RTT confound; `null` when no call was timed. **ALL-CALL, not data-page-only:** every LIST call this run made feeds it, including cheap structure/pivot probes (single-key or `delimiter=/` requests) alongside real data pages — so it reads LOW of what a data page actually costs (observed: median 1.11× low at p50, up to 2.68× at p90). See `regime.worker_page_latency_p50_ms`/`_p99_ms` below for the data-page-only pair. |
-| `regime.worker_page_latency_p50_ms` / `_p99_ms` | percentiles of the `worker_page` call class's `total` phase (`swath.fetch.latency.phase{call_class=worker_page,phase=total}` — the same data `probe_latency[]`, §3 below, is built from), since 0.2.4 | the honest serial-baseline estimator: what a page fetch itself costs, with the cheap structure/pivot probes that dilute `regime.api_latency_p50_ms`/`_p99_ms` excluded. `null` when no `worker_page` call completed this run. |
+| `regime.api_latency_p50_ms` / `_p99_ms` | client-side percentiles of `swath.api.latency` (now `publishPercentiles(0.5, 0.99)`) | the RTT confound; `null` when no call was timed. **ALL-CALL, not data-page-only:** every LIST call this run made feeds it, including cheap structure/pivot probes (single-key or `delimiter=/` requests) alongside real data pages — so it reads LOW of what a data page actually costs (observed across a large production fleet, 2026-08: median ~1.11× low at p50, with the gap widening in the tail). See `regime.worker_page_latency_p50_ms`/`_p99_ms` below for the data-page-only pair. |
+| `regime.worker_page_latency_p50_ms` / `_p99_ms` | percentiles of the `worker_page` call class's `total` phase (`swath.fetch.latency.phase{call_class=worker_page,phase=total}` — the same data `probe_latency[]`, §3 below, is built from), since 0.2.4 | the closest available estimator of what a serial lister would pay per page, with the cheap structure/pivot probes that dilute `regime.api_latency_p50_ms`/`_p99_ms` excluded — not a pure one, since `total` records on the failure path too (a timed-out attempt lands in the distribution same as its all-call sibling, §1's `swath.fetch.latency.phase` row). `null` when no `worker_page` call completed this run. |
 | `regime.worker_count` / `region` | the run config (`--concurrency`, `--region`) | the two other regime confounds (`T`, region). |
 | `regime.throttle_includes_attempt_timeout` | constant `false` (since client attempt-timeouts were reclassified as transients) | client `attempt_timeout`s no longer fold into `THROTTLE.*` / the AIMD signal — they are `TRANSIENT.*` (retried, no AIMD vote). `throttle_events` counts real 503/5xx only; see also `transient_events` / `aimd_votes`. |
 | `fingerprint.{binary_sha256,git_sha,started_at,finished_at}` | process/build (best-effort; `null` when unavailable — e.g. a dev exploded-classes run has no `binary_sha256`) | run identity for reproducibility. `argv` is the **top-level** array (referenced, not duplicated). |

--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -41,10 +41,17 @@ its write/atomicity semantics, and the `stop_source`/`error_class` terminal fact
 aspect of a run's shape or trajectory from one artifact, without a separate metrics backend or a log
 join. All are omitted (not null-valued) on the construction paths where they never computed.
 
+**`sort.merge_ms` times the WHOLE post-listing tail, not the merge proper alone.** It comes from
+`swath.sort.merge.latency`, started at the listing→merge boundary and stopped once the run finishes
+— so it covers boundary sampling (broken out below as `merge_boundaries_ms`), every merge pass, the
+final output writing/finalize, and publish, not just the k-way merge itself. It is the same span the
+top-level run clocks measure as `duration_ms - listing_duration_ms` (§2/§3 of
+[`metrics-and-observability.md`](../metrics-and-observability.md)) — `listing_duration_ms` ends where
+`merge_ms` begins.
+
 **`sort.merge_boundaries_ms`** is the run-total duration read from
 `swath.sort.merge.boundaries.latency`, recorded around `ParallelRangeMerge.boundaries` before any
-range thread starts. It is a component of, not an addition to, `sort.merge_ms`: the latter comes
-from `swath.sort.merge.latency` around the whole staging-to-publish merge. Therefore
+range thread starts. It is a component of, not an addition to, `sort.merge_ms` above. Therefore
 `merge_ms - merge_boundaries_ms` isolates the range-execution/publish remainder for scaling analysis.
 Sampling fewer than two distinct keys still records the timer sample before the run falls back to
 serial; that result cannot be known without paying the sampling pass. Because the JSON field stores
@@ -125,7 +132,13 @@ keys emitted, elapsed, in-flight)` triples taken on the same already-serialized 
 seam the consumer stage's per-page key-count bump already uses (see that class's javadoc for the
 stride-gated decimation scheme once the buffer fills) — a small key share paired with a large wall-time
 share is the serial-tail signature these two gauges exist to make legible from `_swath_summary.json`
-alone, without needing the full `trajectory` bin array. **Resume semantics:** a `--sort --resume`
+alone, without needing the full `trajectory` bin array. **`wall_share` is scoped to the LISTING phase
+on BOTH ends of the ratio on a `--sort` run:** the window end and the wall-time denominator it divides
+by both freeze at the listing→merge boundary, rather than running to the summary's build time. A
+whole-run denominator would otherwise let the post-listing merge sit inside both the window and the
+denominator on a sorted run, so the gauge mostly reported the merge instead of a genuine serial tail.
+`avg_in_flight` needed no equivalent fix — in-flight is inherently zero once the merge begins, so it
+was already listing-scoped by construction. **Resume semantics:** a `--sort --resume`
 reattach's pre-crash backfill (`recordRecoveredObjects`) is folded into the sampler's own baseline
 rather than left to pollute the emitted-keys count it derives the two windows from, so both windows
 stay scoped to THIS process's own relisted span — the same "this process's own view, not the
@@ -159,7 +172,9 @@ tally covers both, though the global counters distinguish them), `demand_gated` 
 owner-split was suppressed by the saturation/demand gate — see `OWNER_SPLIT.demand_gated`, §5).
 Always present as an array (possibly empty — an empty array is itself informative: nothing is left
 in flight, e.g. a genuinely COMPLETED run has already drained every range by the time its terminal
-summary is built).
+summary is built). **On a COMPLETED run this array is always empty** — a fully-quiesced worklist has
+no live ranges left to report, by construction, not a bug to chase. The field earns its keep on a
+truncated, timed-out, or otherwise mid-run/interrupted snapshot, where live ranges genuinely remain.
 
 **`probe_latency[]`**: the per-call-class latency-phase percentile breakdown — the dedicated
 readback of `swath.fetch.latency.phase` (§1) since the generic `meters[]` array below carries a
@@ -305,7 +320,8 @@ Fields:
 | `divergence_depth_histogram[]` | the LCP depth where each split's pivot diverges from its range's cursor (the byte the split turns on), from `recordPivotByteRegion` | the depth distribution of splits; the last bucket is depth `>= 15`. Shallow = splitting near the root; deep = splitting inside long shared prefixes. |
 | `mass_skew_gini` | Gini over the `CHILD_MASS.{empty,tiny,small,large}` distribution | inequality of per-child emitted mass; a **coarse 4-bucket approximation** (raw per-child masses are never retained). High = bimodal empty/large = the zero-transfer-split fingerprint. |
 | `delimiter_fanout.{max,total,probes}` | `commonPrefixes().size()` at each seed + thief `delimiter=/` structure probe | the widest / total delimiter-child count observed and how many probes saw it — the bucket's branching factor. **Thief contributions saturate at `ThiefPolicy.STRUCTURE_PROBE_MAX_KEYS`**, so on a bucket whose structure is discovered at steal time rather than at seed time this under-reads the true branching factor; `STRUCTURE.fanout_capped` says how often that happened. Seed probes are unaffected (they use the full `PROBE_PAGE`). |
-| `regime.api_latency_p50_ms` / `_p99_ms` | client-side percentiles of `swath.api.latency` (now `publishPercentiles(0.5, 0.99)`) | the RTT confound; `null` when no call was timed. |
+| `regime.api_latency_p50_ms` / `_p99_ms` | client-side percentiles of `swath.api.latency` (now `publishPercentiles(0.5, 0.99)`) | the RTT confound; `null` when no call was timed. **ALL-CALL, not data-page-only:** every LIST call this run made feeds it, including cheap structure/pivot probes (single-key or `delimiter=/` requests) alongside real data pages — so it reads LOW of what a data page actually costs (observed: median 1.11× low at p50, up to 2.68× at p90). See `regime.worker_page_latency_p50_ms`/`_p99_ms` below for the data-page-only pair. |
+| `regime.worker_page_latency_p50_ms` / `_p99_ms` | percentiles of the `worker_page` call class's `total` phase (`swath.fetch.latency.phase{call_class=worker_page,phase=total}` — the same data `probe_latency[]`, §3 below, is built from), since 0.2.4 | the honest serial-baseline estimator: what a page fetch itself costs, with the cheap structure/pivot probes that dilute `regime.api_latency_p50_ms`/`_p99_ms` excluded. `null` when no `worker_page` call completed this run. |
 | `regime.worker_count` / `region` | the run config (`--concurrency`, `--region`) | the two other regime confounds (`T`, region). |
 | `regime.throttle_includes_attempt_timeout` | constant `false` (since client attempt-timeouts were reclassified as transients) | client `attempt_timeout`s no longer fold into `THROTTLE.*` / the AIMD signal — they are `TRANSIENT.*` (retried, no AIMD vote). `throttle_events` counts real 503/5xx only; see also `transient_events` / `aimd_votes`. |
 | `fingerprint.{binary_sha256,git_sha,started_at,finished_at}` | process/build (best-effort; `null` when unavailable — e.g. a dev exploded-classes run has no `binary_sha256`) | run identity for reproducibility. `argv` is the **top-level** array (referenced, not duplicated). |
@@ -769,8 +785,8 @@ retired — its emitter was deleted in the same change that added the annotation
 | `SHED` | `timeout_storm` | the sustained-timeout SHED engaged — a starved attempt-timeout storm shed the concurrency target `T` (multiplicative ×0.5, ≤1 per jittered ~30s window; paired with `swath.aimd.timeout_shed`, NOT an AIMD vote). Since probe timeouts stopped feeding the shed gate, ONLY `slotGated=true` WORKER-fetch timeouts can trip this — a probe (pivot/structure) timeout never gates it (see `timeout_storm_probe_fed` below) | |
 | `SHED` | `timeout_storm_worker_fed` | at the SAME shed fire as `timeout_storm` above, magnitude-incremented by the number of `slotGated=true` WORKER-fetch timeouts that fed the tripped window (`ConcurrencyGauge#onTransientTimeout(boolean)`, read at fire time) — the call-class mix that fed the storm, the client-vs-server falsifier signal. Since probe timeouts stopped feeding the shed gate this is the ENTIRE gate: it equals the window's `shedWindowTimeouts` total that actually tripped the shed | |
 | `SHED` | `timeout_storm_probe_fed` | the probe-fetch (`slotGated=false`) half of the call-class split — same shed fire, same window, magnitude-incremented by the probe-timeout count. **VISIBILITY-ONLY.** A probe timeout carries no S3-backpressure signal, so it no longer feeds `shedWindowTimeouts` and can never gate/trip `timeout_storm` on its own — a pure probe-timeout storm now sheds nothing (before probe timeouts were excluded it could, the client-vs-server false positive). This counter still publishes at whatever shed a WORKER storm fires, showing the probe pressure that coexisted with it, purely as a diagnostic | |
-| `FREEZE` | `latency_inflation` | the latency-freeze rung engaged — the successful-attempt latency EWMA inflated past `LATENCY_FREEZE_FACTOR`× the rolling-min baseline, freezing the +1 growth (paired with `swath.aimd.latency_freeze`; a growth GATE, never a decrease) | |
-| `FREEZE` | `transient_timeouts` | the transient-timeout growth-freeze rung engaged — the 10s transient-timeout window (fed ONLY by `slotGated=true` WORKER-fetch timeouts, since probe transients were excluded) reached `TRANSIENT_FREEZE_THRESHOLD`, freezing the +1/doubling growth step (paired with `swath.aimd.growth_freeze`; a growth GATE, never a decrease; distinct from `latency_inflation` above so post-hoc can tell which rung suppressed a given step) | |
+| `FREEZE` | `latency_inflation` | the latency-freeze rung engaged — the successful-attempt latency EWMA inflated past `LATENCY_FREEZE_FACTOR`× the rolling-min baseline, freezing the +1 growth (paired with `swath.aimd.latency_freeze`; a growth GATE, never a decrease). Every success that reaches this and the `transient_timeouts` gate below (i.e. did NOT return early at `Tmax` or inside a throttle cool-down) also increments `swath.aimd.freeze_gate_checks` — the denominator a freeze count needs: raw `latency_freezes` is not comparable across runs at different saturation (a healthy saturated run legitimately reads `0` by design), but `latency_freezes / freeze_gate_checks` is | |
+| `FREEZE` | `transient_timeouts` | the transient-timeout growth-freeze rung engaged — the 10s transient-timeout window (fed ONLY by `slotGated=true` WORKER-fetch timeouts, since probe transients were excluded) reached `TRANSIENT_FREEZE_THRESHOLD`, freezing the +1/doubling growth step (paired with `swath.aimd.growth_freeze`; a growth GATE, never a decrease; distinct from `latency_inflation` above so post-hoc can tell which rung suppressed a given step). Shares the same `swath.aimd.freeze_gate_checks` denominator as `latency_inflation` above — `growth_freezes / freeze_gate_checks` is the comparable rate | |
 | `GROWTH` | `probe_timeout_excluded` | a probe-class transient (attempt-timeout or network fault) excluded from congestion/growth-freeze — the caller does not distinguish fault kind at this call site (it mirrors the shed-side classification, which excludes both kinds identically), so this fires for either; carries no S3-backpressure signal, so it no longer ends slow-start or feeds `FREEZE.transient_timeouts` on its own; it still increments `shedWindowProbeTimeouts` for `timeout_storm_probe_fed` visibility. Name kept as `probe_timeout_excluded` for continuity with the pre-existing metric even though network faults share the path — attempt-timeouts dominate on probes | |
 | `GROWTH` | `frozen_growth_valve` | the latency-inflation freeze VALVE engaged — while `latencyFrozen()` (and NOT `growthFrozen()`) with progress (successes above the starvation gate) and the ~30 s valve cool-down elapsed, one paced additive +1 was admitted, demoting the latency latch to a damper. Fires per admitted step; `FREEZE/latency_inflation` still fires on the same step (semantics unchanged, pre/post comparable). A growth path, never a decrease. | |
 | `THROTTLE` | `network` | REMOVED 2026-07-07 — reclassified to `TRANSIENT.network`: a client-side network fault is self-inflicted, not S3 backpressure, and must not vote AIMD down | removed |

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -213,9 +213,13 @@ keys_per_sec`.
 
 `objects` describes the **dataset the run published**, so on a resume it includes the rows a
 previous attempt already made durable (managed-Parquet parts, `--sort` staging segments) — the same
-rows the published `manifest.json` counts. Everything measured against this process's own clock or
-its own API calls (`keys_per_sec`, `api_calls_per_1k_objects`, `overfetch_ratio`) excludes them: the
-recovered rows cost this run neither a second nor a LIST call.
+rows the published `manifest.json` counts. `recovered_objects` (since 0.2.4, additive under schema
+v2; JSON top level, emitted immediately after `objects`) is exactly that resume-backfilled count —
+`0` on a fresh run, and the row count this process never listed itself. Everything measured against
+this process's own clock or its own API calls (`keys_per_sec`, `api_calls_per_1k_objects`,
+`overfetch_ratio`) excludes it: `objects − recovered_objects` is the this-process-only numerator
+those per-second/per-API-call figures actually divide, and the recovered rows cost this run neither a
+second nor a LIST call.
 
 **`duration_ms` is the WHOLE post-seed run clock, not the whole session.** A fresh run's seed step
 (probing the bucket's shape to tile the initial worklist) runs BEFORE this clock's zero point, so
@@ -245,8 +249,9 @@ count and the merge parallelism actually used.
 
 `listing_duration_ms` is the authoritative denominator when what you want is the listing-phase rate
 instead. Reading it back requires two corrections, both already how `keys_per_sec` itself is scoped
-(§2 above): the denominator is in milliseconds, and the numerator must exclude a resume's recovered
-rows (the `-v` progress line's `recovered_objects`, §4) since this process never listed them. So
+(above): the denominator is in milliseconds, and the numerator must exclude a resume's recovered
+rows — the summary's own top-level `recovered_objects` field (above), not a value reconstructed from
+the `-v` progress line — since this process never listed them. So
 listing keys/s is `(objects − recovered_objects) ÷ (listing_duration_ms / 1000)`, not the raw
 `objects ÷ listing_duration_ms` a reader might reach for first (that both overstates the numerator on
 a resumed run by the whole backfill, and understates the rate 1000× by dividing by milliseconds — see
@@ -311,8 +316,8 @@ A machine-readable, versioned sidecar carrying the complete end-of-run state —
 renamed, retyped, or given a new meaning. **Added fields do not bump it**, so a consumer must
 tolerate keys it does not recognise rather than treat the object as closed: version `2` has gained
 `session_duration_ms`, `cost.basis`, `engine.time_to_first_steal_ms` /
-`engine.time_to_peak_in_flight_ms`, and `listing_duration_ms` since it was first published, and will
-gain more. Key
+`engine.time_to_peak_in_flight_ms`, `listing_duration_ms`, and `recovered_objects` since it was first
+published, and will gain more. Key
 **presence** is the other axis, and it is not a schema signal: several fields are legitimately
 absent or `null` on a given write — `meters[]` on a degraded terminal write (below), the
 `time_to_*` pair when the event never happened, `cost` when the endpoint is overridden and the
@@ -378,6 +383,7 @@ downstream parser should key off, not "does `meters[]` exist".
   "session_duration_ms": 25731,
   "listing_duration_ms": 25731,
   "objects": 109858,
+  "recovered_objects": 0,
   "config": {
     "target": "s3://my-bucket", "region": "us-east-2", "format": "parquet",
     "max_parallel_listings": 64, "no_sign_request": true, "rate_limit_api": null,

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -38,7 +38,7 @@ stderr is a terminal or a file — see [`usage.md`](usage.md#end-of-run-summary)
 | `swath.workers.active` | gauge | — | live concurrency target `T` (the AIMD value) |
 | `swath.in_flight.avg` | gauge | — | time-weighted average in-flight listing count since run start, folded on every in-flight transition (sample-on-change, no polling thread). Also carried end-of-run as `avg_in_flight` in the JSON summary `engine` block (§3), next to `peak_in_flight`: `peak_in_flight` saturates and blinds you once the concurrency ceiling is hit, while `avg_in_flight` shows whether the run *sustained* parallelism or merely spiked to it |
 | `swath.tail_occupancy.avg_in_flight` | gauge | `{pct}` | the mean in-flight count over the window in which the LAST `pct`% (`5` or `10`) of the run's keys were emitted — a whole-run `avg_in_flight` cannot screen for a serial tail (see [`metrics-internals.md`](internals/metrics-internals.md) §3's `trajectory` block, and this meter's own rationale there), so this is measured specifically at the END of the run instead. `NaN` before any page has emitted a key |
-| `swath.tail_occupancy.wall_share` | gauge | `{pct}` | that same last-`pct`%-of-keys window's share of the run's wall time so far — a serial tail is a SMALL key share paired with a LARGE wall-time share. Scoped to the LISTING phase on BOTH ends on a `--sort` run: the window end and the wall-time denominator both freeze at the listing→merge boundary, so the post-listing merge can never inflate this gauge — a whole-run denominator would otherwise read mostly the merge instead of a genuine serial tail. `avg_in_flight` above was already listing-scoped by construction (in-flight is inherently zero once the merge begins) and needed no fix; `NaN` under the same unobserved idiom as that meter |
+| `swath.tail_occupancy.wall_share` | gauge | `{pct}` | that same last-`pct`%-of-keys window's share of the run's wall time so far — a serial tail is a SMALL key share paired with a LARGE wall-time share. Scoped to the LISTING phase on BOTH ends on a `--sort` run: the window end and the wall-time denominator both freeze at the listing→merge boundary, so the post-listing merge can never inflate this gauge — a whole-run denominator would otherwise read mostly the merge instead of a genuine serial tail. `avg_in_flight` above needed no equivalent fix: its window is selected purely by emit-index (the last `pct`% of THIS process's listed keys), and the merge emits no keys, so no merge-time sample ever lands in that window regardless of which elapsed value is fed in — elapsed only guards against a not-yet-positive read there, it is never a divisor. `NaN` under the same unobserved idiom as that meter |
 | `swath.steals` | counter | `{result}` | steal outcomes (e.g. `CHILD_CREATED`) |
 | `swath.errors` | counter | `{type}` | errors by type (e.g. `throttle`) |
 | `swath.steal_reason` | counter | `{outcome, reason}` | engagement counters for every steal/split/seed decision path (§5); bounded enum (~30-50 `outcome.reason` combinations, same low-cardinality shape as `swath.steals{result}`) |
@@ -230,15 +230,35 @@ by tens of seconds.
 
 **`listing_duration_ms`** (since 0.2.4, additive under schema v2) is the THIRD clock, carried
 alongside the other two: the listing-only span, ending at the listing→merge boundary on a `--sort`
-run, and equal to `duration_ms` on a run that never merges. It exists because `keys_per_sec`
-(`efficiency.keys_per_sec`), `efficiency.cpu_efficiency`, and `engine.avg_in_flight` all divide by
-the whole-run `duration_ms` and deliberately KEEP that whole-run semantics for compatibility — so on
-a sorted run they are diluted by the merge (median ~20% of wall, up to ~64% observed on real sorted
-runs — see [performance.md](performance.md#reading-the-merges-share-of-the-wall)).
+run, and equal to `duration_ms` on a run that never merges. That boundary is where listing HANDS OFF
+to the merge, not the instant of the last LIST response: on a `--sort` run `listing_duration_ms`
+still includes the sort lane's final drain/encode of its staged segments (real staging work that
+happens after the last key was listed), so it is the listing-and-staging span, not a bare
+API-calls-only span. It exists because `keys_per_sec` (`efficiency.keys_per_sec`),
+`efficiency.cpu_efficiency`, and `engine.avg_in_flight` all divide by the whole-run `duration_ms` and
+deliberately KEEP that whole-run semantics for compatibility — so on a sorted run they are diluted by
+the merge. The [PR #99 field-campaign table](performance.md#the-sorted-merge) is the source for how
+much: on its shipped-default arm the merge tail ran 20–39% of session wall across the three sorted
+buckets measured (median ~32%), rising to as much as ~72% of session wall on the explicit-serial-merge
+arm — recompute from that table for any other split, since the ratio depends on the bucket's segment
+count and the merge parallelism actually used.
+
 `listing_duration_ms` is the authoritative denominator when what you want is the listing-phase rate
-instead: listing keys/s is `objects ÷ listing_duration_ms`, and rescaling `avg_in_flight` to the
-listing phase is `avg_in_flight × duration_ms ÷ listing_duration_ms` (see
+instead. Reading it back requires two corrections, both already how `keys_per_sec` itself is scoped
+(§2 above): the denominator is in milliseconds, and the numerator must exclude a resume's recovered
+rows (the `-v` progress line's `recovered_objects`, §4) since this process never listed them. So
+listing keys/s is `(objects − recovered_objects) ÷ (listing_duration_ms / 1000)`, not the raw
+`objects ÷ listing_duration_ms` a reader might reach for first (that both overstates the numerator on
+a resumed run by the whole backfill, and understates the rate 1000× by dividing by milliseconds — see
+the `meters[]`-in-seconds trap above for the mirror image of that same units mistake). Rescaling
+`avg_in_flight` to the listing phase is `avg_in_flight × duration_ms ÷ listing_duration_ms` (see
 [performance.md](performance.md#the-one-number-to-look-at-first-in-flight-utilisation)).
+
+**On a merge-only `--sort --resume`** (`sort.merge_only_resume: true` — this process re-runs only the
+merge from durable staging segments, zero new LIST fetches), `listing_duration_ms` lands near zero
+while `objects` is the FULL recovered dataset — the honest figure for a run that listed nothing, not
+a gap. Listing-phase rates are meaningless for such a run; check `sort.merge_only_resume` before
+computing one.
 
 None of the three figures is wrong — read `duration_ms`/`keys_per_sec`/`avg_in_flight` for the
 whole-run figures the summary always reports, `listing_duration_ms` when the listing phase needs to

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -207,19 +207,19 @@ proactive-cap contribution mixed into it.
 
 ## 2. `list_run_summary` (one line at run end)
 
-Core: `run_id, objects, duration_ms, listing_duration_ms, session_duration_ms, strategy, api_calls,
-cost_usd, output_files, compressed_size_bytes, keys, pages, peak_in_flight, steals, splits, errors,
-keys_per_sec`.
+Core: `run_id, objects, recovered_objects, duration_ms, listing_duration_ms, session_duration_ms,
+strategy, api_calls, cost_usd, output_files, compressed_size_bytes, keys, pages, peak_in_flight,
+steals, splits, errors, keys_per_sec`.
 
 `objects` describes the **dataset the run published**, so on a resume it includes the rows a
 previous attempt already made durable (managed-Parquet parts, `--sort` staging segments) — the same
 rows the published `manifest.json` counts. `recovered_objects` (since 0.2.4, additive under schema
-v2; JSON top level, emitted immediately after `objects`) is exactly that resume-backfilled count —
-`0` on a fresh run, and the row count this process never listed itself. Everything measured against
-this process's own clock or its own API calls (`keys_per_sec`, `api_calls_per_1k_objects`,
-`overfetch_ratio`) excludes it: `objects − recovered_objects` is the this-process-only numerator
-those per-second/per-API-call figures actually divide, and the recovered rows cost this run neither a
-second nor a LIST call.
+v2; emitted right after `objects` on both this line and the JSON top level) is exactly that
+resume-backfilled row count — the rows this process never listed itself, `0` on a fresh run.
+Everything measured against this process's own clock or its own API calls (`keys_per_sec`,
+`api_calls_per_1k_objects`, `overfetch_ratio`) excludes it: `objects − recovered_objects` is the
+this-process-only numerator those per-second/per-API-call figures actually divide, and the recovered
+rows cost this run neither a second nor a LIST call.
 
 **`duration_ms` is the WHOLE post-seed run clock, not the whole session.** A fresh run's seed step
 (probing the bucket's shape to tile the initial worklist) runs BEFORE this clock's zero point, so
@@ -261,9 +261,13 @@ the `meters[]`-in-seconds trap above for the mirror image of that same units mis
 
 **On a merge-only `--sort --resume`** (`sort.merge_only_resume: true` — this process re-runs only the
 merge from durable staging segments, zero new LIST fetches), `listing_duration_ms` lands near zero
-while `objects` is the FULL recovered dataset — the honest figure for a run that listed nothing, not
-a gap. Listing-phase rates are meaningless for such a run; check `sort.merge_only_resume` before
-computing one.
+while `objects` is the FULL recovered dataset and `recovered_objects` equals it — the honest figures
+for a run that listed nothing, not a gap. `keys_per_sec` reads `0.0` **by construction** on such a
+run, not merely a meaningless nonzero number: its numerator is `objects − recovered_objects`, which
+is `0` here, because a process that issued zero LIST calls did no listing work to rate. A summary
+written by a build older than this fix instead let the recovered dataset stand in as this process's
+own numerator, producing a spuriously huge rate rather than `0.0` — check `sort.merge_only_resume`
+before trusting a listing-phase rate from such a summary.
 
 None of the three figures is wrong — read `duration_ms`/`keys_per_sec`/`avg_in_flight` for the
 whole-run figures the summary always reports, `listing_duration_ms` when the listing phase needs to

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -38,7 +38,7 @@ stderr is a terminal or a file — see [`usage.md`](usage.md#end-of-run-summary)
 | `swath.workers.active` | gauge | — | live concurrency target `T` (the AIMD value) |
 | `swath.in_flight.avg` | gauge | — | time-weighted average in-flight listing count since run start, folded on every in-flight transition (sample-on-change, no polling thread). Also carried end-of-run as `avg_in_flight` in the JSON summary `engine` block (§3), next to `peak_in_flight`: `peak_in_flight` saturates and blinds you once the concurrency ceiling is hit, while `avg_in_flight` shows whether the run *sustained* parallelism or merely spiked to it |
 | `swath.tail_occupancy.avg_in_flight` | gauge | `{pct}` | the mean in-flight count over the window in which the LAST `pct`% (`5` or `10`) of the run's keys were emitted — a whole-run `avg_in_flight` cannot screen for a serial tail (see [`metrics-internals.md`](internals/metrics-internals.md) §3's `trajectory` block, and this meter's own rationale there), so this is measured specifically at the END of the run instead. `NaN` before any page has emitted a key |
-| `swath.tail_occupancy.wall_share` | gauge | `{pct}` | that same last-`pct`%-of-keys window's share of the run's total wall time so far — a serial tail is a SMALL key share paired with a LARGE wall-time share. `NaN` under the same unobserved idiom as the meter above |
+| `swath.tail_occupancy.wall_share` | gauge | `{pct}` | that same last-`pct`%-of-keys window's share of the run's wall time so far — a serial tail is a SMALL key share paired with a LARGE wall-time share. Scoped to the LISTING phase on BOTH ends on a `--sort` run: the window end and the wall-time denominator both freeze at the listing→merge boundary, so the post-listing merge can never inflate this gauge — a whole-run denominator would otherwise read mostly the merge instead of a genuine serial tail. `avg_in_flight` above was already listing-scoped by construction (in-flight is inherently zero once the merge begins) and needed no fix; `NaN` under the same unobserved idiom as that meter |
 | `swath.steals` | counter | `{result}` | steal outcomes (e.g. `CHILD_CREATED`) |
 | `swath.errors` | counter | `{type}` | errors by type (e.g. `throttle`) |
 | `swath.steal_reason` | counter | `{outcome, reason}` | engagement counters for every steal/split/seed decision path (§5); bounded enum (~30-50 `outcome.reason` combinations, same low-cardinality shape as `swath.steals{result}`) |
@@ -52,6 +52,7 @@ stderr is a terminal or a file — see [`usage.md`](usage.md#end-of-run-summary)
 | `swath.page.short_truncated` | counter | — | truncated pages that returned fewer than `max-keys` |
 | `swath.throttle.events` | counter | `{type}` | throttle events, typed `attempt_timeout\|slowdown\|server5xx\|network` — separates a real S3 `503 SlowDown`/5xx/network fault from a **self-inflicted** client-side attempt timeout. The distinction is load-bearing: counting swath's own 30 s timeouts as "throttle" collapses AIMD to serial with zero real `slowdown` |
 | `swath.aimd.target_reductions` | counter | — | AIMD concurrency-target reductions |
+| `swath.aimd.freeze_gate_checks` | counter | — | the number of page successes that actually REACHED the AIMD growth-freeze gates (`latency_inflation`/`transient_timeouts`, §5 of [`metrics-internals.md`](internals/metrics-internals.md)) — a success at `Tmax`, or one landing inside a throttle cool-down, returns before ever checking, so it can never freeze. This is the denominator a freeze count needs to be comparable across runs: raw `latency_freezes`/`growth_freezes` are not comparable across runs sitting at different saturation (a healthy, fully-saturated run legitimately reads `0` freezes by design), but `latency_freezes / freeze_gate_checks` and `growth_freezes / freeze_gate_checks` are. Surfaced in the JSON summary's `recovered_errors` rollup as `freeze_gate_checks` |
 | `swath.owner_split.demand_gated_t` | gauge | — | the effective concurrency target `T` observed at the INSTANT the most recent `OWNER_SPLIT.demand_gated` suppression fired — so a shed-shrunken `T` closing the owner-split demand gate is visible without cross-referencing `swath.workers.active`'s history against a log timestamp. `NaN` until the gate has fired at least once |
 | `swath.owner_split.demand_gated_t_min` | gauge | — | the LOWEST effective `T` observed across every demand-gate firing this run (the running min, mirroring `swath.aimd.target_low_water`'s idiom) — how far the shed/AIMD brake had pulled `T` down at the gate's worst observed moment. `NaN` until the gate has fired at least once |
 | `swath.queue.wait` | timer | — | producer backpressure (bounded output queue full) — one observation per page, recorded from every producer that hands a page onto the bounded output channel (`WorkStealingScan`, and the sequential `ScanProducer`/`CheckpointedScanProducer` paths), not the fetch worker exclusively. A **client-service-cost span** (§3 `client_cost[]`): publishes p50/p90/p99 |
@@ -170,6 +171,12 @@ field (the four fields may come from different attempts); acceptable at scrape g
   every run's payload carries `SUMMARY`/`GAUGE` datapoints under any value of that env var. The pin
   is forward-looking — it guarantees that any future histogram-publishing series gets a wire shape
   decided by swath, not by the ambient environment.
+- **`meters[]` percentile gauge values are in SECONDS, not milliseconds.** A published-percentile
+  gauge (e.g. `swath.api.latency{phi=0.5}`) carries its `value` in Micrometer's base time unit, which
+  is seconds — unlike every `*_ms` field the JSON summary writes directly (`probe_latency[]`,
+  `client_cost[]`, `shape.regime.api_latency_p*_ms`, `duration_ms`, `listing_duration_ms`, …), which
+  are all milliseconds. A consumer reading `meters[]` generically rather than through one of those
+  dedicated `*_ms` readbacks will silently read a value 1000× too small if it assumes milliseconds.
 
 ### 1.1 Throttle coverage: proactive cap vs. reactive AIMD backoff
 
@@ -200,8 +207,9 @@ proactive-cap contribution mixed into it.
 
 ## 2. `list_run_summary` (one line at run end)
 
-Core: `run_id, objects, duration_ms, session_duration_ms, strategy, api_calls, cost_usd, output_files,
-compressed_size_bytes, keys, pages, peak_in_flight, steals, splits, errors, keys_per_sec`.
+Core: `run_id, objects, duration_ms, listing_duration_ms, session_duration_ms, strategy, api_calls,
+cost_usd, output_files, compressed_size_bytes, keys, pages, peak_in_flight, steals, splits, errors,
+keys_per_sec`.
 
 `objects` describes the **dataset the run published**, so on a resume it includes the rows a
 previous attempt already made durable (managed-Parquet parts, `--sort` staging segments) — the same
@@ -209,23 +217,48 @@ rows the published `manifest.json` counts. Everything measured against this proc
 its own API calls (`keys_per_sec`, `api_calls_per_1k_objects`, `overfetch_ratio`) excludes them: the
 recovered rows cost this run neither a second nor a LIST call.
 
-**`duration_ms` is the LISTING clock, not the whole session.** A fresh run's seed step (probing the
-bucket's shape to tile the initial worklist) runs BEFORE this clock's zero point, so `duration_ms` —
-and everything divided by it, `keys_per_sec` included — excludes seeding entirely; it is the honest
-throughput denominator, since seeding fetches no object. `session_duration_ms` is the OTHER clock,
+**`duration_ms` is the WHOLE post-seed run clock, not the whole session.** A fresh run's seed step
+(probing the bucket's shape to tile the initial worklist) runs BEFORE this clock's zero point, so
+`duration_ms` excludes seeding entirely — it is not, however, listing-only: on a `--sort` run it
+keeps running through the entire post-listing merge/publish tail too, so it is the honest
+whole-post-seed-run denominator, not a listing-phase one. `session_duration_ms` is the OTHER clock,
 carried alongside it on this same line (and at the JSON report's top level): the whole CLI
 invocation, seeding included — the same span the live progress line's `elapsed` already reports. The
 two agree exactly on a resumed run (seeding never re-runs on a normal resume) or any run whose seed
 step was cheap; a fresh run against a deeply-nested or hinted bucket is where they diverge, sometimes
-by tens of seconds. Neither figure is wrong — read `duration_ms` for throughput, `session_duration_ms`
-for "how long did the operator actually wait" — see the end-of-run summary block below, which prints
-both, clearly labeled, exactly when they diverge materially; that same clock is also what decides
-whether the block prints at all.
+by tens of seconds.
+
+**`listing_duration_ms`** (since 0.2.4, additive under schema v2) is the THIRD clock, carried
+alongside the other two: the listing-only span, ending at the listing→merge boundary on a `--sort`
+run, and equal to `duration_ms` on a run that never merges. It exists because `keys_per_sec`
+(`efficiency.keys_per_sec`), `efficiency.cpu_efficiency`, and `engine.avg_in_flight` all divide by
+the whole-run `duration_ms` and deliberately KEEP that whole-run semantics for compatibility — so on
+a sorted run they are diluted by the merge (median ~20% of wall, up to ~64% observed on real sorted
+runs — see [performance.md](performance.md#reading-the-merges-share-of-the-wall)).
+`listing_duration_ms` is the authoritative denominator when what you want is the listing-phase rate
+instead: listing keys/s is `objects ÷ listing_duration_ms`, and rescaling `avg_in_flight` to the
+listing phase is `avg_in_flight × duration_ms ÷ listing_duration_ms` (see
+[performance.md](performance.md#the-one-number-to-look-at-first-in-flight-utilisation)).
+
+None of the three figures is wrong — read `duration_ms`/`keys_per_sec`/`avg_in_flight` for the
+whole-run figures the summary always reports, `listing_duration_ms` when the listing phase needs to
+be isolated from a `--sort` run's merge, and `session_duration_ms` for "how long did the operator
+actually wait" — see the end-of-run summary block below, which prints `duration_ms` and
+`session_duration_ms`, clearly labeled, exactly when they diverge materially; that same clock is also
+what decides whether the block prints at all.
 
 The JSON report's `engine` block additionally carries the two ramp-up timings the
 `list_run_diagnostics` line prints — `time_to_first_steal_ms` and `time_to_peak_in_flight_ms`
 (milliseconds from run start; `null` when the event never happened) — and `cost.basis` names the
 rate `cost_usd` was derived from (`rate_per_1k_usd`, `source`), so no consumer has to assume it.
+
+**`cost.api_calls` vs. `engine.pages`.** The two count different things and are not interchangeable.
+`cost.api_calls` (mirrored in the `list_run_summary` line as `api_calls`) counts every LIST request
+this run **issued**, including engine throttle-retries — the real HTTP-request count, and the only
+one of the two that measures S3 request cost (`cost_usd`, `api_calls_per_1k_objects` both derive from
+it). `engine.pages` counts pages **kept and shipped downstream**: a page whose keys were all dropped
+by a filter is fetched — and so counts toward `cost.api_calls` — but never counts toward
+`engine.pages`. Reading `pages` where `api_calls` belongs undercounts requests on any filtered run.
 
 **Efficiency / resource fields** (summary/log fields — NOT Micrometer meters; sampled once at end;
 `-1` where unavailable, e.g. off-Linux):
@@ -257,8 +290,9 @@ A machine-readable, versioned sidecar carrying the complete end-of-run state —
 **What `schema_version` promises.** It is bumped only for a **breaking** change — a field removed,
 renamed, retyped, or given a new meaning. **Added fields do not bump it**, so a consumer must
 tolerate keys it does not recognise rather than treat the object as closed: version `2` has gained
-`session_duration_ms`, `cost.basis`, and `engine.time_to_first_steal_ms` /
-`engine.time_to_peak_in_flight_ms` since it was first published, and will gain more. Key
+`session_duration_ms`, `cost.basis`, `engine.time_to_first_steal_ms` /
+`engine.time_to_peak_in_flight_ms`, and `listing_duration_ms` since it was first published, and will
+gain more. Key
 **presence** is the other axis, and it is not a schema signal: several fields are legitimately
 absent or `null` on a given write — `meters[]` on a degraded terminal write (below), the
 `time_to_*` pair when the event never happened, `cost` when the endpoint is overridden and the
@@ -322,6 +356,7 @@ downstream parser should key off, not "does `meters[]` exist".
   "as_of": "2026-07-01T00:00:25Z",
   "duration_ms": 25731,
   "session_duration_ms": 25731,
+  "listing_duration_ms": 25731,
   "objects": 109858,
   "config": {
     "target": "s3://my-bucket", "region": "us-east-2", "format": "parquet",
@@ -385,6 +420,7 @@ downstream parser should key off, not "does `meters[]` exist".
     "delimiter_fanout": { "max": 37, "total": 210, "probes": 12 },
     "regime": {
       "api_latency_p50_ms": 41.2, "api_latency_p99_ms": 210.7,
+      "worker_page_latency_p50_ms": 45.6, "worker_page_latency_p99_ms": 224.9,
       "worker_count": 64, "region": "us-east-2",
       "throttle_includes_attempt_timeout": false
     },

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -216,8 +216,16 @@ by an older build that lacks the field, fall back to
 `avg_in_flight × duration_ms / (duration_ms − sort.merge_ms)`. The same dilution
 hits `keys_per_sec` and `cpu_efficiency` on a sorted run — both divide by the
 whole-run `duration_ms`, merge included — so the honest listing-phase rate is
-`objects ÷ listing_duration_ms`, not `efficiency.keys_per_sec`. An unsorted run
-needs no correction: `listing_duration_ms` equals `duration_ms`.
+`(objects − recovered_objects) ÷ (listing_duration_ms / 1000)`, not
+`efficiency.keys_per_sec`: the `/1000` matters (`listing_duration_ms` is
+milliseconds, and dividing by it directly gives keys per MILLISECOND, 1000×
+low), and so does excluding `recovered_objects` (the `-v` progress line's
+resume-backfill count — a `--sort --resume` that recovered rows would otherwise
+have its listing rate overstated by the whole backfill, which this process
+never listed). See
+[metrics-and-observability.md](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end)
+for both fields. An unsorted run needs no correction to the DENOMINATOR:
+`listing_duration_ms` equals `duration_ms`.
 
 ### Is the wall the remote, or you?
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -219,7 +219,7 @@ whole-run `duration_ms`, merge included — so the honest listing-phase rate is
 `(objects − recovered_objects) ÷ (listing_duration_ms / 1000)`, not
 `efficiency.keys_per_sec`: the `/1000` matters (`listing_duration_ms` is
 milliseconds, and dividing by it directly gives keys per MILLISECOND, 1000×
-low), and so does excluding `recovered_objects` (the `-v` progress line's
+low), and so does excluding `recovered_objects` (the summary's own top-level
 resume-backfill count — a `--sort --resume` that recovered rows would otherwise
 have its listing rate overstated by the whole backfill, which this process
 never listed). See

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -208,10 +208,16 @@ makes things worse, not better** — you add scheduling overhead to fetch work
 that does not exist yet.
 
 One caveat when reading a `--sort` run: `avg_in_flight` is averaged over the
-WHOLE run, and in-flight is zero for the entire merge phase, so a sorted run's
-figure is diluted. Rescale it to the listing phase before judging:
-`avg_in_flight × duration_ms / (duration_ms − sort.merge_ms)`. An unsorted run
-needs no correction.
+WHOLE run, and in-flight is zero for the entire post-listing merge/publish tail,
+so a sorted run's figure is diluted. Since 0.2.4 the summary carries
+`listing_duration_ms` — the listing-only clock — directly, so rescale with
+`avg_in_flight × duration_ms / listing_duration_ms`. Against a summary written
+by an older build that lacks the field, fall back to
+`avg_in_flight × duration_ms / (duration_ms − sort.merge_ms)`. The same dilution
+hits `keys_per_sec` and `cpu_efficiency` on a sorted run — both divide by the
+whole-run `duration_ms`, merge included — so the honest listing-phase rate is
+`objects ÷ listing_duration_ms`, not `efficiency.keys_per_sec`. An unsorted run
+needs no correction: `listing_duration_ms` equals `duration_ms`.
 
 ### Is the wall the remote, or you?
 
@@ -238,6 +244,15 @@ Corroborating signals for a genuinely throttling remote:
 `recovered_errors.latency_freezes` climbing, `recovered_errors.min_effective_t`
 falling, non-zero `recovered_errors.connection_aborted`. If those are flat while
 throughput stalls, it is not the remote.
+
+Read `latency_freezes`/`growth_freezes` as a **rate**, not a raw count:
+`recovered_errors.freeze_gate_checks` is the number of page successes that
+actually reached the growth-freeze gates (a success at `Tmax`, or inside a
+throttle cool-down, returns before ever checking, and so can never freeze). A
+healthy saturated run legitimately reads `latency_freezes: 0` by design, and raw
+freeze counts are not comparable across runs sitting at different saturation —
+compare `latency_freezes / freeze_gate_checks` (and `growth_freezes /
+freeze_gate_checks`) instead.
 
 ### Sizing CPU
 
@@ -346,8 +361,14 @@ in-flight utilisation from a single run and infer from those.
 ### Reading the merge's share of the wall
 
 On `--sort` runs, `sort.merge_ms ÷ session_duration_ms` is the merge's share of
-full-session wall clock; `duration_ms` is the listing clock and is not the correct
-denominator here. The listing phase parallelises across cores, and eligible large runs now
+full-session wall clock. `duration_ms` is not the right denominator for that
+FULL-SESSION share — it excludes seeding — and, despite reading as though it
+were listing-only, it was never that either: it runs through the merge tail on
+a sorted run just like `session_duration_ms` does, so `sort.merge_ms ÷
+duration_ms` is a legitimate merge share of the post-seed run, seeding excluded
+(`listing_duration_ms`, since 0.2.4, is the field to reach for instead if what
+you actually want is the listing phase's own span, seeding AND merge excluded).
+The listing phase parallelises across cores, and eligible large runs now
 use the core-derived parallel merge by default. The explicit
 `-Dswath.sort.merge-parallelism=1` baseline — or a run forced onto the serial path
 by its staged-size/resource gates — still leaves the merge unchanged as listing
@@ -398,7 +419,9 @@ Do not mix the rates represented by this campaign. MRMS's merge-object rate was 
 for the default merge versus a 733,123 objects/s serial-bracket rate; that is objects processed per
 merge wall, not listing throughput. The separate `823.7 M / 723.2 s ≈ 1.14 million objects/s` figure
 is a **derived full-session object/wall quotient**, spanning listing plus merge. Neither value is the
-run summary's listing-clock `keys_per_sec`, and neither supersedes the directly observed 655,346
+run summary's `keys_per_sec` (itself a whole-run figure on a sorted run, merge included — see
+[metrics-and-observability.md](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end)),
+and neither supersedes the directly observed 655,346
 keys/s unsorted sweep above. No exact 1.5 million keys/s result was measured.
 
 ## Where swath is slow (honest limits)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -978,12 +978,12 @@ When a run ends, swath prints a short summary block to **stderr** (stdout stays 
 
 The headline's elapsed figure is `duration_ms` — the same clock `keys/s` divides by — which starts
 only AFTER a fresh run's seed step (probing the bucket's shape to tile the initial worklist). On an
-unsorted run this genuinely is the listing clock, and the headline labels it ` listing` whenever the
+unsorted run this genuinely is the listing clock, and the headline labels it `listing` whenever the
 second (session) figure below appears. On a `--sort` run `duration_ms` also runs through the whole
 post-listing merge/publish tail, so both the headline and its `keys/s` are whole-run figures on a
 sorted run, diluted by the merge — `--report`'s `listing_duration_ms` is where the listing-phase-only
 rate lives (see [`metrics-and-observability.md`](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end)).
-The headline never prints the ` listing` label on such a run: labeling a span that carries the merge
+The headline never prints the `listing` label on such a run: labeling a span that carries the merge
 with it "listing" would misattribute the merge to the scan, so the label only ever appears when
 `duration_ms` and `listing_duration_ms` genuinely agree.
 
@@ -991,7 +991,7 @@ On a run whose seed step took a while, the headline instead carries a second
 figure, the whole session (seeding included — the same span the live progress line already
 reports), clearly labeled so which one the rate is keyed to is never ambiguous:
 
-```
+```text
   3,270,132 objects in 1m43s listing · 31,750 keys/s · 2m22s total
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -978,10 +978,15 @@ When a run ends, swath prints a short summary block to **stderr** (stdout stays 
 
 The headline's elapsed figure is `duration_ms` — the same clock `keys/s` divides by — which starts
 only AFTER a fresh run's seed step (probing the bucket's shape to tile the initial worklist). On an
-unsorted run this genuinely is the listing clock; on a `--sort` run it also runs through the whole
+unsorted run this genuinely is the listing clock, and the headline labels it ` listing` whenever the
+second (session) figure below appears. On a `--sort` run `duration_ms` also runs through the whole
 post-listing merge/publish tail, so both the headline and its `keys/s` are whole-run figures on a
 sorted run, diluted by the merge — `--report`'s `listing_duration_ms` is where the listing-phase-only
 rate lives (see [`metrics-and-observability.md`](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end)).
+The headline never prints the ` listing` label on such a run: labeling a span that carries the merge
+with it "listing" would misattribute the merge to the scan, so the label only ever appears when
+`duration_ms` and `listing_duration_ms` genuinely agree.
+
 On a run whose seed step took a while, the headline instead carries a second
 figure, the whole session (seeding included — the same span the live progress line already
 reports), clearly labeled so which one the rate is keyed to is never ambiguous:
@@ -990,9 +995,13 @@ reports), clearly labeled so which one the rate is keyed to is never ambiguous:
   3,270,132 objects in 1m43s listing · 31,750 keys/s · 2m22s total
 ```
 
-That second figure only appears when it would actually differ from the listing one by more than
-about a second (`SummaryRenderer.SESSION_DELTA_MIN`) — a resumed run, or any run whose seed step was
-cheap, keeps the single-figure form above rather than printing two near-identical numbers. `--report`
+That's an unsorted run's shape — its `duration_ms` is genuinely listing-only, so the `listing` label
+applies. A `--sort` run with the same seed/session gap prints the same two-figure form minus the
+word `listing` (`3,270,132 objects in 1m43s · 31,750 keys/s · 2m22s total`), since its elapsed figure
+carries the merge too. That second figure only appears when it would actually differ from the first
+by more than about a second (`SummaryRenderer.SESSION_DELTA_MIN`) — a resumed run, or any run whose
+seed step was cheap, keeps the single-figure form above rather than printing two near-identical
+numbers. `--report`
 carries all three unconditionally: `duration_ms` (this headline's clock), the additive
 `session_duration_ms` (the whole invocation), and `listing_duration_ms` (the listing-phase-only clock,
 equal to `duration_ms` on an unsorted run) — see

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -976,9 +976,13 @@ When a run ends, swath prints a short summary block to **stderr** (stdout stays 
   12 files · 84.0 MB written · peak RSS 512.0 MB
 ```
 
-The headline's elapsed figure is the **listing clock** — the same one `keys/s` divides
-by — which starts only AFTER a fresh run's seed step (probing the bucket's shape to tile the
-initial worklist). On a run whose seed step took a while, the headline instead carries a second
+The headline's elapsed figure is `duration_ms` — the same clock `keys/s` divides by — which starts
+only AFTER a fresh run's seed step (probing the bucket's shape to tile the initial worklist). On an
+unsorted run this genuinely is the listing clock; on a `--sort` run it also runs through the whole
+post-listing merge/publish tail, so both the headline and its `keys/s` are whole-run figures on a
+sorted run, diluted by the merge — `--report`'s `listing_duration_ms` is where the listing-phase-only
+rate lives (see [`metrics-and-observability.md`](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end)).
+On a run whose seed step took a while, the headline instead carries a second
 figure, the whole session (seeding included — the same span the live progress line already
 reports), clearly labeled so which one the rate is keyed to is never ambiguous:
 
@@ -989,8 +993,9 @@ reports), clearly labeled so which one the rate is keyed to is never ambiguous:
 That second figure only appears when it would actually differ from the listing one by more than
 about a second (`SummaryRenderer.SESSION_DELTA_MIN`) — a resumed run, or any run whose seed step was
 cheap, keeps the single-figure form above rather than printing two near-identical numbers. `--report`
-carries both unconditionally: `duration_ms` (listing, unchanged) and the additive `session_duration_ms`
-(the whole invocation) — see
+carries all three unconditionally: `duration_ms` (this headline's clock), the additive
+`session_duration_ms` (the whole invocation), and `listing_duration_ms` (the listing-phase-only clock,
+equal to `duration_ms` on an unsorted run) — see
 [`metrics-and-observability.md`](metrics-and-observability.md#2-list_run_summary-one-line-at-run-end).
 
 A **faults line** — `throttled N · retried M · errors K` — is inserted only when one of those

--- a/swath-cli/src/main/java/io/varve/swath/cli/SummaryRenderer.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/SummaryRenderer.java
@@ -60,10 +60,12 @@ final class SummaryRenderer implements RunSummarySink {
 
     /**
      * How far {@link RunSummary#sessionDuration()} must exceed {@link RunSummary#duration()}
-     * before the headline earns a second figure. {@code duration} is the listing clock (a fresh
-     * run's zero point is set AFTER seeding); {@code sessionDuration} is the whole CLI invocation,
-     * seeding included. A negligible seed (or a resumed run, where the two are always equal) keeps
-     * the one-figure line rather than printing two near-identical numbers a second apart.
+     * before the headline earns a second figure. {@code duration} is the whole post-seed run (a
+     * fresh run's zero point is set AFTER seeding, and on a {@code --sort} run it runs on through
+     * the merge/publish tail); {@link RunSummary#listingDuration()} is the listing-only span, and
+     * {@code sessionDuration} is the whole CLI invocation, seeding included. A negligible seed (or a
+     * resumed run, where the two are always equal) keeps the one-figure line rather than printing
+     * two near-identical numbers a second apart.
      */
     static final Duration SESSION_DELTA_MIN = Duration.ofSeconds(1);
 
@@ -228,20 +230,26 @@ final class SummaryRenderer implements RunSummarySink {
     }
 
     /**
-     * The block's headline: objects, the LISTING clock {@code keys_per_sec} is keyed to, and the
-     * rate itself — plus, when a fresh run's seed step made the whole session materially longer than
-     * that (§ {@link #SESSION_DELTA_MIN}), the session total too, so the two adjacent numbers an
-     * operator sees (this line and the live progress line, which is session-scoped) never disagree
-     * without explanation. {@code keys/s} sits directly after the {@code listing} figure — not the
+     * The block's headline: objects, the post-seed run clock {@code keys_per_sec} is keyed to, and
+     * the rate itself — plus, when a fresh run's seed step made the whole session materially longer
+     * than that (§ {@link #SESSION_DELTA_MIN}), the session total too, so the two adjacent numbers
+     * an operator sees (this line and the live progress line, which is session-scoped) never
+     * disagree without explanation. {@code keys/s} sits directly after the run figure — not the
      * {@code total} one — so which of the two the rate divides by is never left for the reader to
      * guess.
+     *
+     * <p>That figure is labelled {@code listing} only when it really is listing-only, i.e. when the
+     * run never crossed into a merge ({@code duration} equals {@link RunSummary#listingDuration()}).
+     * A {@code --sort} run's {@code duration} carries the post-listing merge/publish tail with it,
+     * and calling that span "listing" would misattribute merge time to the scan.
      */
     private static String headline(RunSummary summary) {
-        Duration listing = summary.duration();
+        Duration run = summary.duration();
         Duration session = summary.sessionDuration();
-        boolean materialSeed = session.minus(listing).compareTo(SESSION_DELTA_MIN) > 0;
-        String line = count(summary.objects()) + " objects in " + elapsed(listing)
-                + (materialSeed ? " listing" : "")
+        boolean materialSeed = session.minus(run).compareTo(SESSION_DELTA_MIN) > 0;
+        boolean listingOnly = run.equals(summary.listingDuration());
+        String line = count(summary.objects()) + " objects in " + elapsed(run)
+                + (materialSeed && listingOnly ? " listing" : "")
                 + SEP + count(Math.round(summary.keysPerSecond())) + " keys/s";
         return materialSeed ? line + SEP + elapsed(session) + " total" : line;
     }

--- a/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
@@ -439,14 +439,15 @@ final class SummaryRendererTest {
     }
 
     /**
-     * A {@link RunSummary} with an explicit {@code duration} (listing)/{@code sessionDuration}
+     * A {@link RunSummary} with an explicit post-seed {@code duration}/{@code sessionDuration}
      * split, for the headline's material-vs-negligible-seed threshold tests — every other field is
      * a placeholder, since only those two clocks (plus {@code objects}/{@code keysPerSecond}) drive
-     * what {@link SummaryRenderer#lines} renders on the headline.
+     * what {@link SummaryRenderer#lines} renders on the headline. These runs never merge, so the
+     * listing clock is the run clock.
      */
-    private static RunSummary summaryWithDurations(Duration listing, Duration session) {
+    private static RunSummary summaryWithDurations(Duration run, Duration session) {
         return new RunSummary(
-                1L, 1_500L, listing, session, WORK_STEALING, 0L, 0.0,
+                1L, 1_500L, run, session, run, WORK_STEALING, 0L, 0.0,
                 0L, 0L, 1_500L, 0L, 0L, 0.0, -1L, -1L, 0L, 0L, 0L,
                 50.0, 0.0, -1L, -1L, -1.0, -1.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);

--- a/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
@@ -475,7 +475,7 @@ final class SummaryRendererTest {
      */
     private static RunSummary summaryWithClocks(Duration run, Duration session, Duration listing) {
         return new RunSummary(
-                1L, 1_500L, run, session, listing, WORK_STEALING, 0L, 0.0,
+                1L, 1_500L, 0L, run, session, listing, WORK_STEALING, 0L, 0.0,
                 0L, 0L, 1_500L, 0L, 0L, 0.0, -1L, -1L, 0L, 0L, 0L,
                 50.0, 0.0, -1L, -1L, -1.0, -1.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);

--- a/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
@@ -164,6 +164,7 @@ final class SummaryRendererTest {
 
     @Test
     void materialSeedRendersBothTheListingFigureAndTheSessionTotal() {
+        // An unsorted run: the run clock IS the listing clock, so the figure earns the label.
         RunSummary summary = summaryWithDurations(Duration.ofSeconds(103), Duration.ofSeconds(142));
 
         List<String> lines = SummaryRenderer.lines(AUTO, summary, diagnostics(), COMPLETED);
@@ -172,6 +173,24 @@ final class SummaryRendererTest {
                 .as("keys/s sits right after the listing figure, so the rate's denominator is "
                         + "never ambiguous between the two elapsed numbers")
                 .contains("1,500 objects in 1m43s listing").contains("keys/s")
+                .contains("2m22s total");
+    }
+
+    @Test
+    void aSortedRunsFigureIsNeverLabelledListingBecauseItCarriesTheMergeTail() {
+        // 1m43s post-seed, of which only 1m20s was listing -- the rest is the merge/publish tail.
+        RunSummary summary = summaryWithClocks(
+                Duration.ofSeconds(103), Duration.ofSeconds(142), Duration.ofSeconds(80));
+
+        List<String> lines = SummaryRenderer.lines(AUTO, summary, diagnostics(), COMPLETED);
+
+        assertThat(lines.get(0))
+                .as("the headline figure includes the merge, so labelling it 'listing' would "
+                        + "misattribute merge time to the scan")
+                .contains("1,500 objects in 1m43s")
+                .doesNotContain("listing");
+        assertThat(lines.get(0))
+                .as("the session total still earns its place — only the label is withheld")
                 .contains("2m22s total");
     }
 
@@ -446,8 +465,17 @@ final class SummaryRendererTest {
      * listing clock is the run clock.
      */
     private static RunSummary summaryWithDurations(Duration run, Duration session) {
+        return summaryWithClocks(run, session, run);
+    }
+
+    /**
+     * As {@link #summaryWithDurations}, but with the listing clock split out from the run clock —
+     * the {@code --sort} shape, where {@code duration} runs on past the listing through the
+     * merge/publish tail.
+     */
+    private static RunSummary summaryWithClocks(Duration run, Duration session, Duration listing) {
         return new RunSummary(
-                1L, 1_500L, run, session, run, WORK_STEALING, 0L, 0.0,
+                1L, 1_500L, run, session, listing, WORK_STEALING, 0L, 0.0,
                 0L, 0L, 1_500L, 0L, 0L, 0.0, -1L, -1L, 0L, 0L, 0L,
                 50.0, 0.0, -1L, -1L, -1.0, -1.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);

--- a/swath-core/src/main/java/io/varve/swath/engine/ConcurrencyGauge.java
+++ b/swath-core/src/main/java/io/varve/swath/engine/ConcurrencyGauge.java
@@ -673,6 +673,9 @@ public final class ConcurrencyGauge {
         // growth-freeze must not re-couple to pausing steals, or a timeout-heavy period would keep the
         // fleet under-parallelized even after 503-backpressure cleared. The two concerns stay independent.
         stealingAllowed = true;
+        // The freeze counters' denominator: every early return above this line is a success that
+        // could never have frozen, so only successes reaching here are comparable trials.
+        metrics.recordFreezeGateCheck();
         // Two independent growth-gate rungs (both leave T untouched; the shed owns all decreases). Each
         // records its own attribution counter so post-hoc can tell WHICH rung suppressed a growth step;
         // both may fire on the same step. We are past the cool-down and below Tmax, so a fired rung is

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -460,6 +460,11 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         // compatibility. Additive under schema v2 -- NOT a v3 bump.
         root.put("listing_duration_ms", summary.listingDuration().toMillis());
         root.put("objects", summary.objects());
+        // The rows a resume carried over from a previous attempt: objects describes the DATASET, so
+        // objects - recovered_objects is the numerator for anything this process's own rate is
+        // measured on (it neither listed nor paid a LIST call for them). Previously visible only on
+        // the -v progress line. Additive under schema v2 -- NOT a v3 bump.
+        root.put("recovered_objects", summary.recoveredObjects());
 
         RunConfig rc = config.runConfig();
         writeConfig(root.putObject("config"), rc);

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -449,11 +449,16 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         // regardless of which write path (periodic, complete(), or a close()-time retry/degrade)
         // produced the file, and regardless of whether a later write attempt silently failed.
         root.put("as_of", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        // duration_ms is the whole-run clock (post-seed): on a --sort run it includes the
+        // merge/publish tail, not listing alone.
         root.put("duration_ms", summary.duration().toMillis());
         // The whole-invocation session clock, seeding included -- the SAME span the live progress
-        // line reports, unlike duration_ms above (the listing-only clock keys_per_sec divides by,
-        // which keeps its meaning unchanged here). Additive under schema v2 -- NOT a v3 bump.
+        // line reports, unlike duration_ms above. Additive under schema v2 -- NOT a v3 bump.
         root.put("session_duration_ms", summary.sessionDuration().toMillis());
+        // The listing-only clock (equal to duration_ms on a run that never merges) -- the honest
+        // denominator for a listing-phase rate, since keys_per_sec/cpu_efficiency stay whole-run for
+        // compatibility. Additive under schema v2 -- NOT a v3 bump.
+        root.put("listing_duration_ms", summary.listingDuration().toMillis());
         root.put("objects", summary.objects());
 
         RunConfig rc = config.runConfig();
@@ -644,6 +649,11 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         recoveredNode.put("latency_freezes", (long) counterCount("swath.aimd.latency_freeze"));
         // The transient-timeout growth-freeze rung, parallel to latency_freezes above.
         recoveredNode.put("growth_freezes", (long) counterCount("swath.aimd.growth_freeze"));
+        // The denominator for the two freeze counters above: successes that actually REACHED the
+        // growth-freeze gates. A success at Tmax (or inside a throttle cool-down) returns before the
+        // gates and can never freeze, so raw freeze counts are incomparable across runs at different
+        // saturation; latency_freezes / freeze_gate_checks is the comparable rate.
+        recoveredNode.put("freeze_gate_checks", (long) counterCount("swath.aimd.freeze_gate_checks"));
         recoveredNode.put("connection_aborted", (long) counterCount("swath.s3.pool.connection_aborted"));
         recoveredNode.put("handshakes", (long) counterCount("swath.s3.pool.handshakes"));
         // Socket-closure / IOException-wrapper faults (a non-SdkException RuntimeException whose
@@ -839,6 +849,14 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         ObjectNode regime = shape.putObject("regime");
         putDoubleOrNullBoxed(regime, "api_latency_p50_ms", s.apiLatencyP50Ms());
         putDoubleOrNullBoxed(regime, "api_latency_p99_ms", s.apiLatencyP99Ms());
+        // api_latency_* spans EVERY call class, cheap structure/pivot probes included, so it reads
+        // low of what a data page actually costs. The worker_page total is what a serial lister
+        // would pay per page — the honest serial-baseline estimator.
+        RunSummary.CallClassLatencySummary workerPage = workerPageTotalLatency(summary);
+        putDoubleOrNullBoxed(regime, "worker_page_latency_p50_ms",
+                workerPage == null ? null : workerPage.p50Ms());
+        putDoubleOrNullBoxed(regime, "worker_page_latency_p99_ms",
+                workerPage == null ? null : workerPage.p99Ms());
         regime.put("worker_count", rc.maxParallelListings());
         if (rc.region() == null) {
             regime.putNull("region");
@@ -858,6 +876,17 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         fingerprint.put("finished_at",
                 DateTimeFormatter.ISO_INSTANT.format(startedAt.plus(summary.duration())));
         // argv is the top-level "argv" array — referenced here, not duplicated.
+    }
+
+    /** The whole-call {@code worker_page} latency row, or {@code null} when no page was ever timed. */
+    private static RunSummary.CallClassLatencySummary workerPageTotalLatency(RunSummary summary) {
+        for (RunSummary.CallClassLatencySummary c : summary.callClassLatency()) {
+            if (RunMetrics.CALL_CLASS_WORKER_PAGE.equals(c.callClass())
+                    && RunMetrics.LATENCY_PHASE_TOTAL.equals(c.phase())) {
+                return c;
+            }
+        }
+        return null;
     }
 
     private static void putTextOrNull(ObjectNode node, String field, String value) {

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -955,6 +955,30 @@ public final class RunMetrics {
     }
 
     /**
+     * Merge-only {@code --sort --resume} row attribution — the rows that resume's merge re-published
+     * from durable segments an EARLIER process listed. Attributes them as RECOVERED work and nothing
+     * else, so the per-second/per-API-call figures ({@code keys_per_sec}, {@code
+     * api_calls_per_1k_objects}) come out at zero for a process that issued no LIST call at all,
+     * instead of crediting a whole bucket to the merge's wall clock (see {@link
+     * #sessionObjects(long)}).
+     *
+     * <p>Deliberately NOT {@link #recordRecoveredObjects}, which is the OTHER resume shape's seam:
+     * that one also backfills {@code swath.entries.emitted}, because a reattach resume's own {@code
+     * objects} field is read off that counter and would otherwise under-report the pre-crash rows. A
+     * merge-only resume takes {@code objects} from {@code summary(..., objectsOverride)} instead, so
+     * the counter needs no backfill here — and this path must leave {@code entries.emitted}/{@code
+     * progress.units} untouched (the merge already fed {@code progress.units} row-by-row via {@link
+     * #recordProgress}, and this process listed nothing to attribute entries to). Nothing is folded
+     * into the {@link #tailOccupancy} baseline either, for the same reason: that baseline offsets
+     * {@code entries.emitted}, which stays at zero on this path, and no sample is ever taken.
+     */
+    public void recordRecoveredSortRows(long rows) {
+        if (rows > 0) {
+            recoveredObjects.addAndGet(rows);
+        }
+    }
+
+    /**
      * Reattach/partial-relist {@code --sort --resume} backfill
      * — sibling of {@link #recordRecoveredSortSegments} for the OTHER
      * resume shape. On a reattach resume, {@code ListRunner} re-lists only the non-durable TAIL:
@@ -2577,7 +2601,8 @@ public final class RunMetrics {
      * the post-listing merge/publish tail. One CAS on {@link #listingEndNanos} both claims the
      * crossing and publishes its stamp, so the first crossing wins even when the clock reads 0
      * there, and no reader can observe a claimed boundary without the stamp it is claimed with (see
-     * the field's comment). It scopes the tail-occupancy gauges (see {@link
+     * the field's comment) — there is no publication window for a concurrent gauge scrape to fall
+     * into, so no test can exercise one. It scopes the tail-occupancy gauges (see {@link
      * #tailOccupancyAvgInFlight}) and {@code listing_duration_ms}; a run that never merges never
      * calls it, and both fall back to the live run clock.
      *

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -79,9 +79,13 @@ public final class RunMetrics {
     private final StuckErrorClassifier stuckClassifier = new StuckErrorClassifier();
     private final AtomicLong runId = new AtomicLong(-1L);
     private final AtomicLong runStartNanos = new AtomicLong();
-    // The listing->merge boundary stamp (0 = listing has not finished, which is also the terminal
-    // state of a run that never merges). See markListingFinished().
+    // The listing->merge boundary stamp, valid only while `listingFinished` is set. The flag is
+    // SEPARATE rather than a 0 sentinel on the timestamp itself, for exactly the reason spelled out
+    // for sessionClaimed below: nanoClock is a test seam a deterministic test may legitimately start
+    // at 0, and a CAS-from-0 scheme would then store 0, read as "still listing", and hand the first
+    // NON-ZERO crossing the win instead of the first one. See markListingFinished().
     private final AtomicLong listingEndNanos = new AtomicLong();
+    private final AtomicBoolean listingFinished = new AtomicBoolean();
     // The whole-invocation session clock's zero point: set exactly once, when the OUTERMOST
     // RunProgressReporter claims this run (the CLI's session-wide reporter, opened before seeding —
     // see RunProgressReporter's own javadoc) -- never by a nested/joined start. `sessionClaimed`
@@ -1883,8 +1887,8 @@ public final class RunMetrics {
 
     /** Nanos of LISTING elapsed: live until {@link #markListingFinished()}, frozen at it after. */
     private long listingElapsedNanos() {
-        long end = listingEndNanos.get();
-        return (end != 0L ? end : nanoClock.getAsLong()) - runStartNanos.get();
+        long end = listingFinished.get() ? listingEndNanos.get() : nanoClock.getAsLong();
+        return end - runStartNanos.get();
     }
 
     public void setConcurrencyTarget(long value) {
@@ -2237,12 +2241,11 @@ public final class RunMetrics {
         // empty run (compressedBytes == 0).
         long rawBytesEstimated = Math.round(bytesEstimated.count());
         // The listing-only clock: `duration` runs to summary time, so on a --sort run it already
-        // includes the merge/publish tail. Before the boundary is stamped -- an unsorted run, or a
+        // includes the merge/publish tail. Before the boundary is claimed -- an unsorted run, or a
         // mid-listing snapshot -- the two are the same span by construction.
-        long listingEnd = listingEndNanos.get();
-        Duration listingDuration = listingEnd == 0L
-                ? duration
-                : Duration.ofNanos(Math.max(0L, listingEnd - runStartNanos.get()));
+        Duration listingDuration = listingFinished.get()
+                ? Duration.ofNanos(Math.max(0L, listingEndNanos.get() - runStartNanos.get()))
+                : duration;
 
         return new RunSummary(
                 runId.get(),
@@ -2558,6 +2561,9 @@ public final class RunMetrics {
     public void markRunStarted() {
         long now = nanoClock.getAsLong();
         runStartNanos.set(now);
+        // Clear the claim BEFORE the stamp it guards: a reader between the two sees "still listing"
+        // and falls back to the live clock, never a claimed boundary pointing at a zeroed stamp.
+        listingFinished.set(false);
         listingEndNanos.set(0L);
         firstStealNanos.set(-1L);
         peakInFlightNanos.set(-1L);
@@ -2567,10 +2573,12 @@ public final class RunMetrics {
 
     /**
      * Stamp the LISTING&rarr;merge boundary — the instant this run stopped listing and handed off to
-     * the post-listing merge/publish tail. Idempotent (first call wins), so a path that reaches the
-     * boundary more than once still reports the first crossing. It scopes the tail-occupancy gauges
-     * (see {@link #tailOccupancyAvgInFlight}) and {@code listing_duration_ms}; a run that never
-     * merges never calls it, and both fall back to the live run clock.
+     * the post-listing merge/publish tail. Idempotent: the {@link #listingFinished} flag is what
+     * claims the crossing, so a path that reaches the boundary more than once reports the FIRST one
+     * even when the clock reads 0 there (see the field's comment, and {@code sessionClaimed}'s for
+     * the same rationale). It scopes the tail-occupancy gauges (see {@link
+     * #tailOccupancyAvgInFlight}) and {@code listing_duration_ms}; a run that never merges never
+     * calls it, and both fall back to the live run clock.
      *
      * <p>Reads the injectable {@code nanoClock}, NOT {@link System#nanoTime()}: this stamp feeds
      * summary and gauge values, so it must share {@link #runStartNanos}'s zero point and stay
@@ -2579,7 +2587,9 @@ public final class RunMetrics {
      * not add reads off the injectable seam (see {@link #setPhase}).
      */
     public void markListingFinished() {
-        listingEndNanos.compareAndSet(0L, nanoClock.getAsLong());
+        if (listingFinished.compareAndSet(false, true)) {
+            listingEndNanos.set(nanoClock.getAsLong());
+        }
     }
 
     private void markFirstSteal() {

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -79,6 +79,9 @@ public final class RunMetrics {
     private final StuckErrorClassifier stuckClassifier = new StuckErrorClassifier();
     private final AtomicLong runId = new AtomicLong(-1L);
     private final AtomicLong runStartNanos = new AtomicLong();
+    // The listing->merge boundary stamp (0 = listing has not finished, which is also the terminal
+    // state of a run that never merges). See markListingFinished().
+    private final AtomicLong listingEndNanos = new AtomicLong();
     // The whole-invocation session clock's zero point: set exactly once, when the OUTERMOST
     // RunProgressReporter claims this run (the CLI's session-wide reporter, opened before seeding —
     // see RunProgressReporter's own javadoc) -- never by a nested/joined start. `sessionClaimed`
@@ -173,6 +176,8 @@ public final class RunMetrics {
     private final Counter aimdTimeoutShed;
     /** {@code swath.aimd.latency_freeze}: successful-attempt latency-inflation +1-growth freezes. */
     private final Counter aimdLatencyFreeze;
+    /** {@code swath.aimd.freeze_gate_checks}: successes that reached the growth-freeze gates at all. */
+    private final Counter aimdFreezeGateChecks;
     /** {@code swath.aimd.growth_freeze}: transient-timeout +1-growth freezes (worker-storm-only). */
     private final Counter aimdGrowthFreeze;
     /** {@code swath.aimd.latency_baseline_ms}: the Vegas rolling-min healthy-latency baseline (ms). */
@@ -484,6 +489,7 @@ public final class RunMetrics {
         aimdTargetReductions = Counter.builder("swath.aimd.target_reductions").register(registry);
         aimdTimeoutShed = Counter.builder("swath.aimd.timeout_shed").register(registry);
         aimdLatencyFreeze = Counter.builder("swath.aimd.latency_freeze").register(registry);
+        aimdFreezeGateChecks = Counter.builder("swath.aimd.freeze_gate_checks").register(registry);
         aimdGrowthFreeze = Counter.builder("swath.aimd.growth_freeze").register(registry);
         Gauge.builder("swath.aimd.latency_baseline_ms", latencyBaselineMillis, AtomicLong::get).register(registry);
         // Publish client-side p50/p99 so the regime-confound RTT is real (the timer
@@ -1390,6 +1396,19 @@ public final class RunMetrics {
     }
 
     /**
+     * A successful attempt on the {@link io.varve.swath.engine.ConcurrencyGauge} reached the
+     * growth-freeze gates ({@code swath.aimd.freeze_gate_checks}) — the DENOMINATOR for {@link
+     * #recordLatencyFreeze()} and {@link #recordGrowthFreeze()}. A success that returns earlier (at
+     * {@code Tmax}, or inside a throttle cool-down) could never have frozen, so raw freeze counts
+     * alone are incomparable across runs at different saturation: a healthy run pinned at {@code
+     * Tmax} reads zero freezes by construction, not by health. {@code latency_freeze /
+     * freeze_gate_checks} is the comparable rate.
+     */
+    public void recordFreezeGateCheck() {
+        aimdFreezeGateChecks.increment();
+    }
+
+    /**
      * The transient-timeout rung froze a would-be +1 growth step on the {@link
      * io.varve.swath.engine.ConcurrencyGauge} ({@code swath.aimd.growth_freeze}). Distinct from {@link
      * #recordLatencyFreeze()} (a separate freeze rung) so post-hoc analysis can tell which rung
@@ -1840,19 +1859,32 @@ public final class RunMetrics {
 
     /**
      * The {@code pct}% tail-occupancy avg-in-flight gauge supplier — reads the CURRENT cumulative
-     * emitted-keys/elapsed-wall totals (live, mid-run values are a valid — if still-growing —
-     * approximation, same as every other pull-based gauge here) and asks {@link #tailOccupancy} to
-     * derive the last-{@code pct}% window's mean in-flight over its bounded sample buffer.
+     * emitted-keys total (live, mid-run values are a valid — if still-growing — approximation, same
+     * as every other pull-based gauge here) and asks {@link #tailOccupancy} to derive the
+     * last-{@code pct}% window's mean in-flight over its bounded sample buffer.
+     *
+     * <p>The elapsed span handed to the sampler is LISTING-scoped ({@link #listingElapsedNanos}):
+     * still growing during listing, frozen at the listing&rarr;merge boundary afterwards. The
+     * sampler only ever samples listing-time page emits, so a whole-run elapsed would open a window
+     * (and, for the wall-share sibling, a denominator) that runs past the last sample and swallows a
+     * sorted run's whole merge/publish tail — reporting the merge instead of the serial listing tail
+     * these gauges exist to screen for.
      */
     private double tailOccupancyAvgInFlight(int pct) {
         return tailOccupancy.avgInFlightForWindow(pct, Math.round(entriesEmitted.count()),
-                nanoClock.getAsLong() - runStartNanos.get());
+                listingElapsedNanos());
     }
 
     /** Sibling of {@link #tailOccupancyAvgInFlight} for the window's wall-time SHARE. */
     private double tailOccupancyWallShare(int pct) {
         return tailOccupancy.wallShareForWindow(pct, Math.round(entriesEmitted.count()),
-                nanoClock.getAsLong() - runStartNanos.get());
+                listingElapsedNanos());
+    }
+
+    /** Nanos of LISTING elapsed: live until {@link #markListingFinished()}, frozen at it after. */
+    private long listingElapsedNanos() {
+        long end = listingEndNanos.get();
+        return (end != 0L ? end : nanoClock.getAsLong()) - runStartNanos.get();
     }
 
     public void setConcurrencyTarget(long value) {
@@ -2204,12 +2236,20 @@ public final class RunMetrics {
         // not 0; the ratio only renders 0.0 via the zero-denominator guard on a genuinely
         // empty run (compressedBytes == 0).
         long rawBytesEstimated = Math.round(bytesEstimated.count());
+        // The listing-only clock: `duration` runs to summary time, so on a --sort run it already
+        // includes the merge/publish tail. Before the boundary is stamped -- an unsorted run, or a
+        // mid-listing snapshot -- the two are the same span by construction.
+        long listingEnd = listingEndNanos.get();
+        Duration listingDuration = listingEnd == 0L
+                ? duration
+                : Duration.ofNanos(Math.max(0L, listingEnd - runStartNanos.get()));
 
         return new RunSummary(
                 runId.get(),
                 keyCount,
                 duration,
                 sessionDuration(duration),
+                listingDuration,
                 strategy,
                 apiCallCount,
                 estimatedListCost(apiCallCount),
@@ -2518,10 +2558,28 @@ public final class RunMetrics {
     public void markRunStarted() {
         long now = nanoClock.getAsLong();
         runStartNanos.set(now);
+        listingEndNanos.set(0L);
         firstStealNanos.set(-1L);
         peakInFlightNanos.set(-1L);
         inFlightGauge.reset(now);
         baselineCpuNanos = ResourceMetrics.processCpuTimeNanos();
+    }
+
+    /**
+     * Stamp the LISTING&rarr;merge boundary — the instant this run stopped listing and handed off to
+     * the post-listing merge/publish tail. Idempotent (first call wins), so a path that reaches the
+     * boundary more than once still reports the first crossing. It scopes the tail-occupancy gauges
+     * (see {@link #tailOccupancyAvgInFlight}) and {@code listing_duration_ms}; a run that never
+     * merges never calls it, and both fall back to the live run clock.
+     *
+     * <p>Reads the injectable {@code nanoClock}, NOT {@link System#nanoTime()}: this stamp feeds
+     * summary and gauge values, so it must share {@link #runStartNanos}'s zero point and stay
+     * deterministic under a fake clock. It is deliberately a separate call from {@code
+     * setPhase(Phase.MERGING)} for that reason — that method's clock is a display clock, and must
+     * not add reads off the injectable seam (see {@link #setPhase}).
+     */
+    public void markListingFinished() {
+        listingEndNanos.compareAndSet(0L, nanoClock.getAsLong());
     }
 
     private void markFirstSteal() {
@@ -2536,16 +2594,16 @@ public final class RunMetrics {
     }
 
     /**
-     * The whole-invocation session clock -- {@code listingDuration} (the {@code duration} param
-     * every other caller of {@link #summary} passes) with seeding folded back in, when there was a
-     * session-wide reporter around to measure it. Falls back to {@code listingDuration} itself (the
-     * two collapse to one figure, never a garbage delta) when {@link #sessionStartNanos} was never
+     * The whole-invocation session clock -- {@code runDuration} (the post-seed {@code duration}
+     * param every caller of {@link #summary} passes) with seeding folded back in, when there was a
+     * session-wide reporter around to measure it. Falls back to {@code runDuration} itself (the two
+     * collapse to one figure, never a garbage delta) when {@link #sessionStartNanos} was never
      * claimed -- a pre-seed early exit, or a caller (most unit tests) that builds a summary without
      * ever starting a {@link RunProgressReporter}.
      */
-    private Duration sessionDuration(Duration listingDuration) {
+    private Duration sessionDuration(Duration runDuration) {
         if (!sessionClaimed.get()) {
-            return listingDuration;
+            return runDuration;
         }
         return Duration.ofNanos(Math.max(0L, nanoClock.getAsLong() - sessionStartNanos.get()));
     }

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -79,13 +79,15 @@ public final class RunMetrics {
     private final StuckErrorClassifier stuckClassifier = new StuckErrorClassifier();
     private final AtomicLong runId = new AtomicLong(-1L);
     private final AtomicLong runStartNanos = new AtomicLong();
-    // The listing->merge boundary stamp, valid only while `listingFinished` is set. The flag is
-    // SEPARATE rather than a 0 sentinel on the timestamp itself, for exactly the reason spelled out
-    // for sessionClaimed below: nanoClock is a test seam a deterministic test may legitimately start
-    // at 0, and a CAS-from-0 scheme would then store 0, read as "still listing", and hand the first
-    // NON-ZERO crossing the win instead of the first one. See markListingFinished().
-    private final AtomicLong listingEndNanos = new AtomicLong();
-    private final AtomicBoolean listingFinished = new AtomicBoolean();
+    // The listing->merge boundary stamp: null until the boundary is crossed. ONE nullable atomic
+    // rather than a 0 sentinel on a primitive, because nanoClock is a test seam a deterministic test
+    // may legitimately start at 0 (the same reasoning spelled out for sessionClaimed below) -- a
+    // CAS-from-0 would store 0, still read as "still listing", and hand the win to the first
+    // NON-ZERO crossing. It is also ONE variable rather than a claim flag beside the timestamp: a
+    // pair publishes in two steps, so a reader could see the claim before the stamp it guards and
+    // compute a listing span against an unwritten boundary. A nullable reference closes both --
+    // claiming the boundary and publishing its stamp are the same write. See markListingFinished().
+    private final AtomicReference<Long> listingEndNanos = new AtomicReference<>();
     // The whole-invocation session clock's zero point: set exactly once, when the OUTERMOST
     // RunProgressReporter claims this run (the CLI's session-wide reporter, opened before seeding —
     // see RunProgressReporter's own javadoc) -- never by a nested/joined start. `sessionClaimed`
@@ -1887,8 +1889,8 @@ public final class RunMetrics {
 
     /** Nanos of LISTING elapsed: live until {@link #markListingFinished()}, frozen at it after. */
     private long listingElapsedNanos() {
-        long end = listingFinished.get() ? listingEndNanos.get() : nanoClock.getAsLong();
-        return end - runStartNanos.get();
+        Long end = listingEndNanos.get();
+        return (end != null ? end : nanoClock.getAsLong()) - runStartNanos.get();
     }
 
     public void setConcurrencyTarget(long value) {
@@ -2243,8 +2245,9 @@ public final class RunMetrics {
         // The listing-only clock: `duration` runs to summary time, so on a --sort run it already
         // includes the merge/publish tail. Before the boundary is claimed -- an unsorted run, or a
         // mid-listing snapshot -- the two are the same span by construction.
-        Duration listingDuration = listingFinished.get()
-                ? Duration.ofNanos(Math.max(0L, listingEndNanos.get() - runStartNanos.get()))
+        Long listingEnd = listingEndNanos.get();
+        Duration listingDuration = listingEnd != null
+                ? Duration.ofNanos(Math.max(0L, listingEnd - runStartNanos.get()))
                 : duration;
 
         return new RunSummary(
@@ -2562,10 +2565,7 @@ public final class RunMetrics {
     public void markRunStarted() {
         long now = nanoClock.getAsLong();
         runStartNanos.set(now);
-        // Clear the claim BEFORE the stamp it guards: a reader between the two sees "still listing"
-        // and falls back to the live clock, never a claimed boundary pointing at a zeroed stamp.
-        listingFinished.set(false);
-        listingEndNanos.set(0L);
+        listingEndNanos.set(null);
         firstStealNanos.set(-1L);
         peakInFlightNanos.set(-1L);
         inFlightGauge.reset(now);
@@ -2574,10 +2574,10 @@ public final class RunMetrics {
 
     /**
      * Stamp the LISTING&rarr;merge boundary — the instant this run stopped listing and handed off to
-     * the post-listing merge/publish tail. Idempotent: the {@link #listingFinished} flag is what
-     * claims the crossing, so a path that reaches the boundary more than once reports the FIRST one
-     * even when the clock reads 0 there (see the field's comment, and {@code sessionClaimed}'s for
-     * the same rationale). It scopes the tail-occupancy gauges (see {@link
+     * the post-listing merge/publish tail. One CAS on {@link #listingEndNanos} both claims the
+     * crossing and publishes its stamp, so the first crossing wins even when the clock reads 0
+     * there, and no reader can observe a claimed boundary without the stamp it is claimed with (see
+     * the field's comment). It scopes the tail-occupancy gauges (see {@link
      * #tailOccupancyAvgInFlight}) and {@code listing_duration_ms}; a run that never merges never
      * calls it, and both fall back to the live run clock.
      *
@@ -2585,12 +2585,12 @@ public final class RunMetrics {
      * summary and gauge values, so it must share {@link #runStartNanos}'s zero point and stay
      * deterministic under a fake clock. It is deliberately a separate call from {@code
      * setPhase(Phase.MERGING)} for that reason — that method's clock is a display clock, and must
-     * not add reads off the injectable seam (see {@link #setPhase}).
+     * not add reads off the injectable seam (see {@link #setPhase}). The CAS argument is evaluated
+     * first, so a repeat call reads the clock and discards it; the boundary call sites are mutually
+     * exclusive per run, so that is at most one wasted read on no real path.
      */
     public void markListingFinished() {
-        if (listingFinished.compareAndSet(false, true)) {
-            listingEndNanos.set(nanoClock.getAsLong());
-        }
+        listingEndNanos.compareAndSet(null, nanoClock.getAsLong());
     }
 
     private void markFirstSteal() {

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -2250,6 +2250,7 @@ public final class RunMetrics {
         return new RunSummary(
                 runId.get(),
                 keyCount,
+                recoveredObjects.get(),
                 duration,
                 sessionDuration(duration),
                 listingDuration,

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -29,7 +29,11 @@ import java.util.List;
  * nothing. {@code listingDuration} is the listing-only clock — the same zero point, ending at the
  * listing&rarr;merge boundary ({@code RunMetrics#markListingFinished()}) — and is the honest
  * denominator for a listing-phase rate; it equals {@code duration} exactly on a run that never
- * merges. {@code sessionDuration} is the whole CLI invocation's own clock instead, seeding included
+ * merges. On a merge-only {@code --sort --resume}, where this process re-runs only the merge and
+ * lists nothing, {@code listingDuration} is near zero while {@code objects} is the full recovered
+ * dataset — so a consumer computing listing-phase rates must SKIP such runs rather than divide by
+ * that, and {@code sort.merge_only_resume: true} in the summary JSON is the tell.
+ * {@code sessionDuration} is the whole CLI invocation's own clock instead, seeding included
  * — the same span the live progress line already reports; a fresh run's seed step is the gap
  * between it and {@code duration}, and the two agree exactly on a resumed or seed-skipped run.
  * {@code sessionDuration} equals {@code duration} (never garbage) on any snapshot taken before the

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -21,16 +21,20 @@ import java.util.List;
  * compressionRatio} instead render {@code 0.0} on a zero denominator, since they are always
  * computable from existing counters (no hot-path cost), just possibly vacuous on a tiny run.
  *
- * <p>{@code duration} is the LISTING clock — the same one {@code keysPerSecond} and every other
- * per-second/per-API-call figure divides by — {@code RunMetrics#markRunStarted()}'s zero point,
- * which a fresh run resets to AFTER seeding. {@code sessionDuration} is the whole CLI invocation's
- * own clock instead, seeding included — the same span the live progress line already reports. The
- * two agree exactly on a resumed or seed-skipped run; a fresh run's seed step is the gap between
- * them. Neither is wrong: {@code duration} is the honest throughput denominator (seeding fetches no
- * object), {@code sessionDuration} is what the operator actually waited on. {@code sessionDuration}
- * equals {@code duration} (never garbage) on any snapshot taken before the session-wide progress
- * reporter has claimed its start — a pre-seed early exit, or a caller that builds a summary directly
- * without ever starting one.
+ * <p>Three clocks, three different spans. {@code duration} is the POST-SEED WHOLE-RUN clock — it
+ * starts at {@code RunMetrics#markRunStarted()}'s zero point, which a fresh run resets to AFTER
+ * seeding, and ends when the summary is built. On a {@code --sort} run that end is past the merge,
+ * so {@code duration} includes the whole post-listing merge/publish tail, and {@code keysPerSecond}
+ * / {@code cpuEfficiency} (which divide by it) are whole-run rates diluted by a phase that lists
+ * nothing. {@code listingDuration} is the listing-only clock — the same zero point, ending at the
+ * listing&rarr;merge boundary ({@code RunMetrics#markListingFinished()}) — and is the honest
+ * denominator for a listing-phase rate; it equals {@code duration} exactly on a run that never
+ * merges. {@code sessionDuration} is the whole CLI invocation's own clock instead, seeding included
+ * — the same span the live progress line already reports; a fresh run's seed step is the gap
+ * between it and {@code duration}, and the two agree exactly on a resumed or seed-skipped run.
+ * {@code sessionDuration} equals {@code duration} (never garbage) on any snapshot taken before the
+ * session-wide progress reporter has claimed its start — a pre-seed early exit, or a caller that
+ * builds a summary directly without ever starting one.
  *
  * <p>{@code timeToFirstStealMs} and {@code timeToPeakInFlightMs} are the run's ramp-up timings —
  * milliseconds from run start to the first work steal / to the instant peak concurrency was first
@@ -54,6 +58,7 @@ public record RunSummary(
         long objects,
         Duration duration,
         Duration sessionDuration,
+        Duration listingDuration,
         String strategy,
         long apiCalls,
         double costUsd,

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -21,6 +21,14 @@ import java.util.List;
  * compressionRatio} instead render {@code 0.0} on a zero denominator, since they are always
  * computable from existing counters (no hot-path cost), just possibly vacuous on a tiny run.
  *
+ * <p>{@code recoveredObjects} is the resume-backfilled row count this process never listed itself
+ * ({@code RunMetrics#recordRecoveredObjects}), {@code 0} on a fresh run. {@code objects} describes
+ * the DATASET and so includes it; {@code objects - recoveredObjects} is the this-process-only
+ * numerator every per-second/per-API-call figure here ({@code keysPerSecond}, {@code
+ * apiCallsPer1kObjects}) already divides, since pre-crash rows cost this process neither a second
+ * nor a LIST call. Carried here so that numerator is readable off the summary rather than
+ * reconstructible only from the {@code -v} progress line.
+ *
  * <p>Three clocks, three different spans. {@code duration} is the POST-SEED WHOLE-RUN clock — it
  * starts at {@code RunMetrics#markRunStarted()}'s zero point, which a fresh run resets to AFTER
  * seeding, and ends when the summary is built. On a {@code --sort} run that end is past the merge,
@@ -60,6 +68,7 @@ import java.util.List;
 public record RunSummary(
         long runId,
         long objects,
+        long recoveredObjects,
         Duration duration,
         Duration sessionDuration,
         Duration listingDuration,

--- a/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
@@ -707,6 +707,7 @@ public final class ListRunner {
                     // Listing complete + all segments durable. Latch nodes, then merge + publish.
                     store.markOutputComplete(runId);
                     store.setSortPhase(runId, SortPhase.MERGING);
+                    ctx.metrics().markListingFinished();
                     ctx.metrics().setPhase(Phase.MERGING);
                     // Normal listing-completion publish: no identity-verified merge-reentry guarantee here,
                     // so the NARROW part-*.parquet stale-finals sweep only (see sortMergeAndPublish javadoc).
@@ -752,6 +753,9 @@ public final class ListRunner {
         boolean summaryEmitted = false;
         try {
             store.setSortPhase(runId, SortPhase.MERGING);
+            // This process lists nothing, so the listing clock lands near zero — the honest figure
+            // for a merge-only resume, not a gap.
+            ctx.metrics().markListingFinished();
             ctx.metrics().setPhase(Phase.MERGING);
             List<PartRef> segRows = sortedSegmentRows(store, runId);
             // Merge-only resume: identity-verified merge-reentry (ListCommand#isPublishedByThisRun
@@ -1376,8 +1380,9 @@ public final class ListRunner {
     }
 
     private static void logSummary(RunSummary summary) {
-        log.info("list_run_summary run_id={} objects={} duration_ms={} session_duration_ms={} strategy={} api_calls={} cost_usd={} output_files={} compressed_size_bytes={} keys={} pages={} peak_in_flight={} steals={} splits={} errors={} keys_per_sec={} api_calls_per_1k_objects={} peak_rss_bytes={} peak_heap_bytes={} cpu_seconds={} cpu_efficiency={}",
+        log.info("list_run_summary run_id={} objects={} duration_ms={} listing_duration_ms={} session_duration_ms={} strategy={} api_calls={} cost_usd={} output_files={} compressed_size_bytes={} keys={} pages={} peak_in_flight={} steals={} splits={} errors={} keys_per_sec={} api_calls_per_1k_objects={} peak_rss_bytes={} peak_heap_bytes={} cpu_seconds={} cpu_efficiency={}",
                 summary.runId(), summary.objects(), summary.duration().toMillis(),
+                summary.listingDuration().toMillis(),
                 summary.sessionDuration().toMillis(), summary.strategy(),
                 summary.apiCalls(), summary.costUsd(), summary.outputFiles(), summary.compressedBytes(),
                 summary.keys(), summary.pages(), summary.peakInFlight(), summary.steals(), summary.splits(),

--- a/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
@@ -771,7 +771,11 @@ public final class ListRunner {
             // under-report objects:0 / sort.segments:0 despite publishing the full, correct output
             // — see RunMetrics#summary(...,objectsOverride) and #recordRecoveredSortSegments for why
             // this is NOT a blind counter replay (progress.units/entries are deliberately untouched).
+            // The rows are attributed as RECOVERED alongside: they were listed by an earlier process,
+            // so crediting them to this one's wall clock would report a keys/sec for a run that
+            // issued zero LIST calls (see RunMetrics#recordRecoveredSortRows).
             ctx.metrics().recordRecoveredSortSegments(segRows.size());
+            ctx.metrics().recordRecoveredSortRows(result.totalRows());
 
             // Progress ends before the first terminal record, exactly as in runLifecycle's epilogue:
             // the reporter this method's merge started is closed, but the CLI's session reporter is not.

--- a/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
+++ b/swath-core/src/main/java/io/varve/swath/runtime/ListRunner.java
@@ -1380,8 +1380,9 @@ public final class ListRunner {
     }
 
     private static void logSummary(RunSummary summary) {
-        log.info("list_run_summary run_id={} objects={} duration_ms={} listing_duration_ms={} session_duration_ms={} strategy={} api_calls={} cost_usd={} output_files={} compressed_size_bytes={} keys={} pages={} peak_in_flight={} steals={} splits={} errors={} keys_per_sec={} api_calls_per_1k_objects={} peak_rss_bytes={} peak_heap_bytes={} cpu_seconds={} cpu_efficiency={}",
-                summary.runId(), summary.objects(), summary.duration().toMillis(),
+        log.info("list_run_summary run_id={} objects={} recovered_objects={} duration_ms={} listing_duration_ms={} session_duration_ms={} strategy={} api_calls={} cost_usd={} output_files={} compressed_size_bytes={} keys={} pages={} peak_in_flight={} steals={} splits={} errors={} keys_per_sec={} api_calls_per_1k_objects={} peak_rss_bytes={} peak_heap_bytes={} cpu_seconds={} cpu_efficiency={}",
+                summary.runId(), summary.objects(), summary.recoveredObjects(),
+                summary.duration().toMillis(),
                 summary.listingDuration().toMillis(),
                 summary.sessionDuration().toMillis(), summary.strategy(),
                 summary.apiCalls(), summary.costUsd(), summary.outputFiles(), summary.compressedBytes(),

--- a/swath-core/src/test/java/io/varve/swath/engine/ConcurrencyGaugeFreezeGateDenominatorTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/ConcurrencyGaugeFreezeGateDenominatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.varve.swath.observability.RunMetrics;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code swath.aimd.freeze_gate_checks} counts the successes that actually REACHED the growth-freeze
+ * gates — the denominator that makes {@code latency_freeze}/{@code growth_freeze} comparable across
+ * runs. A success that returns earlier (at {@code Tmax}, or inside a throttle cool-down) could never
+ * have frozen, so without this counter a healthy saturated run reads zero freezes by construction
+ * and looks identical to a run whose rungs genuinely never engaged.
+ */
+final class ConcurrencyGaugeFreezeGateDenominatorTest {
+
+    private static final long WINDOW = ConcurrencyGauge.SHED_WINDOW_BASE_NANOS;
+    private static final long MS_100 = 100_000_000L;
+    private static final long MS_300 = 300_000_000L;
+
+    private final AtomicLong now = new AtomicLong(1_000_000_000_000L);   // non-zero base (0 = "unset" sentinel)
+
+    private ConcurrencyGauge newGauge(int tMax, RunMetrics metrics) {
+        return new ConcurrencyGauge(tMax, metrics, now::get, () -> WINDOW, ConcurrencyGauge.defaultInitialT(tMax));
+    }
+
+    private static double freezeGateChecks(RunMetrics metrics) {
+        return metrics.registry().get("swath.aimd.freeze_gate_checks").counter().count();
+    }
+
+    private static double latencyFreezes(RunMetrics metrics) {
+        return metrics.registry().get("swath.aimd.latency_freeze").counter().count();
+    }
+
+    @Test
+    void successesAtTmaxAreNotTrials() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        // tMax == the slow-start initial T, so the gauge starts pinned at its ceiling.
+        ConcurrencyGauge gauge = newGauge(ConcurrencyGauge.SLOW_START_INITIAL_T, metrics);
+        assertThat(gauge.effectiveT()).isEqualTo(ConcurrencyGauge.SLOW_START_INITIAL_T);
+
+        for (int i = 0; i < 5; i++) {
+            gauge.reportStatus(200);
+        }
+
+        assertThat(freezeGateChecks(metrics))
+                .as("a success at Tmax returns before the freeze gates — it can never freeze, so it "
+                        + "is not a trial the freeze counters can be read against")
+                .isZero();
+    }
+
+    @Test
+    void successesInsideAThrottleCooldownAreNotTrials() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        ConcurrencyGauge gauge = newGauge(64, metrics);
+        gauge.reportStatus(ConcurrencyGauge.SLOWDOWN_STATUS);   // T below Tmax, cool-down armed
+
+        gauge.reportStatus(200);
+
+        assertThat(freezeGateChecks(metrics))
+                .as("the cool-down eats this success's growth opportunity before the gates")
+                .isZero();
+    }
+
+    @Test
+    void everySuccessThatReachesTheGatesCounts() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        ConcurrencyGauge gauge = newGauge(64, metrics);
+        gauge.reportStatus(ConcurrencyGauge.SLOWDOWN_STATUS);   // below Tmax
+        gauge.forceCleanWindow();                               // past the cool-down
+
+        gauge.reportStatus(200);
+        gauge.reportStatus(200);
+        gauge.reportStatus(200);
+
+        assertThat(freezeGateChecks(metrics))
+                .as("below Tmax and past the cool-down, every success is a genuine freeze trial")
+                .isEqualTo(3.0);
+        assertThat(latencyFreezes(metrics))
+                .as("healthy latency freezes nothing, but the trials still counted — that gap is "
+                        + "exactly what the denominator makes visible")
+                .isZero();
+    }
+
+    @Test
+    void freezesNeverOutnumberTheTrialsTheyHappenedIn() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        ConcurrencyGauge gauge = newGauge(64, metrics);
+        gauge.reportStatus(ConcurrencyGauge.SLOWDOWN_STATUS);
+        gauge.forceCleanWindow();
+        gauge.onAttemptLatency(MS_100);                         // baseline := 100ms
+        for (int i = 0; i < 5; i++) {
+            gauge.onAttemptLatency(MS_300);                     // EWMA climbs past 2x the baseline
+        }
+
+        for (int i = 0; i < 4; i++) {
+            gauge.reportStatus(200);
+        }
+
+        assertThat(latencyFreezes(metrics)).isPositive();
+        assertThat(latencyFreezes(metrics))
+                .as("a freeze is only recordable from inside a trial, so the ratio is a real rate "
+                        + "in [0,1] — never above 1")
+                .isLessThanOrEqualTo(freezeGateChecks(metrics));
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -6,6 +6,7 @@
 package io.varve.swath.observability;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.awaitility.Awaitility.await;
 
 import ch.qos.logback.classic.Level;
@@ -50,7 +51,7 @@ final class JsonRunSummaryWriterTest {
         // round-trip test below exercises duration_ms, session_duration_ms and listing_duration_ms
         // separately, rather than values where any two would coincide.
         return new RunSummary(
-                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
+                42L, 1000L, 0L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
                 "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
@@ -537,7 +538,7 @@ final class JsonRunSummaryWriterTest {
         // cpu_seconds/cpu_efficiency (double); JSON renders these as null, not -1 (the log-line
         // sentinel).
         RunSummary summary = new RunSummary(
-                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(25), Duration.ofSeconds(25),
+                42L, 1000L, 0L, Duration.ofSeconds(25), Duration.ofSeconds(25), Duration.ofSeconds(25),
                 "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, -1L, -1L, -1.0, -1.0,
@@ -1047,7 +1048,7 @@ final class JsonRunSummaryWriterTest {
 
     private static RunSummary summaryWithDuration(Duration duration) {
         return new RunSummary(
-                42L, 1000L, duration, duration, duration, "WORK_STEALING", 118L, 0.00059,
+                42L, 1000L, 0L, duration, duration, duration, "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
@@ -1142,7 +1143,7 @@ final class JsonRunSummaryWriterTest {
     private static RunSummary summaryWithCallClassLatency(
             List<RunSummary.CallClassLatencySummary> callClassLatency) {
         return new RunSummary(
-                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
+                42L, 1000L, 0L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
                 "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
@@ -1181,6 +1182,57 @@ final class JsonRunSummaryWriterTest {
         assertThat(root.get("listing_duration_ms").asLong())
                 .as("the merge lists nothing, so it is not part of the listing clock")
                 .isEqualTo(5_000L);
+    }
+
+    /**
+     * The rate numerator a consumer needs — {@code objects - recovered_objects} — has to be
+     * computable from the artifact alone, not scraped off the {@code -v} progress line.
+     */
+    @Test
+    void recoveredObjectsIsZeroOnAFreshRunAndCarriesTheBackfillOnAResume(@TempDir Path dir) throws Exception {
+        Path fresh = dir.resolve("fresh.json");
+        SimpleMeterRegistry freshRegistry = new SimpleMeterRegistry();
+        RunMetrics freshMetrics = new RunMetrics(freshRegistry);
+        freshMetrics.markRunStarted();
+        freshMetrics.recordEntriesEmitted(900L);
+        writeSummary(fresh, freshRegistry, freshMetrics.summary(Duration.ofSeconds(5), "WORK_STEALING", 1L, 0L));
+
+        JsonNode freshRoot = MAPPER.readTree(fresh.toFile());
+        assertThat(freshRoot.get("objects").asLong()).isEqualTo(900L);
+        assertThat(freshRoot.get("recovered_objects").asLong())
+                .as("a fresh run listed everything it reports — present as 0, never omitted")
+                .isZero();
+
+        Path resumed = dir.resolve("resumed.json");
+        SimpleMeterRegistry resumedRegistry = new SimpleMeterRegistry();
+        RunMetrics resumedMetrics = new RunMetrics(resumedRegistry);
+        resumedMetrics.markRunStarted();
+        resumedMetrics.recordRecoveredObjects(348L);   // the pre-crash durable rows, backfilled
+        resumedMetrics.recordEntriesEmitted(900L);     // the tail this process actually relisted
+        writeSummary(resumed, resumedRegistry,
+                resumedMetrics.summary(Duration.ofSeconds(5), "WORK_STEALING", 1L, 0L));
+
+        JsonNode resumedRoot = MAPPER.readTree(resumed.toFile());
+        assertThat(resumedRoot.get("objects").asLong())
+                .as("objects describes the DATASET, backfill included")
+                .isEqualTo(1_248L);
+        assertThat(resumedRoot.get("recovered_objects").asLong()).isEqualTo(348L);
+        assertThat(resumedRoot.get("objects").asLong() - resumedRoot.get("recovered_objects").asLong())
+                .as("the difference is the this-process-only numerator keys_per_sec divides")
+                .isEqualTo(900L);
+        assertThat(resumedRoot.get("efficiency").get("keys_per_sec").asDouble())
+                .isCloseTo(900 / 5.0, within(1e-9));
+    }
+
+    /** Write one terminal summary and close, the shape every artifact assertion here starts from. */
+    private static void writeSummary(Path path, SimpleMeterRegistry registry, RunSummary summary) {
+        JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
+                config(path, Duration.ofMinutes(10)), registry, Instant.now(), () -> summary);
+        try {
+            writer.complete(summary);
+        } finally {
+            writer.close();
+        }
     }
 
     /** A run that never merges never stamps a boundary: the two clocks are one figure. */

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -46,11 +46,12 @@ final class JsonRunSummaryWriterTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static RunSummary summary() {
-        // sessionDuration (31s) deliberately differs from duration (25s) -- the listing-scoped
-        // clock -- so the round-trip test below exercises BOTH the unchanged duration_ms and the
-        // new additive session_duration_ms field, rather than a value where they'd coincide.
+        // All three clocks deliberately differ -- session (31s) > run (25s) > listing (20s) -- so the
+        // round-trip test below exercises duration_ms, session_duration_ms and listing_duration_ms
+        // separately, rather than values where any two would coincide.
         return new RunSummary(
-                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(31), "WORK_STEALING", 118L, 0.00059,
+                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
+                "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
@@ -119,10 +120,12 @@ final class JsonRunSummaryWriterTest {
         assertThat(root.get("stop_reason").asText())
                 .as("completed:true ⇔ stop_reason=completed (schema v2)").isEqualTo("completed");
         assertThat(root.get("started_at").asText()).isEqualTo("2026-07-01T00:00:00Z");
-        // duration_ms stays LISTING-scoped (unchanged meaning) -- session_duration_ms is the
-        // additive, whole-invocation figure with seeding folded back in (RunSummary's javadoc).
+        // Three clocks, three spans (RunSummary's javadoc): duration_ms is the post-seed whole-run
+        // clock, session_duration_ms folds seeding back in, listing_duration_ms stops at the
+        // listing->merge boundary.
         assertThat(root.get("duration_ms").asLong()).isEqualTo(25_000L);
         assertThat(root.get("session_duration_ms").asLong()).isEqualTo(31_000L);
+        assertThat(root.get("listing_duration_ms").asLong()).isEqualTo(20_000L);
         assertThat(root.get("objects").asLong()).isEqualTo(1000L);
 
         JsonNode config = root.get("config");
@@ -206,6 +209,10 @@ final class JsonRunSummaryWriterTest {
         JsonNode regime = shape.get("regime");
         assertThat(regime.get("api_latency_p50_ms").asDouble()).isEqualTo(41.2);
         assertThat(regime.get("api_latency_p99_ms").asDouble()).isEqualTo(210.7);
+        // This summary carries no worker_page latency row, so the data-page percentiles render as
+        // JSON null rather than being omitted — a fleet parser never needs a key-presence check.
+        assertThat(regime.get("worker_page_latency_p50_ms").isNull()).isTrue();
+        assertThat(regime.get("worker_page_latency_p99_ms").isNull()).isTrue();
         assertThat(regime.get("worker_count").asInt()).isEqualTo(64);
         assertThat(regime.get("region").asText()).isEqualTo("us-east-2");
         JsonNode fingerprint = shape.get("fingerprint");
@@ -530,7 +537,8 @@ final class JsonRunSummaryWriterTest {
         // cpu_seconds/cpu_efficiency (double); JSON renders these as null, not -1 (the log-line
         // sentinel).
         RunSummary summary = new RunSummary(
-                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(25), "WORK_STEALING", 118L, 0.00059,
+                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(25), Duration.ofSeconds(25),
+                "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, -1L, -1L, -1.0, -1.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);
@@ -1039,7 +1047,7 @@ final class JsonRunSummaryWriterTest {
 
     private static RunSummary summaryWithDuration(Duration duration) {
         return new RunSummary(
-                42L, 1000L, duration, duration, "WORK_STEALING", 118L, 0.00059,
+                42L, 1000L, duration, duration, duration, "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
@@ -1065,5 +1073,138 @@ final class JsonRunSummaryWriterTest {
         JsonNode rollup = MAPPER.readTree(path.toFile()).get("recovered_errors");
         assertThat(rollup.get("attempt_timeout_events").asLong()).isZero();
         assertThat(rollup.get("min_effective_t").isNull()).isTrue();
+        assertThat(rollup.get("freeze_gate_checks").asLong())
+                .as("a run whose successes never reached the freeze gates reports zero TRIALS — "
+                        + "which is what makes its zero freeze counts readable")
+                .isZero();
+    }
+
+    /**
+     * The freeze counters are only comparable against the trials they could have fired in, so the
+     * denominator has to travel with them in the same block.
+     */
+    @Test
+    void recoveredErrorRollupCarriesTheFreezeGateDenominator(@TempDir Path dir) throws Exception {
+        Path path = dir.resolve("summary.json");
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RunMetrics metrics = new RunMetrics(registry);
+        metrics.recordFreezeGateCheck();
+        metrics.recordFreezeGateCheck();
+        metrics.recordFreezeGateCheck();
+        metrics.recordLatencyFreeze();
+        RunSummary snapshot = summary();
+        JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
+                config(path, Duration.ofMinutes(10)), registry, Instant.now(), () -> snapshot);
+        try {
+            writer.complete(snapshot);
+        } finally {
+            writer.close();
+        }
+
+        JsonNode rollup = MAPPER.readTree(path.toFile()).get("recovered_errors");
+        assertThat(rollup.get("latency_freezes").asLong()).isEqualTo(1L);
+        assertThat(rollup.get("freeze_gate_checks").asLong()).isEqualTo(3L);
+    }
+
+    /**
+     * The regime's serial-baseline estimator is the {@code worker_page} DATA-page cost, not the
+     * all-call-classes {@code api_latency_*} (which cheap structure/pivot probes pull low).
+     */
+    @Test
+    void regimeReadsTheWorkerPagePercentilesOffTheCallClassRows(@TempDir Path dir) throws Exception {
+        Path path = dir.resolve("summary.json");
+        RunSummary snapshot = summaryWithCallClassLatency(List.of(
+                // A cheap probe class and a non-total phase, both of which must be passed over.
+                new RunSummary.CallClassLatencySummary(RunMetrics.CALL_CLASS_STRUCTURE_PROBE,
+                        RunMetrics.LATENCY_PHASE_TOTAL, 12L, 8.0, 11.0, 14.0, 15.0),
+                new RunSummary.CallClassLatencySummary(RunMetrics.CALL_CLASS_WORKER_PAGE,
+                        RunMetrics.LATENCY_PHASE_TTFB, 900L, 33.0, 60.0, 140.0, 190.0),
+                new RunSummary.CallClassLatencySummary(RunMetrics.CALL_CLASS_WORKER_PAGE,
+                        RunMetrics.LATENCY_PHASE_TOTAL, 900L, 88.0, 150.0, 420.0, 610.0)));
+        JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
+                config(path, Duration.ofMinutes(10)), registryWithMeters(), Instant.now(), () -> snapshot);
+        try {
+            writer.complete(snapshot);
+        } finally {
+            writer.close();
+        }
+
+        JsonNode regime = MAPPER.readTree(path.toFile()).get("shape").get("regime");
+        assertThat(regime.get("worker_page_latency_p50_ms").asDouble()).isEqualTo(88.0);
+        assertThat(regime.get("worker_page_latency_p99_ms").asDouble()).isEqualTo(420.0);
+        assertThat(regime.get("api_latency_p50_ms").asDouble())
+                .as("the all-call-classes figure stays exactly as it was — the data-page pair is "
+                        + "additive alongside it, not a redefinition")
+                .isEqualTo(41.2);
+    }
+
+    /** {@link #summary()} with an explicit per-call-class latency row set. */
+    private static RunSummary summaryWithCallClassLatency(
+            List<RunSummary.CallClassLatencySummary> callClassLatency) {
+        return new RunSummary(
+                42L, 1000L, Duration.ofSeconds(25), Duration.ofSeconds(31), Duration.ofSeconds(20),
+                "WORK_STEALING", 118L, 0.00059,
+                4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
+                4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
+                2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
+                new RunSummary.SeedSummary("shallow", 5L, 12L, 4L, 13L),
+                shape(), null, List.of(), callClassLatency, clientCost(), null);
+    }
+
+    /**
+     * End-to-end through {@link RunMetrics} over a fake clock: {@code listing_duration_ms} is the
+     * listing-only clock, so it stops at the listing&rarr;merge boundary while {@code duration_ms}
+     * runs on through the merge/publish tail.
+     */
+    @Test
+    void listingDurationStopsAtTheMergeBoundaryWhileDurationRunsOn(@TempDir Path dir) throws Exception {
+        Path path = dir.resolve("summary.json");
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AtomicLong clock = new AtomicLong(1_000_000_000L);   // non-zero: 0 is the unstamped sentinel
+        RunMetrics metrics = new RunMetrics(registry, clock::get);
+        metrics.markRunStarted();
+        clock.addAndGet(5_000_000_000L);    // 5s of listing
+        metrics.markListingFinished();
+        clock.addAndGet(10_000_000_000L);   // 10s of merge/publish
+
+        RunSummary snapshot = metrics.summary(Duration.ofSeconds(15), "WORK_STEALING", 1L, 0L);
+        JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
+                config(path, Duration.ofMinutes(10)), registry, Instant.now(), () -> snapshot);
+        try {
+            writer.complete(snapshot);
+        } finally {
+            writer.close();
+        }
+
+        JsonNode root = MAPPER.readTree(path.toFile());
+        assertThat(root.get("duration_ms").asLong()).isEqualTo(15_000L);
+        assertThat(root.get("listing_duration_ms").asLong())
+                .as("the merge lists nothing, so it is not part of the listing clock")
+                .isEqualTo(5_000L);
+    }
+
+    /** A run that never merges never stamps a boundary: the two clocks are one figure. */
+    @Test
+    void listingDurationEqualsDurationOnARunThatNeverMerges(@TempDir Path dir) throws Exception {
+        Path path = dir.resolve("summary.json");
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AtomicLong clock = new AtomicLong(1_000_000_000L);
+        RunMetrics metrics = new RunMetrics(registry, clock::get);
+        metrics.markRunStarted();
+        clock.addAndGet(15_000_000_000L);
+
+        RunSummary snapshot = metrics.summary(Duration.ofSeconds(15), "WORK_STEALING", 1L, 0L);
+        JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
+                config(path, Duration.ofMinutes(10)), registry, Instant.now(), () -> snapshot);
+        try {
+            writer.complete(snapshot);
+        } finally {
+            writer.close();
+        }
+
+        JsonNode root = MAPPER.readTree(path.toFile());
+        assertThat(root.get("listing_duration_ms").asLong())
+                .isEqualTo(root.get("duration_ms").asLong())
+                .isEqualTo(15_000L);
     }
 }

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -1160,7 +1160,7 @@ final class JsonRunSummaryWriterTest {
     void listingDurationStopsAtTheMergeBoundaryWhileDurationRunsOn(@TempDir Path dir) throws Exception {
         Path path = dir.resolve("summary.json");
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        AtomicLong clock = new AtomicLong(1_000_000_000L);   // non-zero: 0 is the unstamped sentinel
+        AtomicLong clock = new AtomicLong(1_000_000_000L);
         RunMetrics metrics = new RunMetrics(registry, clock::get);
         metrics.markRunStarted();
         clock.addAndGet(5_000_000_000L);    // 5s of listing

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsCharacterizationWorkload.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsCharacterizationWorkload.java
@@ -152,6 +152,7 @@ final class RunMetricsCharacterizationWorkload {
         m.recordAimdVote();
         m.recordAimdTargetReduction();
         m.recordTimeoutShed();
+        m.recordFreezeGateCheck();
         m.recordLatencyFreeze();
         m.recordGrowthFreeze();
         m.setLatencyBaselineMillis(42L);

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsOtlpSeriesIdentityTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsOtlpSeriesIdentityTest.java
@@ -77,7 +77,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class RunMetricsOtlpSeriesIdentityTest {
 
     /** Micrometer-side meter count under an OTLP registry — no {@code *.percentile} gauges. */
-    static final int EXPECTED_OTLP_METER_COUNT = 127;
+    static final int EXPECTED_OTLP_METER_COUNT = 128;
 
     /**
      * {@code swath.process.cpu.time} is the ONLY platform-conditional meter: it is a {@code
@@ -92,6 +92,7 @@ final class RunMetricsOtlpSeriesIdentityTest {
 
     /** Every meter registered on an OTLP registry, as {@code TYPE|name|{sorted tags}}. FROZEN. */
     private static final List<String> EXPECTED_OTLP_METER_IDS = List.of(
+            "COUNTER|swath.aimd.freeze_gate_checks|{}",
             "COUNTER|swath.aimd.growth_freeze|{}",
             "COUNTER|swath.aimd.latency_freeze|{}",
             "COUNTER|swath.aimd.target_reductions|{}",

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSimpleRegistrySeriesIdentityTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSimpleRegistrySeriesIdentityTest.java
@@ -76,6 +76,7 @@ final class RunMetricsSimpleRegistrySeriesIdentityTest {
      * deliberately.
      */
     private static final List<String> EXPECTED_METER_IDS = List.of(
+            "COUNTER|swath.aimd.freeze_gate_checks|{}",
             "COUNTER|swath.aimd.growth_freeze|{}",
             "COUNTER|swath.aimd.latency_freeze|{}",
             "COUNTER|swath.aimd.target_reductions|{}",
@@ -272,6 +273,7 @@ final class RunMetricsSimpleRegistrySeriesIdentityTest {
 
     /** Deterministic event counts for the same workload, as {@code name{tags}=count}. FROZEN. */
     private static final List<String> EXPECTED_DETERMINISTIC_COUNTS = List.of(
+            "swath.aimd.freeze_gate_checks{}=1",
             "swath.aimd.growth_freeze{}=1",
             "swath.aimd.latency_freeze{}=1",
             "swath.aimd.target_reductions{}=1",
@@ -374,7 +376,7 @@ final class RunMetricsSimpleRegistrySeriesIdentityTest {
             "swath.throttle.events{type=slowdown}=1");
 
     /** Size of {@link #EXPECTED_METER_IDS} — see the class javadoc for why it differs under OTLP. */
-    private static final int EXPECTED_SIMPLE_METER_COUNT = 193;
+    private static final int EXPECTED_SIMPLE_METER_COUNT = 194;
 
     /**
      * A valid production run emits exactly ONE {@code swath.api.calls} series, because {@code

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -45,11 +45,14 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
      * {@link RunSummary}'s record components, in declaration order. FROZEN. {@code sessionDuration}
      * was ADDED right after {@code duration} — the resolution for the elapsed-scope inconsistency
      * between the live progress line (session-scoped, seeding included) and this record's
-     * `duration` (listing-scoped, a fresh run's clock starts AFTER seeding): moved deliberately here
-     * alongside that change, not re-captured.
+     * `duration` (post-seed, a fresh run's clock starts AFTER seeding). {@code listingDuration}
+     * followed it, once `duration` turned out to run PAST the listing on a sorted run (it ends at
+     * summary time, merge included). Both moved deliberately here alongside their change, not
+     * re-captured.
      */
     private static final List<String> EXPECTED_SUMMARY_FIELDS = List.of(
-            "runId", "objects", "duration", "sessionDuration", "strategy", "apiCalls", "costUsd",
+            "runId", "objects", "duration", "sessionDuration", "listingDuration",
+            "strategy", "apiCalls", "costUsd",
             "outputFiles", "compressedBytes", "keys", "pages", "peakInFlight", "avgInFlight", "timeToFirstStealMs",
             "timeToPeakInFlightMs", "steals", "splits",
             "errors", "keysPerSecond", "apiCallsPer1kObjects", "peakRssBytes", "peakHeapBytes",
@@ -86,6 +89,9 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
         // counters directly), so sessionDuration falls back to the listing duration verbatim rather
         // than reading a garbage delta off an unset clock — see RunMetrics#sessionDuration(Duration).
         assertThat(s.sessionDuration()).isEqualTo(Duration.ofSeconds(5));
+        // The workload never crosses a listing→merge boundary (markListingFinished is never called),
+        // so the listing clock is the run clock verbatim — the unsorted-run case.
+        assertThat(s.listingDuration()).isEqualTo(Duration.ofSeconds(5));
         assertThat(s.strategy()).isEqualTo("WORK_STEALING");         // passed through verbatim
         assertThat(s.apiCalls()).isEqualTo(3L);           // the single WORK_STEALING series (production ordering)
         assertThat(s.costUsd()).isCloseTo(3 * 0.005 / 1_000.0, within(1e-12));

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -47,11 +47,13 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
      * between the live progress line (session-scoped, seeding included) and this record's
      * `duration` (post-seed, a fresh run's clock starts AFTER seeding). {@code listingDuration}
      * followed it, once `duration` turned out to run PAST the listing on a sorted run (it ends at
-     * summary time, merge included). Both moved deliberately here alongside their change, not
+     * summary time, merge included), and {@code recoveredObjects} after {@code objects}, so the
+     * this-process-only rate numerator (`objects - recoveredObjects`) stops being reconstructible
+     * only from the -v progress line. All three moved deliberately here alongside their change, not
      * re-captured.
      */
     private static final List<String> EXPECTED_SUMMARY_FIELDS = List.of(
-            "runId", "objects", "duration", "sessionDuration", "listingDuration",
+            "runId", "objects", "recoveredObjects", "duration", "sessionDuration", "listingDuration",
             "strategy", "apiCalls", "costUsd",
             "outputFiles", "compressedBytes", "keys", "pages", "peakInFlight", "avgInFlight", "timeToFirstStealMs",
             "timeToPeakInFlightMs", "steals", "splits",
@@ -83,6 +85,9 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
 
         assertThat(s.runId()).isEqualTo(7L);
         assertThat(s.objects()).isEqualTo(910L);          // entries.emitted, incl. recordRecoveredObjects
+        // The backfilled share of that total, carried so `objects - recoveredObjects` (the 900 rows
+        // this process actually listed) is readable straight off the summary.
+        assertThat(s.recoveredObjects()).isEqualTo(10L);
         assertThat(s.keys()).isEqualTo(910L);             // keys mirrors objects
         assertThat(s.duration()).isEqualTo(Duration.ofSeconds(5));   // passed through verbatim
         // No session-wide RunProgressReporter ever claimed this RunMetrics (the workload drives

--- a/swath-core/src/test/java/io/varve/swath/observability/TailOccupancyListingScopeTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/TailOccupancyListingScopeTest.java
@@ -106,4 +106,32 @@ final class TailOccupancyListingScopeTest {
                 .as("first call wins — listing_duration_ms stays the first crossing")
                 .isEqualTo(10L);
     }
+
+    /**
+     * A boundary crossed at clock 0 is a real crossing. The stamp is claimed by a separate flag, not
+     * by a CAS from a 0 sentinel on the timestamp — a fake clock may legitimately read 0 there, and
+     * a sentinel scheme would silently leave the boundary unstamped and hand the win to the first
+     * NON-ZERO crossing instead (the same reasoning {@code sessionClaimed} is built on).
+     */
+    @Test
+    void aBoundaryStampedAtClockZeroSticks() {
+        long[] clock = {0L};
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry(), () -> clock[0]);
+        metrics.markRunStarted();       // run start and the boundary both land at clock 0
+        metrics.incrementInFlight();
+        metrics.recordEntriesEmitted(KEYS_PER_PAGE);
+        metrics.markListingFinished();
+
+        clock[0] = 500 * MS;
+        metrics.markListingFinished();   // a later crossing must not take a stamp already claimed
+
+        assertThat(metrics.summary(Duration.ofMillis(500), "WORK_STEALING", 0L, 0L)
+                .listingDuration())
+                .as("a zero-length listing is a real listing — not an unstamped boundary")
+                .isEqualTo(Duration.ZERO);
+        // The listing window has zero elapsed, so the gauges report the sampler's "unobserved" NaN
+        // rather than picking the merge's wall time back up as the run clock advances.
+        assertThat(gauge(metrics, "swath.tail_occupancy.wall_share", 10)).isNaN();
+        assertThat(gauge(metrics, "swath.tail_occupancy.avg_in_flight", 10)).isNaN();
+    }
 }

--- a/swath-core/src/test/java/io/varve/swath/observability/TailOccupancyListingScopeTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/TailOccupancyListingScopeTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The tail-occupancy gauges are scoped to the LISTING phase, not the whole run — the window and its
+ * wall-share denominator both end where the samples end ({@link RunMetrics#markListingFinished()}),
+ * never at gauge-read time. Driven over a fake clock ({@code RunMetrics(MeterRegistry,
+ * LongSupplier)}), so a simulated post-listing merge is a clock advance rather than a sleep.
+ *
+ * <p>What this pins: {@link TailOccupancySampler} only ever samples listing-time page emits, so a
+ * whole-run elapsed would stretch the window past the last sample and — on a {@code --sort} run,
+ * whose merge/publish tail can be a majority of wall time — report the merge instead of the serial
+ * listing tail these gauges exist to screen for.
+ */
+final class TailOccupancyListingScopeTest {
+
+    private static final long MS = 1_000_000L;
+
+    /** Pages of 100 keys, one per millisecond, at a steady 2 in flight. */
+    private static final int PAGES = 20;
+    private static final long KEYS_PER_PAGE = 100L;
+
+    private static double gauge(RunMetrics metrics, String name, int pct) {
+        return metrics.registry().get(name).tag("pct", Integer.toString(pct)).gauge().value();
+    }
+
+    @Test
+    void postListingWallTimeNeverMovesTheTailWindow() {
+        long[] clock = {0L};
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry(), () -> clock[0]);
+        metrics.markRunStarted();
+        metrics.incrementInFlight();
+        metrics.incrementInFlight();
+        for (int page = 0; page < PAGES; page++) {
+            clock[0] += MS;
+            metrics.recordEntriesEmitted(KEYS_PER_PAGE);
+        }
+
+        // At the boundary: the last 10% of 2000 keys starts at key 1800, i.e. the sample taken at
+        // t=18ms, so the window is the final 2ms of a 20ms listing.
+        double wallShareAtBoundary = gauge(metrics, "swath.tail_occupancy.wall_share", 10);
+        double avgInFlightAtBoundary = gauge(metrics, "swath.tail_occupancy.avg_in_flight", 10);
+        assertThat(wallShareAtBoundary).isCloseTo(0.1, within(1e-9));
+        assertThat(avgInFlightAtBoundary).isCloseTo(2.0, within(1e-9));
+
+        metrics.markListingFinished();
+        clock[0] += 180 * MS;   // a merge/publish tail 9x the listing it followed
+
+        assertThat(gauge(metrics, "swath.tail_occupancy.wall_share", 10))
+                .as("the wall share is a share of LISTING wall time — a merge that emits no key "
+                        + "cannot move it")
+                .isEqualTo(wallShareAtBoundary);
+        assertThat(gauge(metrics, "swath.tail_occupancy.avg_in_flight", 10))
+                .as("the window is unchanged, so its mean in-flight is too")
+                .isEqualTo(avgInFlightAtBoundary);
+        assertThat(gauge(metrics, "swath.tail_occupancy.wall_share", 5))
+                .as("a whole-run denominator would drive every window's share toward 1 — the "
+                        + "serial-tail signal these gauges exist for, drowned by the merge")
+                .isLessThan(0.5);
+    }
+
+    @Test
+    void anUnsortedRunKeepsTheLiveListingClock() {
+        long[] clock = {0L};
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry(), () -> clock[0]);
+        metrics.markRunStarted();
+        metrics.incrementInFlight();
+        for (int page = 0; page < PAGES; page++) {
+            clock[0] += MS;
+            metrics.recordEntriesEmitted(KEYS_PER_PAGE);
+        }
+
+        // No boundary is ever stamped on a run that never merges, so elapsed keeps growing with the
+        // run clock: the same 2ms window now sits inside a 40ms listing.
+        assertThat(gauge(metrics, "swath.tail_occupancy.wall_share", 10)).isCloseTo(0.1, within(1e-9));
+        clock[0] += 20 * MS;
+        assertThat(gauge(metrics, "swath.tail_occupancy.wall_share", 10)).isCloseTo(0.55, within(1e-9));
+    }
+
+    @Test
+    void theListingBoundaryStampIsIdempotent() {
+        long[] clock = {0L};
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry(), () -> clock[0]);
+        metrics.markRunStarted();
+        metrics.incrementInFlight();
+        clock[0] = 10 * MS;
+        metrics.recordEntriesEmitted(KEYS_PER_PAGE);
+
+        metrics.markListingFinished();
+        clock[0] = 500 * MS;
+        metrics.markListingFinished();   // a second crossing must not re-stamp the boundary
+
+        assertThat(metrics.summary(Duration.ofMillis(500), "WORK_STEALING", 0L, 0L)
+                .listingDuration().toMillis())
+                .as("first call wins — listing_duration_ms stays the first crossing")
+                .isEqualTo(10L);
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/runtime/ListRunnerObservabilityTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/ListRunnerObservabilityTest.java
@@ -163,10 +163,11 @@ final class ListRunnerObservabilityTest {
                 .orElseThrow(() -> new AssertionError("no list_run_diagnostics log line emitted"));
 
         assertThat(summaryLine)
-                .as("the -v line must carry both clocks, same as the JSON report and the "
+                .as("the -v line must carry all three clocks, same as the JSON report and the "
                         + "stderr summary, so a machine consumer scraping this line never disagrees "
                         + "with the other two surfaces about the session's actual wall clock")
                 .contains("duration_ms=")
+                .contains("listing_duration_ms=")
                 .contains("session_duration_ms=")
                 .contains("api_calls_per_1k_objects=")
                 .contains("peak_rss_bytes=")

--- a/swath-core/src/test/java/io/varve/swath/runtime/ListRunnerObservabilityTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/ListRunnerObservabilityTest.java
@@ -169,6 +169,7 @@ final class ListRunnerObservabilityTest {
                 .contains("duration_ms=")
                 .contains("listing_duration_ms=")
                 .contains("session_duration_ms=")
+                .contains("recovered_objects=")
                 .contains("api_calls_per_1k_objects=")
                 .contains("peak_rss_bytes=")
                 .contains("peak_heap_bytes=")

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortMergeReentryContractTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortMergeReentryContractTest.java
@@ -229,6 +229,20 @@ final class SortMergeReentryContractTest {
             assertThat(summaryJson.get("sort").get("merge_only_resume").asBoolean())
                     .as("summary.sort.merge_only_resume marks these as recovered-from-checkpoint counts")
                     .isTrue();
+            // ...and every one of those rows is attributed as RECOVERED, because an earlier process
+            // listed them. This one issued zero LIST calls, so the figures measured against ITS work
+            // must read zero rather than credit a whole bucket to the merge's wall clock.
+            assertThat(summaryJson.get("recovered_objects").asLong())
+                    .as("a merge-only resume listed none of the rows it republished")
+                    .isEqualTo(keyspace.size());
+            assertThat(summaryJson.get("efficiency").get("keys_per_sec").asDouble())
+                    .as("objects - recovered_objects is 0, so this process's listing rate is 0 — "
+                            + "not a bucket's worth of keys divided by the merge's seconds")
+                    .isZero();
+            assertThat(summaryJson.get("efficiency").get("api_calls_per_1k_objects").asDouble())
+                    .as("no LIST call and no self-listed object: the per-object call figure is 0, "
+                            + "never a division against rows this process never fetched")
+                    .isZero();
         }
     }
 


### PR DESCRIPTION
## What

A production-fleet analysis found that several summary fields are computed over the whole run while being named and read as listing-phase figures. On a `--sort` run the post-listing merge/publish tail is a meaningful share of wall, and every one of these biases the same way: it makes the engine look worse than it is. This PR scopes what must be scoped, adds the fields consumers need to do the rest, and fixes the docs that encoded the wrong reading.

## Changes

**`tail_occupancy.wall_share` can now actually detect a serial tail on a sorted run.** The window is derived from listing-time samples, but both the window end and the denominator were gauge-read-time whole-run elapsed — so on a sorted run the merge sat inside both and the gauge mostly reported the merge, not a serial tail. Ranking buckets by the raw gauge put the biggest merges at the top of a "worst serial tails" list — the exact inverse of the truth. Both ends now freeze at the listing→merge boundary. `tail_occupancy.avg_in_flight` was always listing-scoped and is unchanged.

**New `listing_duration_ms`** (top-level, beside `duration_ms`/`session_duration_ms`): the listing-only clock, stamped at the listing→merge boundary; equals `duration_ms` on a run that never merges. `keys_per_sec`, `cpu_efficiency`, and `avg_in_flight` deliberately keep their whole-run semantics for schema stability — the new field makes the listing-phase rate a trivial division instead of a reconstruction from `sort.merge_ms`. The boundary is claimed by a single atomic nullable stamp (one CAS both claims the crossing and publishes it — no reader can observe "finished" without the timestamp it's finished with).

**New `recovered_objects`** (top-level, beside `objects`): the resume-backfilled row count this process never listed — the exact numerator correction `keys_per_sec` already applies internally, previously visible only on the `-v` progress line. Listing rate is now derivable from the artifact alone: `(objects − recovered_objects) ÷ (listing_duration_ms / 1000)`. A merge-only `--sort --resume` (this process re-runs only the merge, zero new LIST fetches) now attributes every republished row as recovered, so its `keys_per_sec` reads `0.0` by construction instead of crediting a whole bucket to the merge's wall clock.

**New `recovered_errors.freeze_gate_checks`**: the AIMD freeze counters count suppressed growth opportunities, and a success at Tmax (or inside a throttle cool-down) returns before the gates — so a healthy saturated run reads zero freezes by design, and raw counts are incomparable across runs at different saturation. That selection effect can produce a false "low occupancy is self-throttling" inference. The new counter is the denominator: `latency_freezes / freeze_gate_checks` is the comparable rate.

**New `shape.regime.worker_page_latency_p50_ms`/`_p99_ms`**: the existing `api_latency_*` pair spans every call class including cheap structure/pivot probes and reads low of the data-page cost — which understates a serial tool's cost and therefore swath's own advantage. The worker-page pair is the closest available estimator of what a serial lister would pay per page.

**CLI headline**: the `listing` label now renders only when the figure is actually listing-only (`duration_ms == listing_duration_ms`) — on a sorted run the old label attributed merge time to the scan.

**Docs**: the three-clock explanation (`duration_ms` / `listing_duration_ms` / `session_duration_ms`); `sort.merge_ms` documented as the whole post-listing tail (boundary sampling + merge passes + final write + publish), not the merge proper; `engine.pages` (pages kept and shipped) vs `cost.api_calls` (requests issued); `meters[]` percentile-gauge values are in seconds, unlike the `*_ms` fields; `slow_ranges` is always empty on a completed run; merge-only `--sort --resume` reads `listing_duration_ms ≈ 0` with full `objects`/`recovered_objects` (`sort.merge_only_resume` is the tell); rescale guidance in performance.md now uses `listing_duration_ms`.

All summary changes are additive under schema v2 — no field renamed, no semantics changed.

## Not in this PR

The same analysis flagged the per-page checkpoint commit wait as a large share of estimated worker-time on the largest sorted runs — a perf lead, not a metric bug: refs #102.

## Testing

Full `./gradlew build` green. New tests: listing-scope freezing of the tail gauges (incl. a boundary-at-clock-0 regression), freeze-gate denominator invariants (Tmax and cool-down successes are not trials; freezes never outnumber trials), `listing_duration_ms`/`recovered_objects`/regime-field emission, merge-only-resume attribution (`recovered_objects`/`keys_per_sec`/`api_calls_per_1k_objects` all zero-on-this-process's-own-work), and the renderer label gating (both sides pinned). Characterization sets moved deliberately: +1 meter (`swath.aimd.freeze_gate_checks`), +2 `RunSummary` components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run summaries now distinguish listing, session, and total run durations.
  * Reports include listing duration and recovered-object counts.
  * JSON output adds worker-page latency percentiles and freeze-gate trial metrics.
* **Bug Fixes**
  * Sorted-run summaries no longer attribute merge and publishing time to listing.
  * Tail occupancy metrics exclude post-listing merge time.
  * Recovery and resume accounting is more accurate, including throughput metrics.
* **Documentation**
  * Expanded guidance explains updated timing, throughput, recovery, and observability metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->