### PR TITLE
fix: address documentation review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ controlled by somebody else, and a serial listing is too slow.
 is difficult to parallelize, then walks through swath's range model, safe splitting,
 work stealing, checkpoints, and the cases where swath is not the right tool.
 
-[![Swath demo: interrupt and resume a 39.7-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)](https://swath.varve.io/runs/noaa-gestofs-pds/)
+[![Swath demo: interrupt and resume a 39.6-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)](https://swath.varve.io/runs/noaa-gestofs-pds/)
 
-*A real 39.7-million-object run: one of 513 initial range guesses held 68% of the
+*A real 39.6-million-object run: one of 513 initial range guesses held 68% of the
 bucket. swath discovered the imbalance while listing and split the busy ranges so idle
 workers could help. [Explore the run trace](https://swath.varve.io/runs/noaa-gestofs-pds/)
 or [see the visual field guide](https://swath.varve.io/field-guide/).*
@@ -37,7 +37,7 @@ or [see the visual field guide](https://swath.varve.io/field-guide/).*
 ## Try it
 
 This is the exact listing shown in the demo. It scans the entire public NOAA bucket—
-39.7 million objects in the recorded run—and saves a resumable Parquet dataset:
+39.6 million objects in the recorded run—and saves a resumable Parquet dataset:
 
 ```bash
 mkdir -p out

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ and similar environments.
 | `JAVA_TOOL_OPTIONS` | unset | JVM flags read by Java itself; works with the jar, launcher, and Docker image |
 | `NO_COLOR` | unset | Disables automatic color when set to any value |
 | `TERM=dumb` | environment | Disables automatic color and terminal redraws |
-| `CLICOLOR_FORCE` | unset | Forces automatic color off a terminal |
+| `CLICOLOR_FORCE` | unset | Forces automatic color on outside a terminal |
 
 An explicit `--color=always` or `--color=never` wins over terminal environment signals.
 

--- a/docs/internals/overview.md
+++ b/docs/internals/overview.md
@@ -27,7 +27,7 @@ overlap.
 The shipped product is a Java 25 CLI for general-purpose S3 buckets. It supports:
 
 - recursive current-object listing;
-- current objects, with schema support for delete markers and versions;
+- current objects; the output schema can also represent delete markers and versioned rows;
 - JSONL, TSV, table, and managed Parquet output;
 - filtering by key, size, modification time, and storage class;
 - checkpoint/resume for managed Parquet datasets (the CLI's directory output);

--- a/notes/docs-redesign.md
+++ b/notes/docs-redesign.md
@@ -98,7 +98,7 @@ not carry a second detailed table or explanation.
 
 - Put a copy-pasteable successful listing before architecture, tuning, benchmarks, or every install
   variant.
-- Explain the work-stealing idea once in plain language, with a small range example. Deep pages may
+- Explain the work-stealing idea once in plain language, with a small range-based example. Deep pages may
   use the exact `(A, B]` model after linking back to that explanation.
 - Keep decision-critical warnings next to the action they affect: LIST cost before a large run,
   sorted-output disk requirements beside `--sort`, and resume limitations beside output choice.

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
@@ -99,8 +99,8 @@ class ParquetWriterPoolTest {
         for (Path part : parts(dir)) {
             durableRows += ParquetReads.keys(part).size();
         }
-        // Only finalized parts are durable; the open tail was discarded ⇒ strictly fewer rows.
-        assertThat(durableRows).isLessThan(1001).isGreaterThan(0);
+        // Only the 1,000-row finalized part is durable; the open tail was discarded.
+        assertThat(durableRows).isEqualTo(1000);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- correct the recorded object count and terminal color wording
- clarify current-object versus versioned-row schema support
- make the Parquet abort durability assertion deterministic
- apply the remaining small documentation grammar fix

Follow-up to #116.

## Testing

- `./gradlew :swath-core:test --tests 'io.varve.swath.output.parquet.ParquetWriterPoolTest'`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated demo and quickstart examples to reflect processing 39.6 million objects.
  - Clarified that any set `CLICOLOR_FORCE` value enables color output outside a terminal.
  - Expanded output schema documentation to cover current objects, delete markers, and versioned rows.
  - Refined work-stealing guidance with a small range-based example while retaining the `(A, B]` model for deeper pages.

- **Tests**
  - Strengthened abort behavior validation to require exactly 1,000 durable rows after discarding the open tail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->