### PR TITLE
Improve Swath's public newcomer journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,61 @@
 **Lists very large S3 buckets in parallel, working out how to split the keyspace
 while it lists.**
 
-![Swath demo: interrupt and resume a 39.6-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)
+Use swath when you need every key in a bucket too big to list one page at a time,
+and there is no fresh S3 Inventory or S3 Metadata table to fall back on. It reads
+listings, never object contents. If you already have a current precomputed listing,
+use that instead: querying it is strictly cheaper than any live
+`ListObjectsV2` lister, swath included.
 
-**Real 39.6-million-object run:** interrupt the listing, resume it from checkpoint,
+## Quickstart
+
+With Docker installed, this lists a real public prefix without requiring an AWS
+account, credentials, a local Swath installation, or a JDK:
+
+```bash
+docker run --rm ghcr.io/varveio/swath:latest \
+  list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request --format tsv > /dev/null
+```
+
+One day of NOAA's global surge model output on AWS Open Data contains about
+5,200 objects and should finish in a few seconds. The object rows are discarded
+for this installation and connectivity check; Swath's summary on stderr reports
+the objects, elapsed time, API calls, and estimated request cost. Anonymous LIST
+requests are not associated with your AWS account. This small slice validates
+the workflow, not Swath's scaling claims; the recorded full-bucket run below is
+the scale and mechanism evidence.
+
+To keep the same listing as crash-resumable Parquet, create a host directory and
+run the container as your user so it can write through the bind mount:
+
+```bash
+mkdir -p out
+docker run --rm -t --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
+  ghcr.io/varveio/swath:latest \
+  list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request \
+  --format parquet -o /out/data
+```
+
+This produces `out/data/data/*.parquet` plus `out/data/manifest.json`. Every
+object is one row; the most useful columns are the byte-exact `key`, `size`,
+`last_modified`, `etag`, `storage_class`, and `row_type`. DuckDB, Athena, Spark,
+and Trino can query the directory dataset directly, with no merge step. Resume
+an interrupted Docker run from its last committed cursor with:
+
+```bash
+docker run --rm -t --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
+  ghcr.io/varveio/swath:latest resume /out/data
+```
+
+See [`docs/install.md`](docs/install.md) for every install path, download
+verification, private-bucket credentials, and the maintained quickstart. The
+complete output schema is in [`docs/usage.md`](docs/usage.md).
+
+![Swath demo: interrupt and resume a 39.7-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)
+
+**Real 39.7-million-object run:** interrupt the listing, resume it from checkpoint,
 then query the Parquet inventory with DuckDB.
 
 S3 lists a bucket one page at a time: 1000 keys per request, strictly in
@@ -18,9 +70,10 @@ the keyspace is free; knowing whether the split was balanced costs a listing.
 
 swath guesses disjoint ranges blind, starts workers on the guesses, and corrects
 them as real keys come back — stealing work across a fixed pool when a range turns
-out denser or emptier than the guess assumed. No prefix hints, no pre-pass, no
-prior knowledge of how the keys are laid out. The name fits the method: the
-keyspace is tiled into adjacent ranges and swept in parallel, like mown swaths.
+out denser or emptier than the guess assumed. It needs no user-supplied prefix
+hints and no full listing pre-pass; one bounded delimiter probe helps seed the
+initial guesses. The name fits the method: the keyspace is tiled into adjacent
+ranges and swept in parallel, like mown swaths.
 
 To see the mechanism rather than read it, the
 [visual field guide](https://swath.varve.io/field-guide/) walks the range
@@ -29,71 +82,17 @@ guess secretly held 68% of the bucket — with the
 [generated trace report](https://swath.varve.io/runs/noaa-gestofs-pds/) of that
 run to interrogate. Both live at [swath.varve.io](https://swath.varve.io/).
 
-swath is built and maintained by [Varve](https://varve.io/) — we catalog the
-datasets inside object storage from listing structure alone, never object
-contents. swath is the listing layer underneath it, and we wanted it inspectable
-by the people who would have to trust it.
+swath is built and maintained by [Varve](https://varve.io/), a system of record
+for object storage.
 
 It is a **Java 25** CLI for general-purpose S3 buckets (directory buckets are not
-supported), distributed as a self-contained jar and an installable launcher.
+supported), distributed as a signed multi-arch Docker image, self-contained jar,
+and application-distribution archives.
 
-**Status: pre-1.0.** The `list` and `resume` commands are built and tested,
-including globally sorted Parquet output and crash-safe checkpoint/resume. Still
-planned: the `inspect` and `diff` subcommands, versioned-bucket listing, and
-object stores beyond S3 (there are internal design seams, but no supported
-backend SPI yet) — see
-[`ROADMAP.md`](ROADMAP.md). Flags and output schemas may still change before 1.0.
-
-## Quickstart
-
-Tagged releases ship a signed multi-arch Docker image, a self-contained
-uber-jar, and application-distribution archives — grab the newest from the
-[releases page](https://github.com/varveio/swath/releases). See
-[`docs/install.md`](docs/install.md) for every install path, download
-verification, and a fuller quickstart.
-
-```bash
-docker run --rm -v "$PWD/out:/out" ghcr.io/varveio/swath:latest \
-  list s3://my-bucket/prefix/ --no-sign-request --format parquet -o /out/data
-```
-
-Or from source:
-
-```bash
-./gradlew :swath-cli:installDist
-export PATH="$PWD/swath-cli/build/install/swath/bin:$PATH"
-swath list s3://my-bucket/prefix/ --no-sign-request --format parquet -o out/
-```
-
-Every object becomes one row. The columns you will use most:
-
-```text
-key              BINARY       raw key bytes, byte-exact, never UTF-8 coerced
-size             INT64        object size in bytes
-last_modified    TIMESTAMP    micros, UTC
-etag             UTF8         quotes stripped, multipart ETags kept verbatim
-storage_class    UTF8         STANDARD, GLACIER, ...
-row_type         UTF8         OBJECT | COMMON_PREFIX (DELETE_MARKER reserved)
-```
-
-Owner, checksum, and versioning columns are always present too, reserved for
-versioned listing rather than populated by it. The full schema is in
-[`docs/usage.md`](docs/usage.md).
-
-Resume an interrupted run from its output directory:
-
-```bash
-swath resume out/
-```
-
-## When not to use it
-
-swath reads listings, never objects. It is **LIST-only** by design, and it exists
-for buckets where a precomputed listing (AWS S3 Inventory or S3 Metadata tables)
-isn't an option — not enabled, too stale, or on a bucket you don't own. If you
-already have a fresh Inventory or Metadata table you can query, use that: reading a
-precomputed listing is strictly cheaper than any live `ListObjectsV2` lister, swath
-included, and swath will tell you so rather than pretend otherwise.
+Swath ships `list` and `resume` — crash-safe checkpoint/resume and optional
+globally sorted Parquet included. On the roadmap: `inspect`, `diff`,
+versioned-bucket listing, and object stores beyond S3. See
+[`ROADMAP.md`](ROADMAP.md).
 
 ## Behaviour and limits
 
@@ -105,10 +104,11 @@ included, and swath will tell you so rather than pretend otherwise.
   heap. Active pipeline buffers are configuration-bounded; Parquet output also
   retains metadata proportional to finalized part count, and `--sort` retains
   metadata proportional to staging-segment count.
-- **Published scale evidence is still thin.** The CI gate pins heap behaviour at
-  100,000 keys — a regression guard, not a scale measurement. Larger runs are in
-  progress; their figures, and a throughput number, will land in
-  [`docs/performance.md`](docs/performance.md).
+- **The published large-run evidence is one recorded 39.7-million-object
+  listing.** It demonstrates the mechanism under substantial skew, but is not a
+  comparative benchmark or a broad characterization of performance. The CI gate
+  also pins heap behaviour at 100,000 keys as a regression guard, not a scale
+  measurement. See [`docs/performance.md`](docs/performance.md).
 - **Costs one LIST request per 1000 keys.** A billion-key bucket is roughly 1M
   requests — about $5 at a $0.005-per-1000-requests reference rate — before probe
   and retry overhead, and before egress if you run it outside the bucket's region.

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,14 +11,18 @@ custody), and attached to the
 ## Docker
 
 ```
-docker run --rm -v "$PWD/out:/out" ghcr.io/varveio/swath \
-  list s3://my-bucket/prefix/ --no-sign-request \
+mkdir -p out
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
+  ghcr.io/varveio/swath:latest \
+  list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request \
   --format parquet -o /out/data
 ```
 
 Images are published to `ghcr.io/varveio/swath`; `:latest` and the `X.Y.Z`
-semver tags are owned solely by releases, and a bare image name resolves to
-`:latest`. Drop `--no-sign-request` and add credentials for a private bucket. See
+semver tags are owned solely by releases. The command above lists a small public
+demo prefix without AWS credentials. For a private bucket, replace the target,
+drop `--no-sign-request`, and use the normal AWS credential chain. See
 [`packaging-and-docker.md`](packaging-and-docker.md) for the image's signal
 handling, tag scheme, and how to pin a digest rather than a mutable tag.
 
@@ -66,23 +70,25 @@ module graph.
 
 ## Quickstart
 
-Once you have a `swath` binary (any of the above), point it at a bucket and
-look at the result on your terminal — no flags beyond the target:
+Once you have a `swath` binary (any of the above), try the verified public demo
+prefix and look at the result on your terminal:
 
 ```
-swath list s3://my-bucket/prefix/ --no-sign-request
+swath list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request
 ```
 
 On a terminal this prints an aligned table; piped to a file or another
-program it switches to TSV instead (`--format auto`, the default). Drop
-`--no-sign-request` to list a bucket you have credentials for — swath then
-uses the standard AWS credential chain (environment, profile, instance role;
-see [`faq.md`](faq.md)).
+program it switches to TSV instead (`--format auto`, the default). For your own
+bucket, replace the target and region. Drop `--no-sign-request` when using
+credentials — swath then uses the standard AWS credential chain (environment,
+profile, instance role; see [`faq.md`](faq.md)).
 
 For real output you'll keep, write a Parquet dataset:
 
 ```
-swath list s3://my-bucket/prefix/ --no-sign-request -o out/ --format parquet
+swath list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request -o out/ --format parquet
 ```
 
 This produces a directory dataset — `out/data/*.parquet` plus

--- a/notes/INDEX.md
+++ b/notes/INDEX.md
@@ -1,0 +1,4 @@
+# Notes index
+
+- [Newcomer journey across Swath surfaces](newcomer-journey.md) — coordinated
+  UX and copy proposal for the project homepage, field guide, and README.

--- a/notes/newcomer-journey.md
+++ b/notes/newcomer-journey.md
@@ -1,0 +1,225 @@
+# Newcomer journey across Swath surfaces
+
+Status: approved for prototype
+
+## Problem
+
+The Swath homepage, field guide, and README are each technically credible, but
+all three begin near the same mechanism-heavy depth. A visitor arriving from
+Varve has to understand keyspace partitioning before getting a small, safe
+first success. The quickstart uses a placeholder bucket, important “use
+Inventory instead” guidance is buried, and the field guide has no prominent
+path back to installing the tool.
+
+The goal is progressive disclosure without flattening Swath's technical depth.
+
+## Research summary
+
+Current pages were audited at desktop and mobile widths. Prior art was sampled
+from the official sites and documentation for restic, rclone, uv, Litestream,
+and DuckDB.
+
+| Project | Observed newcomer pattern |
+| --- | --- |
+| [restic](https://restic.net/) | Leads with the familiar backup job and benefits, then routes to use and internals. |
+| [rclone](https://rclone.org/) | Explains itself through familiar user jobs and gives a short, numbered first run before exhaustive reference. |
+| [uv](https://docs.astral.sh/uv/getting-started/) | Separates guides, concepts, and reference; tutorials show a concrete result before explaining artifacts. |
+| [Litestream](https://litestream.io/getting-started/) | Creates a working first success, then routes separately to deployment, mechanism, caveats, and troubleshooting. |
+| [DuckDB CLI](https://duckdb.org/docs/current/clients/cli/overview) | Gives the exact first command and expected prompt, then explains choices and expands into reference. |
+
+The convergence is: familiar problem, concrete outcome, who it is for, one
+bounded action, then deeper mechanism. Limitations work best as decision
+support (“use this when; use that when”), not as a status disclaimer.
+
+## Decision
+
+Give each surface one job:
+
+- **Homepage: front door and router.** Establish relevance in 30 seconds, give
+  one verified first run, then route to GitHub, the full quickstart, the field
+  guide, and recorded evidence.
+- **README: practitioner entry point.** Establish fit, get a user running, show
+  the result, then explain mechanism, scope, and references.
+- **Field guide: mechanism and evidence.** Preserve its depth and measured-run
+  opening; add a clear exit to using the tool.
+
+Do not repeat the full explanation on every surface. The deliberately repeated
+artifact is one canonical public-demo target.
+
+## Canonical public demo
+
+Target:
+
+```text
+s3://noaa-gestofs-pds/estofs.20210101/
+```
+
+Verified 2026-08-13:
+
+- AWS region: `us-east-1`
+- anonymous `ListObjectsV2`: allowed
+- objects under prefix: 5,196
+- raw pagination: six pages
+- the parent bucket is the same bucket used by the recorded 39.7M-object run
+
+Canonical first run (Docker required; no Swath or JDK installation):
+
+```bash
+docker run --rm ghcr.io/varveio/swath:latest \
+  list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request --format tsv > /dev/null
+```
+
+Supporting copy:
+
+> One day of NOAA's global surge model output on AWS Open Data: about 5,200
+> objects, listed anonymously in a few seconds. No AWS account or credentials
+> are needed; these anonymous LIST requests are not associated with your AWS
+> account. The object rows are discarded in this installation and connectivity
+> check, while Swath's summary reports the objects, time, API calls, and
+> estimated request cost. The next command keeps the result as Parquet. This
+> small slice validates the workflow, not Swath's scaling claims; the recorded
+> full-bucket run is the scale and mechanism evidence.
+
+Do not publish an exact Swath request count because probes and splits add to the
+six raw pagination requests. Re-verify the prefix whenever a release changes
+these public surfaces; a dated operational prefix can eventually be archived.
+
+## Homepage changes
+
+Keep the current identity, tagline, two destination cards, video, and restrained
+visual system.
+
+Replace the opening mechanism paragraph with:
+
+> For when you need every key in a bucket too big to list one page at a time —
+> and there's no fresh S3 Inventory to fall back on. Swath lists; it never reads
+> object contents.
+>
+> It divides the unknown keyspace into guessed ranges, **corrects the guesses
+> while it lists**, and writes JSONL, TSV, or crash-resumable Parquet.
+
+Add a **First run · a real public bucket** block after the primary actions. It
+contains the canonical command, supporting copy, and a link to the maintained
+install and quickstart guide at
+`https://github.com/varveio/swath/blob/main/docs/install.md`. Keep the code block
+selectable and focusable; no copy-button JavaScript.
+
+Rename the recorded-run card heading to **A recorded 39.7M-object listing** so
+the heading names the destination rather than presenting bare metrics. State
+that it is the same NOAA bucket as the demo slice.
+
+The maintained quickstart link points to `docs/install.md`, not a README anchor.
+
+Replace the footer version-status paragraph with factual shipped/roadmap copy:
+
+> Swath ships `list` and `resume` — crash-safe checkpoint/resume and optional
+> globally sorted Parquet included. On the roadmap: `inspect`, `diff`,
+> versioned-bucket listing, and object stores beyond S3.
+
+Accessibility changes:
+
+- Add semantic `header`, `main`, and existing `footer` landmarks.
+- Add explicit `:focus-visible` styles for links and the scrollable code block.
+- Give the video an accessible label and fallback text/link to the trace report;
+  its figcaption and trace-report link contain all essential information, so
+  the muted terminal footage is explicitly supplementary.
+- Adjust light-theme `--ink-3` from `#7C8781` to `#59635D`, and light-theme
+  `--signal` from `#9A6710` to `#875806`. These replacements clear 4.5:1 on
+  `--paper`, `--paper-2`, and the darker `--paper-3` hover surface (minimum
+  measured ratios 4.66:1 and 4.57:1). Adjust dark-theme `--ink-3` from
+  `#74807A` to `#829089` so it also clears every dark surface (minimum 4.60:1
+  on dark `--paper-3`); dark `--signal` already clears all three.
+
+## README changes
+
+Order the first read as:
+
+1. badge, name, one-sentence definition;
+2. concise “when to use it / use Inventory instead” paragraph;
+3. Quickstart using the canonical public demo;
+4. Parquet-output variant with the documented container-user fix;
+5. resume command and expected output shape;
+6. demo GIF as evidence;
+7. two-paragraph mechanism explanation and field-guide link;
+8. factual shipped/roadmap statement;
+9. detailed behaviour, replay server, docs, and internals.
+
+The Parquet variant must avoid the known Linux permissions trap:
+
+```bash
+mkdir -p out
+docker run --rm -t --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
+  ghcr.io/varveio/swath:latest \
+  list s3://noaa-gestofs-pds/estofs.20210101/ \
+  --region us-east-1 --no-sign-request \
+  --format parquet -o /out/data
+```
+
+Clarify two current inconsistencies:
+
+- Replace “No prefix hints, no pre-pass” with “No user-supplied prefix hints
+  and no full listing pre-pass”; Swath does use one bounded delimiter probe.
+- Replace “published scale evidence is still thin” with the precise limitation:
+  one published large recorded run is mechanism evidence, not a comparative
+  benchmark or broad performance characterization.
+
+Do not duplicate the full field guide in the README.
+
+## Field guide changes
+
+Preserve the measured-run question, metrics, technical narrative, provenance,
+collapsible contents, glossary, and candid limits.
+
+In the existing “what Swath is” callout, add a direct route to the install and
+quickstart guide. Add **Use it — install & quickstart** to the hero action row.
+Remove version-status framing from the footer and use the same factual
+shipped/roadmap sentence as the homepage.
+
+Wrap the technical sections in a `main` landmark and add
+`summary:focus-visible` styling. Do not turn the field guide into another
+installation page.
+
+## Varve handoff
+
+The Varve homepage continues to link to the Swath homepage, not directly to the
+field guide or recorded run. Once the Swath homepage gains the verified first
+run and clearer routing, it serves technical leaders and practitioners without
+duplicating those choices on Varve.
+
+## Acceptance criteria
+
+- A first-time visitor can state what Swath does, when to use it, and when to use
+  Inventory instead from the Swath homepage or README before learning its
+  partitioning algorithm.
+- The canonical public-demo command is identical on the homepage and README.
+- The demo target, region, anonymous access, approximate object count, and
+  relationship to the recorded run are factual and re-verified at implementation.
+- The first command requires Docker but no AWS credentials, local Swath/JDK
+  installation, or writable bind mount; it supplies the bucket region
+  explicitly and does not flood the terminal with object rows.
+- The Parquet Docker command runs as the host user and writes inside the mounted
+  directory.
+- Homepage, README, and field guide contain no public “pre-1.0” framing.
+- Roadmap copy does not imply unshipped commands are available.
+- The homepage has clear semantic landmarks and visible keyboard focus.
+- The homepage remains usable without JavaScript; core content and the command
+  are plain HTML.
+- The field guide preserves its full technical content and adds no more than a
+  small use-path callout/action plus footer/accessibility edits.
+- The existing mobile layouts do not acquire page-level horizontal overflow;
+  intentionally wide field-guide figures remain locally scrollable.
+- Links between Varve, Swath, quickstart, field guide, and recorded run form a
+  complete path with no dead end above the fold.
+- All new external links resolve, and the recorded-run report retains a
+  discoverable route back to the Swath homepage or field guide.
+
+## MVP and deferrals
+
+MVP edits the Varve prototype, source README and install guide, public homepage,
+and public field guide. The public HTML pages are prototyped from the `gh-pages`
+branch without publishing them.
+
+Defer a field-guide three-minute reading path, regenerated social-card art, and
+captions/transcript work unless review finds the muted terminal video contains
+unique essential information not covered by its caption and trace report.

--- a/tools/explainer/README.md
+++ b/tools/explainer/README.md
@@ -24,7 +24,7 @@ tools/explainer/
     ├── model.py                  # the reduction: figures, lineage, findings
     ├── render.py                 # model + template -> page
     ├── cli.py                    # argument handling
-    ├── selftest.py               # 29 checks, no inputs needed
+    ├── selftest.py               # internal checks, no inputs needed
     └── templates/
         ├── report.html           # the explainer report
         ├── video-strip.html      # video: the algorithm as it happens
@@ -49,17 +49,22 @@ uv run tools/explainer/explainer.py run.trace.jsonl -o run.html
 ```
 
 Open `run.html`. One file, no CDN, no external images, safe from `file://`, light and dark.
+The page carries a real `<title>` and description computed from the run (so a shared link
+identifies itself), and a one-line footer pointing at the project and the field guide —
+plain anchors, nothing fetched. `--no-links` strips the footer when the page must carry
+no URLs at all.
 
 ```text
 explainer.py TRACE.jsonl [-o OUT.html] [--title NAME] [--anonymize]
                              [--video [--video-style strip|map]]
-explainer.py --self-test              # 29 checks, no inputs needed
+explainer.py --self-test              # internal checks, no inputs needed
 ```
 
 | Flag | What it does |
 |---|---|
 | `--title` | Page heading. Defaults to the trace file's stem. |
 | `--anonymize` | Withhold every key name — positions and counts only. Use when the picture has to travel further than the trace does. |
+| `--no-links` | Omit the site-links footer, leaving a page with no URLs at all. The report never fetches anything either way. |
 | `--video` | Emit a 1080×1350 capture page instead of the report (see below). |
 | `--video-style` | `strip` (default) or `map`. Two different arguments about the same run. |
 

--- a/tools/explainer/src/swath_explainer/cli.py
+++ b/tools/explainer/src/swath_explainer/cli.py
@@ -26,6 +26,9 @@ def main(argv=None):
     parser.add_argument("--title", help="page heading (default: the trace file's stem)")
     parser.add_argument("--anonymize", action="store_true",
                         help="withhold every key name; emit positions and counts only")
+    parser.add_argument("--no-links", action="store_true",
+                        help="omit the site-links footer, leaving a page with no URLs at all; "
+                             "the report never fetches anything either way")
     parser.add_argument("--video", action="store_true",
                         help="emit a 1080x1350 capture page for recording a share-ready clip; "
                              "drive it via window.__seek(ms) and encode the frames")
@@ -56,7 +59,8 @@ def main(argv=None):
 
     model = build_model(events, skipped, args.title or args.trace.stem, args.anonymize)
     out = args.out or args.trace.with_suffix(".html")
-    page = render_video(model, args.video_style) if args.video else render_report(model)
+    page = (render_video(model, args.video_style) if args.video
+            else render_report(model, links=not args.no_links))
     out.write_text(page, encoding="utf-8")
 
     meta, F = model["meta"], model["findings"]

--- a/tools/explainer/src/swath_explainer/render.py
+++ b/tools/explainer/src/swath_explainer/render.py
@@ -28,9 +28,48 @@ def _script_safe(payload):
                    .replace("\u2028", "\\u2028").replace("\u2029", "\\u2029"))
 
 
-def render_report(model):
-    """The self-contained HTML explainer for a run."""
-    return _inject(_load("report.html"), model)
+def _esc(text):
+    return (text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace('"', "&quot;"))
+
+
+def _description(model):
+    """One shareable sentence, computed from the same model the page renders."""
+    meta, f = model["meta"], model["findings"]
+    return ("%s objects \u00b7 %d workers \u00b7 %.0fs \u2014 heaviest of %s seed guesses "
+            "held %.1f%% of the objects"
+            % ("{:,}".format(meta["totalKeys"]), meta["workers"], meta["durationMs"] / 1000.0,
+               "{:,}".format(f["seedCount"]), f["topShare"]))
+
+
+def _head_meta(model):
+    title, desc = _esc(model["meta"]["title"]), _esc(_description(model))
+    return ('<meta name="description" content="%s">\n'
+            '<meta property="og:title" content="%s">\n'
+            '<meta property="og:description" content="%s">\n'
+            '<meta property="og:type" content="article">' % (desc, title, desc))
+
+
+_SITE_LINKS = ('<div id="site-links">listed by '
+               '<a href="https://github.com/varveio/swath">swath</a> \u00b7 how the '
+               'algorithm works: '
+               '<a href="https://swath.varve.io/field-guide/">the field guide</a></div>')
+
+
+def render_report(model, links=True):
+    """The self-contained HTML explainer for a run.
+
+    Self-contained means the page fetches nothing — no CDN, no external images. Plain
+    anchors don't break that, so the default report carries a one-line footer pointing
+    at the project and the field guide, and a real <title>/description so a shared link
+    identifies itself. ``links=False`` strips the footer for a page that must carry no
+    URLs at all; the head metadata stays, since it names the run, not an address.
+    """
+    page = _inject(_load("report.html"), model)
+    page = page.replace("<title>swath run trace</title>",
+                        "<title>%s</title>" % _esc(model["meta"]["title"]), 1)
+    page = page.replace("<!--__HEAD_META__-->", _head_meta(model), 1)
+    return page.replace("<!--__SITE_LINKS__-->", _SITE_LINKS if links else "", 1)
 
 
 def render_video(model, style="strip"):

--- a/tools/explainer/src/swath_explainer/selftest.py
+++ b/tools/explainer/src/swath_explainer/selftest.py
@@ -40,8 +40,10 @@ SELF_TEST_TRACE = [
 
 def self_test():
     failures = []
+    ran = [0]
 
     def check(label, got, want):
+        ran[0] += 1
         if got != want:
             failures.append("%s: got %r, want %r" % (label, got, want))
 
@@ -103,11 +105,21 @@ def self_test():
     check("hostile key cannot close the script block",
           "</script><script>" in hostile_page, False)
     check("anonymized page withholds keys", "a/q" in page, False)
-    check("page is standalone", "http://" in page or "https://" in page, False)
+    # Self-contained means the page FETCHES nothing; plain anchors are allowed. The
+    # default footer links to the project; --no-links strips every URL from the page.
+    check("page fetches nothing",
+          'src="http' in page or "<link" in page or "url(http" in page or "@import" in page,
+          False)
+    check("default page links to the project", "https://github.com/varveio/swath" in page, True)
+    check("default page links to the field guide", "https://swath.varve.io/field-guide/" in page, True)
+    bare = render(build_model(list(SELF_TEST_TRACE), 0, "self-test", True), links=False)
+    check("no-links page carries no URLs", "http://" in bare or "https://" in bare, False)
+    check("title reaches the head", "<title>self-test</title>" in page, True)
+    check("description reaches the head", '<meta name="description"' in page, True)
 
     for line in failures:
         print("FAIL " + line, file=sys.stderr)
-    print("self-test: 29 checks, %d failures" % len(failures), file=sys.stderr)
+    print("self-test: %d checks, %d failures" % (ran[0], len(failures)), file=sys.stderr)
     return 1 if failures else 0
 
 

--- a/tools/explainer/src/swath_explainer/templates/report.html
+++ b/tools/explainer/src/swath_explainer/templates/report.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>swath run trace</title>
+<!--__HEAD_META__-->
 <style>
   :root {
     --paper:#F1F2EB; --panel:#E7E9DF; --deep:#DDE0D3;
@@ -29,6 +30,8 @@
   h1 { font-family:var(--mono); font-weight:500; font-size:clamp(1.55rem,4vw,2.25rem);
        letter-spacing:-.035em; margin:0 0 .35rem; text-wrap:balance; }
   .sub { font-family:var(--mono); font-size:.72rem; color:var(--ink3); margin-bottom:1.5rem; }
+  #site-links { font-family:var(--mono); font-size:.72rem; color:var(--ink3); margin-top:2.4rem; }
+  #site-links a { color:var(--accent); text-decoration-color:var(--rule); }
   h2 { font-family:var(--mono); font-weight:500; font-size:1.22rem; letter-spacing:-.025em;
        margin:0; text-wrap:balance; }
   .sec { padding-top:2.6rem; }
@@ -207,6 +210,7 @@
   </div>
 
   <footer id="provenance"></footer>
+<!--__SITE_LINKS__-->
 </div>
 
 <script>


### PR DESCRIPTION
## What changed

This PR now makes the complete Swath newcomer path coherent:

- gives generated run reports descriptive sharing metadata and routes back to Swath and the field guide
- moves the README quickstart before the algorithm explanation
- adds a verified, anonymous first run against a bounded NOAA public prefix
- fixes the Docker bind-mount permissions path for Parquet output
- clarifies when a live lister is useful and keeps the mechanism explanation precise
- normalizes the recorded-run figure to 39.7 million objects
- documents the coordinated homepage, README, install-guide, and field-guide roles

The matching Swath homepage and field-guide changes are published from the `gh-pages` branch.

## Why

The individual surfaces were technically strong but all began at roughly the same mechanism-heavy depth. New visitors now get a bounded first success, then can choose installation details, the visual mechanism guide, or the recorded-run evidence.

## Validation

- `tools/explainer/explainer.py --self-test` — 34 checks, 0 failures
- canonical Docker demo completed against 5,196 anonymous objects in `us-east-1`
- Parquet bind-mount command completed with host-user permissions
- `git diff --check`
- responsive browser review of the companion public pages at desktop and mobile widths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-links` option to generate reports without footer URLs.
  * Reports now include computed titles, descriptions, and sharing metadata.
  * Default report footers provide project and field-guide links.
  * Generated pages are self-contained and avoid external resource fetching.

* **Documentation**
  * Added Docker and quickstart guidance using a public NOAA demo.
  * Documented Parquet output, resume commands, private-bucket usage, and onboarding guidance.

* **Tests**
  * Expanded self-test coverage for standalone pages, metadata, and optional links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->