### PR TITLE
Measure parallel dataset writer backpressure

### DIFF
--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -295,7 +295,7 @@ a span with zero observations is omitted, never a fabricated all-zero row.
 | `checkpoint_commit` | `swath.checkpoint.commit.latency` | per writer-thread BATCH: op execution + `conn.commit()` (the WAL-fsync critical path). |
 | `emit` | `swath.emit.latency` | per page: the consumer stage's whole sink write (format+write for text, pool dispatch for Parquet, lane admission for `--sort`), including that stage's own row tally. |
 | `writer_backpressure` | `swath.queue.wait` | per page: the fetch worker blocked handing the page onto a full downstream channel. |
-| `parquet_write` | `swath.parquet.write.latency` | per stretch of Parquet WRITER-LANE work: the encode+write of a batch's rows into the open part, plus any finalize it triggered (footer fsync, part MD5, manifest rewrite), timed on the lane's own thread between two waits on its queue. **Not page-scoped** and **not on the page's critical path**: one observation per batch written, plus one per idle-cadence rotation and one per lane's drain-time finalize/discard, so its count is `>=` the page count on a clean run (an aborted/failed run drains its queued batches without writing them, and those record nothing). Parquet-sink runs only. |
+| `parquet_write` | `swath.parquet.write.latency` | per stretch of Parquet WRITER-LANE work: the encode+write of a batch's rows into the open part, plus any finalize it triggered (footer fsync, part MD5, manifest rewrite), timed on the lane's own thread between two waits on its queue. **Elapsed time, not CPU time**: it can include filesystem/checkpoint I/O and manifest-lock waits. **Not page-scoped** and **not on the page's critical path**: one observation per batch written, plus one per idle-cadence rotation and one per lane's drain-time finalize/discard, so its count is `>=` the page count on a clean run (an aborted/failed run drains its queued batches without writing them, and those record nothing). Parquet-sink runs only. |
 | `text_dataset_write` | `swath.text_dataset.write.latency` | the equivalent WRITER-LANE stretch for a partitioned TSV/JSONL dataset: format+compress+write, plus any close/trailer/fsync, MD5, and manifest rewrite it triggers. It has the same off-page-critical-path and observation-count semantics as `parquet_write`; ordinary single-stream text output remains fully represented by `emit`. |
 
 **Reading it.** The spans are percentile-bearing precisely because a per-page cost read as a MEAN
@@ -311,14 +311,14 @@ rows — and `sdk_unmarshal` is by far the larger of the two, so a client-cost r
 nothing to wait for, which is a real client cost of zero, not a missing measurement.
 
 **Why the dataset-writer spans exist.** For ordinary single-stream text sinks `emit` is the whole
-sink write, so summing the spans of a run brackets its process CPU. For Parquet and partitioned-text
-datasets it is not: `emit` ends at the handoff to the writer pool (dispatch — a rounding error per
-page), and the encode/compress/write that follows happens on the pool's own lane threads. Without a
-format-side lane span, that work shows up in the process's CPU with nothing attributing it. This was
-measured for Parquet as roughly
-2 ms/page of pool CPU at low concurrency, of which `swath.parquet.finalize.latency` caught only the
-footer-fsync sliver. `parquet_write` and `text_dataset_write` are those missing terms, each measured
-around its format's lane work. Their bounded lifecycle meters are
+sink write. For Parquet and partitioned-text datasets it is not: `emit` ends at the handoff to the
+writer pool (dispatch), and the encode/compress/write that follows happens on the pool's own lane
+threads. Without a format-side lane span, the active sink work is invisible. This was measured for
+Parquet as roughly 2 ms/page of active lane elapsed time at low concurrency, of which
+`swath.parquet.finalize.latency` caught only the footer-fsync sliver. That observation did not
+separate encoding CPU from file I/O or waits. `parquet_write` and `text_dataset_write` are the
+missing elapsed-time terms, each measured around its format's lane work; retained JFR execution
+samples remain the authority for CPU. Their bounded lifecycle meters are
 `swath.<format>.rotation{trigger}`, `swath.<format>.parts{outcome}`, and
 `swath.<format>.finalize.latency`; partitioned text uses the `text_dataset` namespace.
 
@@ -335,9 +335,45 @@ precisely because the consumer stage is still inside that page's (or an earlier 
 so the two are two ends of the same handoff, not sequential costs. And (3) each dataset-writer span is
 measured on the pool's lane threads, which run concurrently with the fetch workers and the consumer
 stage, so it overlaps *every* span above in wall-clock and is never part of a page's serial
-latency — while for CPU accounting it is genuinely additive to them
-(different threads, disjoint CPU). It also strictly CONTAINS its format's finalize-latency sample of
+latency. JFR execution samples, not these elapsed spans, are what can be aggregated across threads
+for CPU accounting. A lane span also strictly CONTAINS its format's finalize-latency sample of
 any rotation that fired inside the stretch, so those two must never be added together.
+
+**`parquet_writer`**: a bounded structured snapshot, present only when the direct Parquet
+pool was constructed. Lane ids deliberately do not become Micrometer tags. The top-level fields are
+`submit_blocked_count`/`submit_blocked_ms` and
+`head_of_line_blocked_count`/`head_of_line_blocked_ms`; the latter pair is the subset of full-lane
+admissions where at least one *other* lane was waiting for work with an empty queue when blocking
+began. Requiring an actually idle writer distinguishes sticky-routing head-of-line blocking from
+the ordinary case where all writers are busy, without changing routing.
+
+`lanes[]` contains one row per configured writer (1–4):
+
+| field | meaning |
+|---|---|
+| `lane`, `queue_capacity`, `queue_depth`, `queue_depth_peak`, `waiting_for_work` | Sticky lane identity, report-time bounded-queue sample/high-water mark, and whether the lane thread is currently waiting on an empty queue. A full admission records capacity exactly; other peak observations occur at periodic/terminal report cadence. After a clean drain, terminal current depth is normally zero and terminal waiting state is false because the lane threads have exited; waiting state is useful in periodic snapshots. |
+| `rows_written`, `batches_written` | Completely encoded batches/rows. A format failure partway through a batch does not present the partial row count as successful work. |
+| `finalized_bytes`, `parts_finalized` | Actual file sizes and part count after successful finalize/durability handling. |
+| `active_elapsed_ms` | Sum of lane-thread stretches between queue waits. It includes encoding, file/checkpoint I/O, fsync, MD5/manifest work, and any internal waits; it is not CPU and can overlap other lanes. |
+| `submit_blocked_count`, `submit_blocked_ms` | This sticky lane's full-queue encounters and elapsed admission waits. Interrupted waits are still evidence and remain counted. |
+| `head_of_line_blocked_count`, `head_of_line_blocked_ms` | The subset whose wait began while another lane thread was waiting for work with an empty queue. The check scans at most four lanes and runs only after the selected lane is already full. Material time is strong evidence that sticky routing stranded an idle writer; zero only means that condition was not present at blocked-admission start. |
+| `finalize_count`, `finalize_elapsed_ms` | `DatasetPartWriter.close()` attempts and elapsed close time, including failed attempts. Broader post-close MD5/checkpoint/manifest work remains in `active_elapsed_ms`. |
+
+Read the causal chain in order: lane `submit_blocked_ms` is contained in the consumer's `emit`
+span; if it is sustained, the sole consumer stops draining the shared channel; fetch workers then
+accumulate `writer_backpressure` (`swath.queue.wait`). A queue peak at capacity without submit-blocked
+time is not enough to call the sink a throughput bottleneck. Material head-of-line time confirms
+that the dispatcher waited on one sticky lane while another writer was idle; zero means that
+stronger condition did not occur at the start of a blocked admission in the observed run.
+
+**Instrumentation cost.** The normal submit path performs one non-blocking `offer`, the same single
+queue-lock acquisition the former uncontended `put` required. It does not sample queue size, read
+the clock, scan other lanes, or update blocked counters. The encode path updates single-writer
+volatile counters once per batch/lane stretch, not once per row. Only a failed `offer` reads the
+monotonic clock, scans the fixed 1–4 lane array, and updates blocked counters. Queue depth is sampled
+by the periodic/terminal reporter, which also copies that fixed lane array. Benchmark both arms with
+identical instrumentation and JFR settings; the repository does not claim a universal measured
+overhead percentage for this workload.
 
 **`demand_gate`**: the `OWNER_SPLIT.demand_gated` fixed-threshold/effective-T snapshot — `{events, last_t, min_t,
 t_max}`. `events` is the total count of demand-gate suppressions this run; `last_t`/`min_t` are the

--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -339,9 +339,11 @@ latency. JFR execution samples, not these elapsed spans, are what can be aggrega
 for CPU accounting. A lane span also strictly CONTAINS its format's finalize-latency sample of
 any rotation that fired inside the stretch, so those two must never be added together.
 
-**`parquet_writer`**: a bounded structured snapshot, present only when the direct Parquet
-pool was constructed. Lane ids deliberately do not become Micrometer tags. The top-level fields are
-`submit_blocked_count`/`submit_blocked_ms` and
+**`dataset_writer`**: a bounded structured snapshot, present when the shared parallel
+directory-dataset pool was constructed: direct Parquet and directory TSV/JSONL. It is absent for
+stdout, single-file text, discard output, and sorted output, which use different sink paths. Lane ids
+deliberately do not become Micrometer tags. `format` is `parquet`, `tsv`, or `jsonl`; the remaining
+top-level fields are `submit_blocked_count`/`submit_blocked_ms` and
 `head_of_line_blocked_count`/`head_of_line_blocked_ms`; the latter pair is the subset of full-lane
 admissions where at least one *other* lane was waiting for work with an empty queue when blocking
 began. Requiring an actually idle writer distinguishes sticky-routing head-of-line blocking from
@@ -365,6 +367,14 @@ accumulate `writer_backpressure` (`swath.queue.wait`). A queue peak at capacity 
 time is not enough to call the sink a throughput bottleneck. Material head-of-line time confirms
 that the dispatcher waited on one sticky lane while another writer was idle; zero means that
 stronger condition did not occur at the start of a blocked admission in the observed run.
+
+**Capacity decision.** A low-throughput run cannot validate the writer-count ceiling. On a matched
+high-throughput run, sustained `submit_blocked_ms` with lane peaks at capacity shows that aggregate
+sink service is insufficient. Material `head_of_line_blocked_ms` instead shows that sticky routing
+stranded an idle writer and calls for removing cross-lane dispatch coupling before adding buffers.
+Near-zero blocking means more lanes would not improve that run. Interpret lane active time as elapsed
+service, not as sustained capacity or CPU: short bursts can exclude later finalization, filesystem
+writeback, and GC costs.
 
 **Instrumentation cost.** The normal submit path performs one non-blocking `offer`, the same single
 queue-lock acquisition the former uncontended `put` required. It does not sample queue size, read

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -130,7 +130,7 @@ The stable top-level result is organized as follows:
 | `config`, `engine_flags` | Effective user configuration and engine state. |
 | `cost`, `output`, `efficiency`, `sort` | API-cost estimate, sink results, efficiency, and sorted-output details. |
 | `recovered_errors` | Transient faults swath handled without failing the run. |
-| `engine`, `seed`, `trajectory`, `slow_ranges`, `probe_latency`, `client_cost`, `demand_gate`, `shape` | Deeper scheduling, keyspace, and latency evidence. |
+| `engine`, `seed`, `trajectory`, `slow_ranges`, `probe_latency`, `client_cost`, `parquet_writer`, `demand_gate`, `shape` | Deeper scheduling, keyspace, sink, and latency evidence. |
 | `meters` | Final generic meter snapshot. |
 
 `complete=true` means the requested dataset was published. On an unsuccessful run,
@@ -158,6 +158,16 @@ metrics identify the compatibility path that reopened a carried part.
 The report can contain the target URI, arguments, filter values, slow-range bounds, and
 key samples. Treat it as operational data and redact it before sharing.
 
+`parquet_writer` is present only for direct Parquet output. Its aggregate
+`submit_blocked_*` fields measure full sticky-lane admission waits;
+`head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty
+queue when that wait began. The bounded `lanes[]` array reports lane id, queue
+current/capacity/sampled peak, waiting state, rows, finalized bytes, batches, active elapsed time,
+blocked/HOL time, and part/finalize activity. Lane identifiers live
+only in this structured block, not in Micrometer tags. Every duration in the block is elapsed time,
+not CPU time; use the retained-JFR procedure in the [performance guide](performance.md#retain-a-jfr-cpu-profile)
+for actual CPU attribution.
+
 ## 4. Progress and logs
 
 One reporter spans seeding, listing, merging, and writing. Its default cadence is 30
@@ -180,7 +190,7 @@ short investigations rather than routine high-volume runs.
 | --- | --- | --- |
 | High API latency, high in-flight work | Store or network service time | `fetch.latency.phase`, throttles, pool pending, recovered errors |
 | Low API rate and low in-flight work while listing | Work supply or a long tail | steal reasons, probes, tail occupancy, open-frontier share |
-| High `queue.wait` or `emit.latency` | Output admission or sink | Parquet write/finalize latency, output filesystem |
+| High `queue.wait` or `emit.latency` | Output admission or sink | `parquet_writer` blocked/HOL time, lane balance, Parquet write/finalize latency, output filesystem |
 | High checkpoint queue or commit waits | SQLite durability | checkpoint volume latency and queue depth |
 | High sort backpressure or many merge passes | Sort memory/disk/FD limits | `sort` report block, staging peak, effective fan-in |
 | `progress.units` flat for more than five minutes | Potential stall | phase, thread dump, last error, disk and pool state |

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -130,7 +130,7 @@ The stable top-level result is organized as follows:
 | `config`, `engine_flags` | Effective user configuration and engine state. |
 | `cost`, `output`, `efficiency`, `sort` | API-cost estimate, sink results, efficiency, and sorted-output details. |
 | `recovered_errors` | Transient faults swath handled without failing the run. |
-| `engine`, `seed`, `trajectory`, `slow_ranges`, `probe_latency`, `client_cost`, `parquet_writer`, `demand_gate`, `shape` | Deeper scheduling, keyspace, sink, and latency evidence. |
+| `engine`, `seed`, `trajectory`, `slow_ranges`, `probe_latency`, `client_cost`, `dataset_writer`, `demand_gate`, `shape` | Deeper scheduling, keyspace, sink, and latency evidence. |
 | `meters` | Final generic meter snapshot. |
 
 `complete=true` means the requested dataset was published. On an unsuccessful run,
@@ -158,7 +158,9 @@ metrics identify the compatibility path that reopened a carried part.
 The report can contain the target URI, arguments, filter values, slow-range bounds, and
 key samples. Treat it as operational data and redact it before sharing.
 
-`parquet_writer` is present only for direct Parquet output. Its aggregate
+`dataset_writer` is present for direct Parquet and parallel directory TSV/JSONL output; its
+`format` is `parquet`, `tsv`, or `jsonl`. It is absent for stdout, single-file text, discard, and
+sorted output, which do not construct the shared pool. Its aggregate
 `submit_blocked_*` fields measure full sticky-lane admission waits;
 `head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty
 queue when that wait began. The bounded `lanes[]` array reports lane id, queue
@@ -190,7 +192,7 @@ short investigations rather than routine high-volume runs.
 | --- | --- | --- |
 | High API latency, high in-flight work | Store or network service time | `fetch.latency.phase`, throttles, pool pending, recovered errors |
 | Low API rate and low in-flight work while listing | Work supply or a long tail | steal reasons, probes, tail occupancy, open-frontier share |
-| High `queue.wait` or `emit.latency` | Output admission or sink | `parquet_writer` blocked/HOL time, lane balance, Parquet write/finalize latency, output filesystem |
+| High `queue.wait` or `emit.latency` | Output admission or sink | `dataset_writer` blocked/HOL time, lane balance, format write/finalize latency, output filesystem |
 | High checkpoint queue or commit waits | SQLite durability | checkpoint volume latency and queue depth |
 | High sort backpressure or many merge passes | Sort memory/disk/FD limits | `sort` report block, staging peak, effective fan-in |
 | `progress.units` flat for more than five minutes | Potential stall | phase, thread dump, last error, disk and pool state |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -117,7 +117,8 @@ Across a concurrency sweep:
 Treat `shape.divergence_depth_histogram`, `mass_skew_gini`, and `delimiter_fanout` as clues,
 not diagnoses. Direct engagement and wait counters show what actually constrained the run.
 
-For direct Parquet, read the report's `parquet_writer` block with `client_cost`:
+For direct Parquet or a parallel TSV/JSONL directory dataset, read the report's
+format-labelled `dataset_writer` block with `client_cost`:
 
 - `submit_blocked_ms` is the consumer's time waiting for sticky lane admission; it is contained
   in `client_cost[].emit`, not additional time to add to it.
@@ -130,6 +131,12 @@ For direct Parquet, read the report's `parquet_writer` block with `client_cost`:
 - Rising lane-submit blocking followed by rising `client_cost[].writer_backpressure` confirms the
   full causal chain into listing workers. A full queue peak without blocked time is not a
   bottleneck by itself.
+
+Do not infer writer capacity from an I/O-bound run whose lanes are mostly idle. Validate a writer
+count against the fastest expected listing regime: sustained submit blocking means the sink is
+binding; material head-of-line blocking with idle lanes means dispatch coupling is binding. If
+neither appears, raising the writer count would only add memory and file-part overhead for that
+workload.
 
 ### Size CPU and memory empirically
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -21,6 +21,56 @@ Bucket shape, client location, output disk, filters, CPU architecture, and servi
 all affect the result. Absolute numbers from another bucket are rarely useful; the
 relationships among your own report fields are.
 
+### Retain a JFR CPU profile
+
+Elapsed timers cannot attribute CPU: a Parquet lane's active stretch can contain encoding,
+filesystem writes, fsync, checkpoint work, and time waiting to serialize a manifest update.
+For CPU attribution on Linux/JDK 25, derive a profile that explicitly enables the CPU-time
+sampler. The stock `profile.jfc` enables execution sampling but leaves `jdk.CPUTimeSample`
+disabled, so `cpu-time-hot-methods` would otherwise have no events:
+
+```bash
+jfr configure --input "$JAVA_HOME/lib/jfr/profile.jfc" --output swath-cpu-profile.jfc \
+  jdk.CPUTimeSample#enabled=true
+JAVA_OPTS="-XX:StartFlightRecording=filename=$PWD/swath.jfr,settings=$PWD/swath-cpu-profile.jfc,disk=true,dumponexit=true,maxsize=2g" \
+  swath list s3://bucket/prefix/ --format parquet -o out/ --report run.json
+```
+
+The Gradle/application launcher honors `JAVA_OPTS`. For the runnable jar or container use the
+same option on `java` directly or through `JAVA_TOOL_OPTIONS`. `dumponexit=true` retains the
+recording on a normal exit, a handled signal, or an uncaught Java failure. `SIGKILL`, host loss,
+and swath's deliberate `Runtime.halt()` safety paths (the terminal liveness-watchdog escalation and
+sort disk guard) cannot run the exit dump. For a suspected hard wedge, use an external `jcmd
+<pid> JFR.dump filename=...` before the halt deadline. Give each arm a different filename and keep
+its JFR beside its JSON report.
+
+JDK 25's `jfr` tool provides useful first passes:
+
+```bash
+jfr summary swath.jfr
+jfr view cpu-time-hot-methods swath.jfr
+jfr view thread-cpu-load swath.jfr
+jfr view gc-cpu-time swath.jfr
+jfr view file-writes-by-path swath.jfr
+jfr view jdk.CPUTimeSamplesLost swath.jfr
+```
+
+`cpu-time-hot-methods` uses `jdk.CPUTimeSample` for CPU-time attribution. On a platform where that
+event is unavailable, retain the stock `profile` configuration and use `jfr view hot-methods` for
+execution samples instead; do not describe those elapsed execution samples as measured CPU time.
+Check `jdk.CPUTimeSamplesLost` before comparing attribution between arms. If losses are material,
+adjust `jdk.CPUTimeSample#throttle` in the generated configuration and rerun both arms identically;
+more frequent sampling can increase profiler overhead.
+
+Attribute execution samples by both thread and stack. Direct Parquet lanes are named
+`parquet-writer-*`; the checkpoint writer is `swath-checkpoint-writer`. Listing workers are
+virtual threads, so group their samples by `io.varve.swath.engine`, `io.varve.swath.store`, and
+AWS SDK frames rather than expecting a stable platform-thread name. Sorted staging/merge work is
+recognizable from `io.varve.swath.sort` frames and `*-encoder-*` platform threads. The
+[JDK 25 troubleshooting guide](https://docs.oracle.com/en/java/javase/25/troubleshoot/troubleshooting-guide.pdf)
+reports less than 2% overhead for most profiling recordings, but overhead is application-specific:
+measure it on the fixture, and use the same JFR settings and recording size limit in every arm.
+
 ### In-flight utilisation
 
 `--concurrency N` is a ceiling. The achieved request concurrency is
@@ -66,6 +116,20 @@ Across a concurrency sweep:
 
 Treat `shape.divergence_depth_histogram`, `mass_skew_gini`, and `delimiter_fanout` as clues,
 not diagnoses. Direct engagement and wait counters show what actually constrained the run.
+
+For direct Parquet, read the report's `parquet_writer` block with `client_cost`:
+
+- `submit_blocked_ms` is the consumer's time waiting for sticky lane admission; it is contained
+  in `client_cost[].emit`, not additional time to add to it.
+- `head_of_line_blocked_ms` is the subset that began while another lane was waiting for work with
+  an empty queue. Material time confirms that sticky routing stranded an idle writer; zero means
+  that stronger condition was not observed at the start of a blocked admission, not that every
+  possible transient imbalance is ruled out.
+- Per-lane rows, finalized bytes, batches, active elapsed time, queue peak, and finalize activity
+  show load imbalance. `active_elapsed_ms` is elapsed service time and can overlap across lanes.
+- Rising lane-submit blocking followed by rising `client_cost[].writer_backpressure` confirms the
+  full causal chain into listing workers. A full queue peak without blocked time is not a
+  bottleneck by itself.
 
 ### Size CPU and memory empirically
 

--- a/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SummaryRendererTest.java
@@ -478,7 +478,8 @@ final class SummaryRendererTest {
                 1L, 1_500L, 0L, run, session, listing, WORK_STEALING, 0L, 0.0,
                 0L, 0L, 1_500L, 0L, 0L, 0.0, -1L, -1L, 0L, 0L, 0L,
                 50.0, 0.0, -1L, -1L, -1.0, -1.0,
-                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                null, null, null, List.of(), List.of(), List.of(), null, null);
     }
 
     /** A clean, zero-fault diagnostics snapshot — the faults line stays absent either way. */

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -513,10 +513,10 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         // omitted), same idiom and same dedicated-percentile-readback reason as probe_latency above.
         writeClientCost(root.putArray("client_cost"), summary.clientCost());
 
-        // Direct-Parquet only: bounded lane statistics without lane-id metric tags. These are
-        // elapsed-time and queueing signals; JFR remains the CPU authority.
-        if (summary.parquetWriter() != null) {
-            writeParquetWriter(root.putObject("parquet_writer"), summary.parquetWriter());
+        // Parallel directory datasets only: bounded lane statistics without lane-id metric tags.
+        // These are elapsed-time and queueing signals; JFR remains the CPU authority.
+        if (summary.datasetWriter() != null) {
+            writeDatasetWriter(root.putObject("dataset_writer"), summary.datasetWriter());
         }
 
         // OWNER_SPLIT.demand_gated T-vs-Tmax visibility. Omitted entirely (not a null-valued
@@ -841,14 +841,15 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         }
     }
 
-    private static void writeParquetWriter(
-            ObjectNode node, RunSummary.ParquetWriterSummary writer) {
+    private static void writeDatasetWriter(
+            ObjectNode node, RunSummary.DatasetWriterSummary writer) {
+        node.put("format", writer.format());
         node.put("submit_blocked_count", writer.submitBlockedCount());
         node.put("submit_blocked_ms", nanosToMillis(writer.submitBlockedNanos()));
         node.put("head_of_line_blocked_count", writer.headOfLineBlockedCount());
         node.put("head_of_line_blocked_ms", nanosToMillis(writer.headOfLineBlockedNanos()));
         ArrayNode lanes = node.putArray("lanes");
-        for (RunSummary.ParquetWriterLane lane : writer.lanes()) {
+        for (RunSummary.DatasetWriterLane lane : writer.lanes()) {
             ObjectNode ln = lanes.addObject();
             ln.put("lane", lane.lane());
             ln.put("queue_capacity", lane.queueCapacity());

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -513,6 +513,12 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         // omitted), same idiom and same dedicated-percentile-readback reason as probe_latency above.
         writeClientCost(root.putArray("client_cost"), summary.clientCost());
 
+        // Direct-Parquet only: bounded lane statistics without lane-id metric tags. These are
+        // elapsed-time and queueing signals; JFR remains the CPU authority.
+        if (summary.parquetWriter() != null) {
+            writeParquetWriter(root.putObject("parquet_writer"), summary.parquetWriter());
+        }
+
         // OWNER_SPLIT.demand_gated T-vs-Tmax visibility. Omitted entirely (not a null-valued
         // block) when the demand gate never fired this run -- same idiom as seed/shape/trajectory.
         if (summary.demandGate() != null) {
@@ -833,6 +839,38 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
             putDoubleOrNullBoxed(sn, "p99_ms", s.p99Ms());
             sn.put("max_ms", s.maxMs());
         }
+    }
+
+    private static void writeParquetWriter(
+            ObjectNode node, RunSummary.ParquetWriterSummary writer) {
+        node.put("submit_blocked_count", writer.submitBlockedCount());
+        node.put("submit_blocked_ms", nanosToMillis(writer.submitBlockedNanos()));
+        node.put("head_of_line_blocked_count", writer.headOfLineBlockedCount());
+        node.put("head_of_line_blocked_ms", nanosToMillis(writer.headOfLineBlockedNanos()));
+        ArrayNode lanes = node.putArray("lanes");
+        for (RunSummary.ParquetWriterLane lane : writer.lanes()) {
+            ObjectNode ln = lanes.addObject();
+            ln.put("lane", lane.lane());
+            ln.put("queue_capacity", lane.queueCapacity());
+            ln.put("queue_depth", lane.queueDepth());
+            ln.put("queue_depth_peak", lane.queueDepthPeak());
+            ln.put("waiting_for_work", lane.waitingForWork());
+            ln.put("rows_written", lane.rowsWritten());
+            ln.put("finalized_bytes", lane.finalizedBytes());
+            ln.put("batches_written", lane.batchesWritten());
+            ln.put("active_elapsed_ms", nanosToMillis(lane.activeElapsedNanos()));
+            ln.put("submit_blocked_count", lane.submitBlockedCount());
+            ln.put("submit_blocked_ms", nanosToMillis(lane.submitBlockedNanos()));
+            ln.put("head_of_line_blocked_count", lane.headOfLineBlockedCount());
+            ln.put("head_of_line_blocked_ms", nanosToMillis(lane.headOfLineBlockedNanos()));
+            ln.put("parts_finalized", lane.partsFinalized());
+            ln.put("finalize_count", lane.finalizeCount());
+            ln.put("finalize_elapsed_ms", nanosToMillis(lane.finalizeElapsedNanos()));
+        }
+    }
+
+    private static double nanosToMillis(long nanos) {
+        return nanos / 1_000_000.0;
     }
 
     private void writeDemandGate(ObjectNode dg, RunSummary.DemandGateSummary demandGate) {

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -27,6 +27,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -205,6 +206,8 @@ public final class RunMetrics {
     private final ConcurrentMap<String, Counter> parquetParts = new ConcurrentHashMap<>();
     private final Timer parquetFinalizeLatency;
     private final Timer parquetWriteLatency;
+    private final AtomicReference<Supplier<RunSummary.ParquetWriterSummary>> parquetWriterSummary =
+            new AtomicReference<>();
     private final ConcurrentMap<String, Counter> textDatasetRotations = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Counter> textDatasetParts = new ConcurrentHashMap<>();
     private final AtomicReference<Timer> textDatasetFinalizeLatency = new AtomicReference<>();
@@ -1655,9 +1658,11 @@ public final class RunMetrics {
      * One stretch of writer-LANE work: the encode+write of a batch's rows into the open part, plus
      * whatever part finalize (footer fsync, part MD5, manifest rewrite) or drain-time discard that
      * stretch performed — measured on the lane's own thread, between two waits on its queue, so
-     * summing this span over a run accounts for the pool's CPU (an aborted run's lanes drain their
-     * queued batches without writing them, and those record nothing). A client-service-cost span
-     * (see {@link #buildClientCostSummary}),
+     * summing this span over a run accounts for the pool's active elapsed time (an aborted run's
+     * lanes drain their queued batches without writing them, and those record nothing). It is not
+     * CPU attribution: encoding, file I/O, fsync, checkpoint work, and manifest-lock waits can all
+     * contribute; use JFR execution samples for CPU. A client-service-cost span (see {@link
+     * #buildClientCostSummary}),
      * but the ONE that is not on the page's critical path: the lanes run concurrently with fetch and
      * {@link #recordEmit emit} (for Parquet, {@code emit} is the pool DISPATCH only), so this span
      * overlaps them in wall-clock and must never be added to a page's serial cost. It also strictly
@@ -1665,6 +1670,20 @@ public final class RunMetrics {
      */
     public void recordParquetWrite(long nanos) {
         parquetWriteLatency.record(Math.max(0L, nanos), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Attach the direct-Parquet pool's bounded, low-contention lane snapshot. Registration happens once
+     * when the pool is constructed; periodic reports call the supplier without creating Micrometer
+     * lane tags, so cardinality stays fixed.
+     */
+    public void registerParquetWriterSummary(Supplier<RunSummary.ParquetWriterSummary> supplier) {
+        parquetWriterSummary.compareAndSet(null, Objects.requireNonNull(supplier, "supplier"));
+    }
+
+    private RunSummary.ParquetWriterSummary parquetWriterSummary() {
+        Supplier<RunSummary.ParquetWriterSummary> supplier = parquetWriterSummary.get();
+        return supplier == null ? null : supplier.get();
     }
 
     // ---- Partitioned text dataset writer pool -----------------------
@@ -2455,6 +2474,9 @@ public final class RunMetrics {
                 // Per-page client-service-cost spans -- same shape and same cheapness (an empty
                 // list when no page was ever serviced); never null.
                 buildClientCostSummary(),
+                // Direct-Parquet only. The supplier reads a fixed 1–4 lane array; no lane-id metric
+                // tags and no unbounded state. Null when this run did not construct that pool.
+                parquetWriterSummary(),
                 // Demand-gate T-vs-Tmax visibility -- null when OWNER_SPLIT.demand_gated never
                 // fired this run (the writer omits the whole block, same idiom as seed/shape/trajectory).
                 demandGatedEvents.get() > 0

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -206,7 +206,7 @@ public final class RunMetrics {
     private final ConcurrentMap<String, Counter> parquetParts = new ConcurrentHashMap<>();
     private final Timer parquetFinalizeLatency;
     private final Timer parquetWriteLatency;
-    private final AtomicReference<Supplier<RunSummary.ParquetWriterSummary>> parquetWriterSummary =
+    private final AtomicReference<Supplier<RunSummary.DatasetWriterSummary>> datasetWriterSummary =
             new AtomicReference<>();
     private final ConcurrentMap<String, Counter> textDatasetRotations = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Counter> textDatasetParts = new ConcurrentHashMap<>();
@@ -1673,16 +1673,17 @@ public final class RunMetrics {
     }
 
     /**
-     * Attach the direct-Parquet pool's bounded, low-contention lane snapshot. Registration happens once
-     * when the pool is constructed; periodic reports call the supplier without creating Micrometer
+     * Attach the current parallel directory-dataset pool's bounded, low-contention lane snapshot.
+     * A run constructs one such pool; last registration wins so the live pool owns the block if
+     * that invariant ever changes. Periodic reports call the supplier without creating Micrometer
      * lane tags, so cardinality stays fixed.
      */
-    public void registerParquetWriterSummary(Supplier<RunSummary.ParquetWriterSummary> supplier) {
-        parquetWriterSummary.compareAndSet(null, Objects.requireNonNull(supplier, "supplier"));
+    public void registerDatasetWriterSummary(Supplier<RunSummary.DatasetWriterSummary> supplier) {
+        datasetWriterSummary.set(Objects.requireNonNull(supplier, "supplier"));
     }
 
-    private RunSummary.ParquetWriterSummary parquetWriterSummary() {
-        Supplier<RunSummary.ParquetWriterSummary> supplier = parquetWriterSummary.get();
+    private RunSummary.DatasetWriterSummary datasetWriterSummary() {
+        Supplier<RunSummary.DatasetWriterSummary> supplier = datasetWriterSummary.get();
         return supplier == null ? null : supplier.get();
     }
 
@@ -2474,9 +2475,9 @@ public final class RunMetrics {
                 // Per-page client-service-cost spans -- same shape and same cheapness (an empty
                 // list when no page was ever serviced); never null.
                 buildClientCostSummary(),
-                // Direct-Parquet only. The supplier reads a fixed 1–4 lane array; no lane-id metric
-                // tags and no unbounded state. Null when this run did not construct that pool.
-                parquetWriterSummary(),
+                // Parallel directory datasets only. The supplier reads a fixed 1–4 lane array; no
+                // lane-id metric tags and no unbounded state. Null when no shared pool was constructed.
+                datasetWriterSummary(),
                 // Demand-gate T-vs-Tmax visibility -- null when OWNER_SPLIT.demand_gated never
                 // fired this run (the writer omits the whole block, same idiom as seed/shape/trajectory).
                 demandGatedEvents.get() > 0

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -1684,7 +1684,14 @@ public final class RunMetrics {
 
     private RunSummary.DatasetWriterSummary datasetWriterSummary() {
         Supplier<RunSummary.DatasetWriterSummary> supplier = datasetWriterSummary.get();
-        return supplier == null ? null : supplier.get();
+        if (supplier == null) {
+            return null;
+        }
+        try {
+            return supplier.get();
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     // ---- Partitioned text dataset writer pool -----------------------

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -59,9 +59,10 @@ import java.util.List;
  * {@code peakInFlight} saturates once the concurrency ceiling is hit, so {@code avgInFlight} is the
  * one that distinguishes sustained parallelism from a brief spike.
  *
- * <p>{@code seed}, {@code shape}, {@code trajectory}, and {@code demandGate} are {@code null}
- * when their mechanism never engaged this run — no seeding (resumed, or a sequential/
- * no-checkpoint run), no page ever fetched, or the demand gate never fired, respectively.
+ * <p>{@code seed}, {@code shape}, {@code trajectory}, {@code parquetWriter}, and {@code demandGate}
+ * are {@code null} when their mechanism never engaged this run — no seeding (resumed, or a
+ * sequential/no-checkpoint run), no page ever fetched, no direct-Parquet pool constructed, or the
+ * demand gate never fired, respectively.
  * {@code slowRanges} and {@code callClassLatency} are empty (never {@code null}) in the
  * equivalent no-data case.
  */
@@ -104,7 +105,60 @@ public record RunSummary(
         List<SlowRange> slowRanges,
         List<CallClassLatencySummary> callClassLatency,
         List<ClientCostSpan> clientCost,
+        ParquetWriterSummary parquetWriter,
         DemandGateSummary demandGate) {
+
+    /**
+     * Bounded direct-Parquet writer-pool evidence. The aggregate blocked fields are sums across
+     * lanes; {@code headOfLineBlocked*} is the subset where the sticky selected lane was full while
+     * at least one other lane was waiting for work with an empty queue.
+     */
+    public record ParquetWriterSummary(
+            long submitBlockedCount,
+            long submitBlockedNanos,
+            long headOfLineBlockedCount,
+            long headOfLineBlockedNanos,
+            List<ParquetWriterLane> lanes) {
+
+        public ParquetWriterSummary {
+            lanes = List.copyOf(lanes);
+        }
+
+        public static ParquetWriterSummary from(List<ParquetWriterLane> lanes) {
+            long submitBlockedCount = 0L;
+            long submitBlockedNanos = 0L;
+            long headOfLineBlockedCount = 0L;
+            long headOfLineBlockedNanos = 0L;
+            for (ParquetWriterLane lane : lanes) {
+                submitBlockedCount += lane.submitBlockedCount();
+                submitBlockedNanos += lane.submitBlockedNanos();
+                headOfLineBlockedCount += lane.headOfLineBlockedCount();
+                headOfLineBlockedNanos += lane.headOfLineBlockedNanos();
+            }
+            return new ParquetWriterSummary(submitBlockedCount, submitBlockedNanos,
+                    headOfLineBlockedCount, headOfLineBlockedNanos, lanes);
+        }
+    }
+
+    /** One direct-Parquet writer lane; all durations are elapsed time, never CPU time. */
+    public record ParquetWriterLane(
+            int lane,
+            int queueCapacity,
+            int queueDepth,
+            int queueDepthPeak,
+            boolean waitingForWork,
+            long rowsWritten,
+            long finalizedBytes,
+            long batchesWritten,
+            long activeElapsedNanos,
+            long submitBlockedCount,
+            long submitBlockedNanos,
+            long headOfLineBlockedCount,
+            long headOfLineBlockedNanos,
+            long partsFinalized,
+            long finalizeCount,
+            long finalizeElapsedNanos) {
+    }
 
     /**
      * One {@code call_class}/{@code phase} latency-percentile summary row — {@code callClass} is

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -59,10 +59,10 @@ import java.util.List;
  * {@code peakInFlight} saturates once the concurrency ceiling is hit, so {@code avgInFlight} is the
  * one that distinguishes sustained parallelism from a brief spike.
  *
- * <p>{@code seed}, {@code shape}, {@code trajectory}, {@code parquetWriter}, and {@code demandGate}
+ * <p>{@code seed}, {@code shape}, {@code trajectory}, {@code datasetWriter}, and {@code demandGate}
  * are {@code null} when their mechanism never engaged this run — no seeding (resumed, or a
- * sequential/no-checkpoint run), no page ever fetched, no direct-Parquet pool constructed, or the
- * demand gate never fired, respectively.
+ * sequential/no-checkpoint run), no page ever fetched, no parallel directory-dataset pool
+ * constructed, or the demand gate never fired, respectively.
  * {@code slowRanges} and {@code callClassLatency} are empty (never {@code null}) in the
  * equivalent no-data case.
  */
@@ -105,43 +105,45 @@ public record RunSummary(
         List<SlowRange> slowRanges,
         List<CallClassLatencySummary> callClassLatency,
         List<ClientCostSpan> clientCost,
-        ParquetWriterSummary parquetWriter,
+        DatasetWriterSummary datasetWriter,
         DemandGateSummary demandGate) {
 
     /**
-     * Bounded direct-Parquet writer-pool evidence. The aggregate blocked fields are sums across
-     * lanes; {@code headOfLineBlocked*} is the subset where the sticky selected lane was full while
-     * at least one other lane was waiting for work with an empty queue.
+     * Bounded parallel directory-dataset writer-pool evidence. {@code format} is one of {@code
+     * parquet}, {@code tsv}, or {@code jsonl}. The aggregate blocked fields are sums across lanes;
+     * {@code headOfLineBlocked*} is the subset where the sticky selected lane was full while at
+     * least one other lane was waiting for work with an empty queue.
      */
-    public record ParquetWriterSummary(
+    public record DatasetWriterSummary(
+            String format,
             long submitBlockedCount,
             long submitBlockedNanos,
             long headOfLineBlockedCount,
             long headOfLineBlockedNanos,
-            List<ParquetWriterLane> lanes) {
+            List<DatasetWriterLane> lanes) {
 
-        public ParquetWriterSummary {
+        public DatasetWriterSummary {
             lanes = List.copyOf(lanes);
         }
 
-        public static ParquetWriterSummary from(List<ParquetWriterLane> lanes) {
+        public static DatasetWriterSummary from(String format, List<DatasetWriterLane> lanes) {
             long submitBlockedCount = 0L;
             long submitBlockedNanos = 0L;
             long headOfLineBlockedCount = 0L;
             long headOfLineBlockedNanos = 0L;
-            for (ParquetWriterLane lane : lanes) {
+            for (DatasetWriterLane lane : lanes) {
                 submitBlockedCount += lane.submitBlockedCount();
                 submitBlockedNanos += lane.submitBlockedNanos();
                 headOfLineBlockedCount += lane.headOfLineBlockedCount();
                 headOfLineBlockedNanos += lane.headOfLineBlockedNanos();
             }
-            return new ParquetWriterSummary(submitBlockedCount, submitBlockedNanos,
+            return new DatasetWriterSummary(format, submitBlockedCount, submitBlockedNanos,
                     headOfLineBlockedCount, headOfLineBlockedNanos, lanes);
         }
     }
 
-    /** One direct-Parquet writer lane; all durations are elapsed time, never CPU time. */
-    public record ParquetWriterLane(
+    /** One parallel directory-dataset writer lane; all durations are elapsed time, never CPU time. */
+    public record DatasetWriterLane(
             int lane,
             int queueCapacity,
             int queueDepth,

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.observability.RunSummary;
+import io.varve.swath.output.OutputFormat;
+import java.util.Locale;
+
+/** Shared bounded-summary wiring for every parallel directory-dataset writer. */
+public final class DatasetWriterMetrics {
+    private DatasetWriterMetrics() {
+    }
+
+    public static void registerSummary(
+            RunMetrics metrics, OutputFormat format, SharedDatasetWriterPool writerPool) {
+        if (metrics == null) {
+            return;
+        }
+        String summaryFormat = switch (format) {
+            case PARQUET, TSV, JSONL -> format.name().toLowerCase(Locale.ROOT);
+            case TABLE -> throw new IllegalArgumentException("parallel dataset format required");
+        };
+        metrics.registerDatasetWriterSummary(() -> RunSummary.DatasetWriterSummary.from(
+                summaryFormat,
+                writerPool.laneStatistics().stream()
+                        .map(s -> new RunSummary.DatasetWriterLane(
+                                s.lane(), s.queueCapacity(), s.queueDepth(), s.queueDepthPeak(),
+                                s.waitingForWork(), s.rowsWritten(), s.finalizedBytes(), s.batchesWritten(),
+                                s.activeElapsedNanos(), s.submitBlockedCount(), s.submitBlockedNanos(),
+                                s.headOfLineBlockedCount(), s.headOfLineBlockedNanos(),
+                                s.partsFinalized(), s.finalizeCount(), s.finalizeElapsedNanos()))
+                        .toList()));
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
@@ -36,7 +37,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 
 /**
  * A format-neutral, decoupled dataset writer pool: {@code numWriters} lanes
- * (2–4, default 3), each on its own virtual thread draining a bounded queue, so
+ * (2–4, default 3), each on its own platform thread draining a bounded queue, so
  * sink I/O runs away from the listing workers. <b>Sticky</b> assignment — every
  * page of a node goes to {@code writer = nodeId % numWriters}, so a node's pages
  * occupy a contiguous run of one lane's size-rotated parts (which finalize in
@@ -64,6 +65,30 @@ import org.apache.commons.codec.digest.DigestUtils;
  * either trigger.
  */
 public final class SharedDatasetWriterPool implements DatasetWriterPool {
+
+    /**
+     * A bounded snapshot of one writer lane. All durations are elapsed time, not CPU
+     * time: lane work can include encoding, filesystem I/O, checkpoint work, and manifest
+     * serialization. JFR is the authority for sampled CPU attribution.
+     */
+    public record LaneStatistics(
+            int lane,
+            int queueCapacity,
+            int queueDepth,
+            int queueDepthPeak,
+            boolean waitingForWork,
+            long rowsWritten,
+            long finalizedBytes,
+            long batchesWritten,
+            long activeElapsedNanos,
+            long submitBlockedCount,
+            long submitBlockedNanos,
+            long headOfLineBlockedCount,
+            long headOfLineBlockedNanos,
+            long partsFinalized,
+            long finalizeCount,
+            long finalizeElapsedNanos) {
+    }
 
     private static final PageBatch POISON = new PageBatch(-1, -1, List.of());
 
@@ -155,7 +180,8 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         this.committedParts.addAll(config.existingParts());
         this.lanes = new Lane[this.numWriters];
         for (int i = 0; i < this.numWriters; i++) {
-            lanes[i] = new Lane(i, new ArrayBlockingQueue<>(Math.max(1, queueCapacity)));
+            int capacity = Math.max(1, queueCapacity);
+            lanes[i] = new Lane(i, capacity, new ArrayBlockingQueue<>(capacity));
         }
         // Resume: continue each lane's part sequence PAST any carried-over part so a
         // resumed run never reuses (and so overwrites) a prior finalized part's filename.
@@ -190,12 +216,45 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                 throw new OutputException(sinkName + " writer pool is shutting down");
             }
             checkFailure();
-            int lane = (int) Math.floorMod(batch.nodeId(), numWriters);
-            lanes[lane].queue.put(batch);
+            int laneId = (int) Math.floorMod(batch.nodeId(), numWriters);
+            Lane lane = lanes[laneId];
+            if (!lane.queue.offer(batch)) {
+                // Pay for the clock and the 2–4-lane scan only on the saturated path. This is the
+                // missing middle link between consumer-side emit and worker-side channel wait.
+                lane.queueDepthPeak.getAndAccumulate(lane.queueCapacity, Math::max);
+                boolean headOfLine = anotherLaneIsWaitingForWork(laneId);
+                long startedAt = nanoClock.getAsLong();
+                lane.startSubmitBlock(startedAt, headOfLine);
+                try {
+                    lane.queue.put(batch);
+                } finally {
+                    long blockedNanos = Math.max(0L, nanoClock.getAsLong() - startedAt);
+                    lane.finishSubmitBlock(startedAt, blockedNanos, headOfLine);
+                }
+            }
             checkFailure();
         } finally {
             lifecycleLock.readLock().unlock();
         }
+    }
+
+    /** Whether this blocked sticky lane stranded another writer that had no queued work. */
+    private boolean anotherLaneIsWaitingForWork(int selectedLane) {
+        for (Lane lane : lanes) {
+            if (lane.id != selectedLane && lane.waitingForWork && lane.queue.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Bounded per-lane state for periodic and terminal structured summaries. */
+    public List<LaneStatistics> laneStatistics() {
+        List<LaneStatistics> snapshots = new ArrayList<>(lanes.length);
+        for (Lane lane : lanes) {
+            snapshots.add(lane.statistics());
+        }
+        return List.copyOf(snapshots);
     }
 
     public long committedPartCount() {
@@ -233,10 +292,20 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             while (true) {
                 // Floor the poll WAIT (never the staleness check in rotationReason()) so a tiny
                 // positive rotationIntervalNanos can't spin this thread — see ROTATION_POLL_FLOOR_NANOS.
-                PageBatch batch = rotationIntervalNanos > 0
-                        ? lane.queue.poll(Math.max(rotationIntervalNanos, ROTATION_POLL_FLOOR_NANOS),
-                                TimeUnit.NANOSECONDS)
-                        : lane.queue.take();
+                PageBatch batch = lane.queue.poll();
+                if (batch == null) {
+                    // The busy path still pays for one queue operation and no waiting-state
+                    // writes. Publish idleness only after an immediate poll finds no work.
+                    lane.waitingForWork = true;
+                    try {
+                        batch = rotationIntervalNanos > 0
+                                ? lane.queue.poll(Math.max(rotationIntervalNanos, ROTATION_POLL_FLOOR_NANOS),
+                                        TimeUnit.NANOSECONDS)
+                                : lane.queue.take();
+                    } finally {
+                        lane.waitingForWork = false;
+                    }
+                }
                 if (batch == null) {
                     // Timed out — no new batch arrived. Re-evaluate the SAME rotation
                     // check; rotationReason() short-circuits on rows==0 so an idle EMPTY
@@ -253,7 +322,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                             } catch (Throwable t) {
                                 recordFailure(t);
                             } finally {
-                                recordLaneWork(startedAt);
+                                recordLaneWork(lane, startedAt);
                             }
                         }
                     }
@@ -271,7 +340,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                 } catch (Throwable t) {
                     recordFailure(t);
                 } finally {
-                    recordLaneWork(startedAt);
+                    recordLaneWork(lane, startedAt);
                 }
             }
         } catch (InterruptedException e) {
@@ -297,7 +366,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             recordFailure(t);
         } finally {
             if (hasOpenPart) {   // no open part ⇒ both paths no-op; don't record a fabricated zero
-                recordLaneWork(startedAt);
+                recordLaneWork(lane, startedAt);
             }
         }
     }
@@ -316,18 +385,21 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     /**
      * Reports one stretch of lane-thread work through the format-owned observer. Called from the
      * three places a lane does work between waits on its queue (batch write, idle-cadence rotation,
-     * drain-time finalize/discard), so summing the span accounts for the pool's CPU rather than the
-     * dispatch that {@code emit} sees. Measured on {@link #nanoClock}, the same monotonic clock the
-     * rotation triggers read.
+     * drain-time finalize/discard), so summing the span accounts for the pool's active elapsed time
+     * rather than the dispatch that {@code emit} sees. It is not CPU attribution: file I/O, fsync,
+     * checkpoint work, and manifest-lock waits can contribute. Measured on {@link #nanoClock}, the
+     * same monotonic clock the rotation triggers read.
      *
      * <p>Swallows anything thrown while recording. This is the only work in the lane loop that is
      * NOT already inside a catch-all, and it is pure observation: letting a metrics/clock failure
      * escape would kill the lane thread before it consumes the poison sentinel, which is exactly the
      * lane-failure deadlock the "always drain to POISON" rule exists to prevent.
      */
-    private void recordLaneWork(long startedAtNanos) {
+    private void recordLaneWork(Lane lane, long startedAtNanos) {
         try {
-            observer.recordLaneWork(nanoClock.getAsLong() - startedAtNanos);
+            long elapsedNanos = Math.max(0L, nanoClock.getAsLong() - startedAtNanos);
+            lane.activeElapsedNanos += elapsedNanos;
+            observer.recordLaneWork(elapsedNanos);
         } catch (Throwable ignored) {
             // observation only — never take the lane down with it
         }
@@ -340,6 +412,10 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         for (ListEntry e : batch.entries()) {
             lane.current.write(e);
         }
+        // Count only a completely encoded batch. A mid-batch format failure leaves an unknown
+        // partial row count, which is deliberately not presented as successfully written work.
+        lane.rowsWritten += batch.entryCount();
+        lane.batchesWritten++;
         // Track the highest key this node contributed to the open part — the
         // durable_cursor it makes durable when the part finalizes (§4.5). Listing is
         // ascending per node, so the latest batch's last key is the max.
@@ -390,6 +466,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         long rows = w.rows();
         Path path = w.path();
         Object finalizeSample = observer.startFinalize();
+        long finalizeStartedAt = nanoClock.getAsLong();
         try {
             w.close();   // format-owned close completes the part before publication
         } catch (IOException e) {
@@ -410,6 +487,9 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                 e.addSuppressed(observationFailure);
             }
             throw e;
+        } finally {
+            lane.finalizeCount++;
+            lane.finalizeElapsedNanos += Math.max(0L, nanoClock.getAsLong() - finalizeStartedAt);
         }
         if (finalizeSample != null) {
             observer.recordFinalize(finalizeSample);
@@ -433,6 +513,8 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                 lane.id, relPath, rows, bytes, contributions));
         committedParts.add(new PartInfo(relPath, lane.id, rows, bytes, md5));
         observer.recordPart("finalized");
+        lane.finalizedBytes += bytes;
+        lane.partsFinalized++;
         // A part finalize (footer fsync + manifest commit) is real forward progress that no
         // LISTING page/object counter reflects — a large multi-part non-sort finalize tail
         // (close()'s drainAndJoin() below) can otherwise sit with progressSignal() frozen for
@@ -617,7 +699,28 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
 
     private final class Lane {
         final int id;
+        final int queueCapacity;
         final BlockingQueue<PageBatch> queue;
+        final AtomicInteger queueDepthPeak = new AtomicInteger();
+        volatile boolean waitingForWork;
+        // The lane thread is the sole writer for service/finalize counters; volatile makes
+        // periodic summary reads visible without paying for atomic RMW on every encoded batch.
+        volatile long rowsWritten;
+        volatile long finalizedBytes;
+        volatile long batchesWritten;
+        volatile long activeElapsedNanos;
+        final Object submitStatisticsLock = new Object();
+        long submitBlockedCount;
+        long submitBlockedNanos;
+        long inFlightSubmitBlockedCount;
+        long inFlightSubmitStartedAtSum;
+        long headOfLineBlockedCount;
+        long headOfLineBlockedNanos;
+        long inFlightHeadOfLineCount;
+        long inFlightHeadOfLineStartedAtSum;
+        volatile long partsFinalized;
+        volatile long finalizeCount;
+        volatile long finalizeElapsedNanos;
         // Per node id, the highest key written to the open part — flushed to the
         // listener (durable_cursor advance) when the part finalizes; cleared per part.
         final Map<Long, byte[]> partNodeMaxKey = new HashMap<>();
@@ -626,9 +729,66 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         // When the open part was created, on the injected clock — the time-trigger baseline.
         long partOpenedAtNanos;
 
-        Lane(int id, BlockingQueue<PageBatch> queue) {
+        Lane(int id, int queueCapacity, BlockingQueue<PageBatch> queue) {
             this.id = id;
+            this.queueCapacity = queueCapacity;
             this.queue = queue;
+        }
+
+        void startSubmitBlock(long startedAtNanos, boolean headOfLine) {
+            synchronized (submitStatisticsLock) {
+                submitBlockedCount++;
+                inFlightSubmitBlockedCount++;
+                inFlightSubmitStartedAtSum += startedAtNanos;
+                if (headOfLine) {
+                    headOfLineBlockedCount++;
+                    inFlightHeadOfLineCount++;
+                    inFlightHeadOfLineStartedAtSum += startedAtNanos;
+                }
+            }
+        }
+
+        void finishSubmitBlock(long startedAtNanos, long blockedNanos, boolean headOfLine) {
+            synchronized (submitStatisticsLock) {
+                inFlightSubmitBlockedCount--;
+                inFlightSubmitStartedAtSum -= startedAtNanos;
+                submitBlockedNanos += blockedNanos;
+                if (headOfLine) {
+                    inFlightHeadOfLineCount--;
+                    inFlightHeadOfLineStartedAtSum -= startedAtNanos;
+                    headOfLineBlockedNanos += blockedNanos;
+                }
+            }
+        }
+
+        LaneStatistics statistics() {
+            // Sampling happens on the periodic/terminal reporter, never on the sole dispatcher.
+            // A saturated admission records capacity exactly in submit(); otherwise this is a
+            // best-effort high-water mark at report cadence.
+            int queueDepth = queue.size();
+            queueDepthPeak.getAndAccumulate(queueDepth, Math::max);
+            long blockedCount;
+            long blockedNanos;
+            long headOfLineCount;
+            long headOfLineNanos;
+            synchronized (submitStatisticsLock) {
+                long now = inFlightSubmitBlockedCount == 0 ? 0L : nanoClock.getAsLong();
+                blockedCount = submitBlockedCount;
+                blockedNanos = submitBlockedNanos + inFlightElapsed(
+                        now, inFlightSubmitBlockedCount, inFlightSubmitStartedAtSum);
+                headOfLineCount = headOfLineBlockedCount;
+                headOfLineNanos = headOfLineBlockedNanos + inFlightElapsed(
+                        now, inFlightHeadOfLineCount, inFlightHeadOfLineStartedAtSum);
+            }
+            return new LaneStatistics(id, queueCapacity, queueDepth, queueDepthPeak.get(),
+                    waitingForWork, rowsWritten, finalizedBytes, batchesWritten,
+                    activeElapsedNanos, blockedCount, blockedNanos,
+                    headOfLineCount, headOfLineNanos,
+                    partsFinalized, finalizeCount, finalizeElapsedNanos);
+        }
+
+        private long inFlightElapsed(long now, long count, long startedAtSum) {
+            return count == 0 ? 0L : Math.max(0L, now * count - startedAtSum);
         }
 
         void openPart() throws IOException {

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
@@ -9,7 +9,8 @@ import io.micrometer.core.instrument.Timer;
 import io.varve.swath.error.OutputException;
 import io.varve.swath.model.PageBatch;
 import io.varve.swath.observability.RunMetrics;
-import io.varve.swath.observability.RunSummary;
+import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.dataset.DatasetWriterMetrics;
 import io.varve.swath.output.dataset.DatasetWriterObserver;
 import io.varve.swath.output.dataset.DatasetWriterPool;
 import io.varve.swath.output.dataset.DatasetWriterPoolConfig;
@@ -32,7 +33,7 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                              ParquetWriterPoolConfig config) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config));
-        registerLaneSummary(config.metrics(), delegate);
+        DatasetWriterMetrics.registerSummary(config.metrics(), OutputFormat.PARQUET, delegate);
     }
 
     ParquetWriterPool(Path dir, MessageType schema, String argsHash,
@@ -40,7 +41,7 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                       ParquetWriterPoolConfig config, LongSupplier nanoClock) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config), nanoClock);
-        registerLaneSummary(config.metrics(), delegate);
+        DatasetWriterMetrics.registerSummary(config.metrics(), OutputFormat.PARQUET, delegate);
     }
 
     private static DatasetWriterPoolConfig sharedConfig(ParquetWriterPoolConfig config) {
@@ -63,21 +64,6 @@ public final class ParquetWriterPool implements DatasetWriterPool {
             @Override public void recordPart(String result) { metrics.recordParquetPart(result); }
             @Override public void markProgress() { metrics.markProgress(); }
         };
-    }
-
-    private static void registerLaneSummary(RunMetrics metrics, SharedDatasetWriterPool writerPool) {
-        if (metrics == null) {
-            return;
-        }
-        metrics.registerParquetWriterSummary(() -> RunSummary.ParquetWriterSummary.from(
-                writerPool.laneStatistics().stream()
-                        .map(s -> new RunSummary.ParquetWriterLane(
-                                s.lane(), s.queueCapacity(), s.queueDepth(), s.queueDepthPeak(),
-                                s.waitingForWork(), s.rowsWritten(), s.finalizedBytes(), s.batchesWritten(),
-                                s.activeElapsedNanos(), s.submitBlockedCount(), s.submitBlockedNanos(),
-                                s.headOfLineBlockedCount(), s.headOfLineBlockedNanos(),
-                                s.partsFinalized(), s.finalizeCount(), s.finalizeElapsedNanos()))
-                        .toList()));
     }
 
     @Override public void submit(PageBatch batch) throws OutputException, InterruptedException {

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Timer;
 import io.varve.swath.error.OutputException;
 import io.varve.swath.model.PageBatch;
 import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.observability.RunSummary;
 import io.varve.swath.output.dataset.DatasetWriterObserver;
 import io.varve.swath.output.dataset.DatasetWriterPool;
 import io.varve.swath.output.dataset.DatasetWriterPoolConfig;
@@ -31,6 +32,7 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                              ParquetWriterPoolConfig config) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config));
+        registerLaneSummary(config.metrics(), delegate);
     }
 
     ParquetWriterPool(Path dir, MessageType schema, String argsHash,
@@ -38,6 +40,7 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                       ParquetWriterPoolConfig config, LongSupplier nanoClock) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config), nanoClock);
+        registerLaneSummary(config.metrics(), delegate);
     }
 
     private static DatasetWriterPoolConfig sharedConfig(ParquetWriterPoolConfig config) {
@@ -60,6 +63,21 @@ public final class ParquetWriterPool implements DatasetWriterPool {
             @Override public void recordPart(String result) { metrics.recordParquetPart(result); }
             @Override public void markProgress() { metrics.markProgress(); }
         };
+    }
+
+    private static void registerLaneSummary(RunMetrics metrics, SharedDatasetWriterPool writerPool) {
+        if (metrics == null) {
+            return;
+        }
+        metrics.registerParquetWriterSummary(() -> RunSummary.ParquetWriterSummary.from(
+                writerPool.laneStatistics().stream()
+                        .map(s -> new RunSummary.ParquetWriterLane(
+                                s.lane(), s.queueCapacity(), s.queueDepth(), s.queueDepthPeak(),
+                                s.waitingForWork(), s.rowsWritten(), s.finalizedBytes(), s.batchesWritten(),
+                                s.activeElapsedNanos(), s.submitBlockedCount(), s.submitBlockedNanos(),
+                                s.headOfLineBlockedCount(), s.headOfLineBlockedNanos(),
+                                s.partsFinalized(), s.finalizeCount(), s.finalizeElapsedNanos()))
+                        .toList()));
     }
 
     @Override public void submit(PageBatch batch) throws OutputException, InterruptedException {

--- a/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPool.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.Timer;
 import io.varve.swath.error.OutputException;
 import io.varve.swath.model.PageBatch;
 import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.output.dataset.DatasetWriterMetrics;
 import io.varve.swath.output.dataset.DatasetWriterObserver;
 import io.varve.swath.output.dataset.DatasetWriterPool;
 import io.varve.swath.output.dataset.DatasetWriterPoolConfig;
@@ -28,6 +29,7 @@ public final class TextWriterPool implements DatasetWriterPool {
                 config.rotationIntervalNanos(), config.rotationMaxRows(), observer(config.metrics()));
         delegate = new SharedDatasetWriterPool(config.directory(), format, config.argsHash(),
                 config.writers(), config.targetBytes(), config.queueCapacity(), poolConfig);
+        DatasetWriterMetrics.registerSummary(config.metrics(), config.format(), delegate);
     }
 
     private static DatasetWriterObserver observer(RunMetrics metrics) {

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -57,7 +57,7 @@ final class JsonRunSummaryWriterTest {
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
                 new RunSummary.SeedSummary("shallow", 5L, 12L, 4L, 13L),
-                shape(), null, List.of(), List.of(), clientCost(), parquetWriter(), null);
+                shape(), null, List.of(), List.of(), clientCost(), datasetWriter(), null);
     }
 
     /** One populated client-service-cost span, enough to pin the {@code client_cost[]} row shape. */
@@ -66,12 +66,12 @@ final class JsonRunSummaryWriterTest {
                 0.4, 1.2, 4.8, 9.1));
     }
 
-    private static RunSummary.ParquetWriterSummary parquetWriter() {
-        return RunSummary.ParquetWriterSummary.from(List.of(
-                new RunSummary.ParquetWriterLane(
+    private static RunSummary.DatasetWriterSummary datasetWriter() {
+        return RunSummary.DatasetWriterSummary.from("parquet", List.of(
+                new RunSummary.DatasetWriterLane(
                         0, 8, 0, 8, false, 600L, 6000L, 6L, 12_000_000L,
                         2L, 4_000_000L, 1L, 3_000_000L, 2L, 2L, 5_000_000L),
-                new RunSummary.ParquetWriterLane(
+                new RunSummary.DatasetWriterLane(
                         1, 8, 0, 4, true, 400L, 4000L, 4L, 8_000_000L,
                         0L, 0L, 0L, 0L, 1L, 1L, 2_000_000L)));
     }
@@ -245,13 +245,14 @@ final class JsonRunSummaryWriterTest {
         assertThat(emitSpan.get("p99_ms").asDouble()).isEqualTo(4.8);
         assertThat(emitSpan.get("max_ms").asDouble()).isEqualTo(9.1);
 
-        JsonNode parquetWriter = root.get("parquet_writer");
-        assertThat(parquetWriter.get("submit_blocked_count").asLong()).isEqualTo(2L);
-        assertThat(parquetWriter.get("submit_blocked_ms").asDouble()).isEqualTo(4.0);
-        assertThat(parquetWriter.get("head_of_line_blocked_count").asLong()).isEqualTo(1L);
-        assertThat(parquetWriter.get("head_of_line_blocked_ms").asDouble()).isEqualTo(3.0);
-        assertThat(parquetWriter.get("lanes")).hasSize(2);
-        JsonNode lane0 = parquetWriter.get("lanes").get(0);
+        JsonNode datasetWriter = root.get("dataset_writer");
+        assertThat(datasetWriter.get("format").asText()).isEqualTo("parquet");
+        assertThat(datasetWriter.get("submit_blocked_count").asLong()).isEqualTo(2L);
+        assertThat(datasetWriter.get("submit_blocked_ms").asDouble()).isEqualTo(4.0);
+        assertThat(datasetWriter.get("head_of_line_blocked_count").asLong()).isEqualTo(1L);
+        assertThat(datasetWriter.get("head_of_line_blocked_ms").asDouble()).isEqualTo(3.0);
+        assertThat(datasetWriter.get("lanes")).hasSize(2);
+        JsonNode lane0 = datasetWriter.get("lanes").get(0);
         assertThat(lane0.get("queue_depth_peak").asInt()).isEqualTo(8);
         assertThat(lane0.get("waiting_for_work").asBoolean()).isFalse();
         assertThat(lane0.get("rows_written").asLong()).isEqualTo(600L);
@@ -629,7 +630,7 @@ final class JsonRunSummaryWriterTest {
         assertThat(root.has("seed")).isFalse();
         // A null ShapeSummary likewise omits the "shape" block entirely (null-safe).
         assertThat(root.has("shape")).isFalse();
-        assertThat(root.has("parquet_writer")).isFalse();
+        assertThat(root.has("dataset_writer")).isFalse();
     }
 
     @Test

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -57,13 +57,23 @@ final class JsonRunSummaryWriterTest {
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
                 new RunSummary.SeedSummary("shallow", 5L, 12L, 4L, 13L),
-                shape(), null, List.of(), List.of(), clientCost(), null);
+                shape(), null, List.of(), List.of(), clientCost(), parquetWriter(), null);
     }
 
     /** One populated client-service-cost span, enough to pin the {@code client_cost[]} row shape. */
     private static List<RunSummary.ClientCostSpan> clientCost() {
         return List.of(new RunSummary.ClientCostSpan(RunMetrics.CLIENT_COST_SPAN_EMIT, 1000L,
                 0.4, 1.2, 4.8, 9.1));
+    }
+
+    private static RunSummary.ParquetWriterSummary parquetWriter() {
+        return RunSummary.ParquetWriterSummary.from(List.of(
+                new RunSummary.ParquetWriterLane(
+                        0, 8, 0, 8, false, 600L, 6000L, 6L, 12_000_000L,
+                        2L, 4_000_000L, 1L, 3_000_000L, 2L, 2L, 5_000_000L),
+                new RunSummary.ParquetWriterLane(
+                        1, 8, 0, 4, true, 400L, 4000L, 4L, 8_000_000L,
+                        0L, 0L, 0L, 0L, 1L, 1L, 2_000_000L)));
     }
 
     private static RunSummary.ShapeSummary shape() {
@@ -234,6 +244,19 @@ final class JsonRunSummaryWriterTest {
         assertThat(emitSpan.get("p90_ms").asDouble()).isEqualTo(1.2);
         assertThat(emitSpan.get("p99_ms").asDouble()).isEqualTo(4.8);
         assertThat(emitSpan.get("max_ms").asDouble()).isEqualTo(9.1);
+
+        JsonNode parquetWriter = root.get("parquet_writer");
+        assertThat(parquetWriter.get("submit_blocked_count").asLong()).isEqualTo(2L);
+        assertThat(parquetWriter.get("submit_blocked_ms").asDouble()).isEqualTo(4.0);
+        assertThat(parquetWriter.get("head_of_line_blocked_count").asLong()).isEqualTo(1L);
+        assertThat(parquetWriter.get("head_of_line_blocked_ms").asDouble()).isEqualTo(3.0);
+        assertThat(parquetWriter.get("lanes")).hasSize(2);
+        JsonNode lane0 = parquetWriter.get("lanes").get(0);
+        assertThat(lane0.get("queue_depth_peak").asInt()).isEqualTo(8);
+        assertThat(lane0.get("waiting_for_work").asBoolean()).isFalse();
+        assertThat(lane0.get("rows_written").asLong()).isEqualTo(600L);
+        assertThat(lane0.get("active_elapsed_ms").asDouble()).isEqualTo(12.0);
+        assertThat(lane0.get("finalize_elapsed_ms").asDouble()).isEqualTo(5.0);
 
         JsonNode meters = root.get("meters");
         assertThat(meters.isArray()).isTrue();
@@ -585,7 +608,8 @@ final class JsonRunSummaryWriterTest {
                 "WORK_STEALING", 118L, 0.00059,
                 4L, 1234567L, 1000L, 112L, 61L, 16.5, 180L, 4200L, 232602L, 98L, 0L,
                 4269.5, 1.07, -1L, -1L, -1.0, -1.0,
-                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, null, null, null, List.of(), List.of(), List.of(), null);
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                null, null, null, List.of(), List.of(), List.of(), null, null);
         JsonRunSummaryWriter writer = JsonRunSummaryWriter.start(
                 config(path, Duration.ofMinutes(10)), registry, Instant.now(), () -> summary);
         try {
@@ -605,6 +629,7 @@ final class JsonRunSummaryWriterTest {
         assertThat(root.has("seed")).isFalse();
         // A null ShapeSummary likewise omits the "shape" block entirely (null-safe).
         assertThat(root.has("shape")).isFalse();
+        assertThat(root.has("parquet_writer")).isFalse();
     }
 
     @Test
@@ -1096,7 +1121,7 @@ final class JsonRunSummaryWriterTest {
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
                 new RunSummary.SeedSummary("shallow", 5L, 12L, 4L, 13L),
-                shape(), null, List.of(), List.of(), List.of(), null);
+                shape(), null, List.of(), List.of(), List.of(), null, null);
     }
 
     /** A clean run (target never driven by the engine) renders min_effective_t as null, not 0. */
@@ -1192,7 +1217,7 @@ final class JsonRunSummaryWriterTest {
                 4269.5, 1.07, 268435456L, 134217728L, 26.4, 1.03,
                 2.0, 0.95, 0.1, 0.3, 0.6, 1.9,
                 new RunSummary.SeedSummary("shallow", 5L, 12L, 4L, 13L),
-                shape(), null, List.of(), callClassLatency, clientCost(), null);
+                shape(), null, List.of(), callClassLatency, clientCost(), null, null);
     }
 
     /**

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -64,7 +64,7 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
             "slowRanges",
             "callClassLatency",
             "clientCost",
-            "parquetWriter",
+            "datasetWriter",
             "demandGate");
 
     /** {@link RunMetrics.RunDiagnostics}'s record components, in declaration order. FROZEN. */
@@ -80,6 +80,18 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
         assertThat(components(RunSummary.class)).containsExactlyElementsOf(EXPECTED_SUMMARY_FIELDS);
         assertThat(components(RunMetrics.RunDiagnostics.class))
                 .containsExactlyElementsOf(EXPECTED_DIAGNOSTICS_FIELDS);
+    }
+
+    @Test
+    void latestDatasetPoolRegistrationOwnsTheSummary() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        metrics.registerDatasetWriterSummary(
+                () -> RunSummary.DatasetWriterSummary.from("parquet", List.of()));
+        metrics.registerDatasetWriterSummary(
+                () -> RunSummary.DatasetWriterSummary.from("tsv", List.of()));
+
+        assertThat(metrics.summary(Duration.ZERO, "work_stealing", 0L, 0L)
+                .datasetWriter().format()).isEqualTo("tsv");
     }
 
     @Test

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -95,6 +95,17 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
     }
 
     @Test
+    void failingDatasetWriterSnapshotOmitsTheBestEffortBlock() {
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        metrics.registerDatasetWriterSummary(() -> {
+            throw new IllegalStateException("lane snapshot unavailable");
+        });
+
+        assertThat(metrics.summary(Duration.ZERO, "work_stealing", 0L, 0L)
+                .datasetWriter()).isNull();
+    }
+
+    @Test
     void summaryDerivesEveryScalarFromTheSameCountersItDoesToday(@TempDir Path scratchDir) {
         RunMetrics m = RunMetricsCharacterizationWorkload.drive(new SimpleMeterRegistry(), scratchDir);
 

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -60,7 +60,12 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
             "errors", "keysPerSecond", "apiCallsPer1kObjects", "peakRssBytes", "peakHeapBytes",
             "cpuSeconds", "cpuEfficiency", "overfetchRatio", "pageFillRatio", "emptySplitRatio",
             "wastedProbeRatio", "stealSuccessRate", "compressionRatio", "seed", "shape",
-            "trajectory", "slowRanges", "callClassLatency", "clientCost", "demandGate");
+            "trajectory",
+            "slowRanges",
+            "callClassLatency",
+            "clientCost",
+            "parquetWriter",
+            "demandGate");
 
     /** {@link RunMetrics.RunDiagnostics}'s record components, in declaration order. FROZEN. */
     private static final List<String> EXPECTED_DIAGNOSTICS_FIELDS = List.of(

--- a/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
@@ -7,6 +7,7 @@ package io.varve.swath.output.dataset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import io.varve.swath.model.ListEntry;
 import io.varve.swath.output.parquet.DatasetLayout;
@@ -137,6 +138,104 @@ class SharedDatasetWriterPoolFailureTest {
     }
 
     @Test
+    void globallyBusyLanesDoNotMasqueradeAsHeadOfLineBlocking(
+            @TempDir Path directory) throws Exception {
+        CountDownLatch releaseWriters = new CountDownLatch(1);
+        Fixture fixture = fixture(directory, Mode.BLOCK_EVERY_FIRST_WRITE, releaseWriters, 2, 1);
+        SharedDatasetWriterPool pool = fixture.pool();
+        pool.submit(PageBatches.batch(0, 0, 0, 1));
+        pool.submit(PageBatches.batch(1, 0, 1, 2));
+        fixture.format().writerEntered.await();
+        pool.submit(PageBatches.batch(0, 1, 2, 3));
+        pool.submit(PageBatches.batch(1, 1, 3, 4));
+
+        CountDownLatch producerStarted = new CountDownLatch(1);
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            var blockedProducer = executor.submit(() -> {
+                producerStarted.countDown();
+                pool.submit(PageBatches.batch(0, 2, 4, 5));
+                return null;
+            });
+            producerStarted.await();
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                SharedDatasetWriterPool.LaneStatistics lane = pool.laneStatistics().get(0);
+                assertThat(lane.submitBlockedCount()).isEqualTo(1L);
+                assertThat(lane.headOfLineBlockedCount()).isZero();
+            });
+
+            releaseWriters.countDown();
+            blockedProducer.get();
+            pool.abort();
+        }
+
+        assertUnpublishedAndEmpty(directory);
+    }
+
+    @Test
+    void saturatedStickyLaneRecordsHeadOfLineBlockingWhileAnotherLaneWaitsForWork(
+            @TempDir Path directory) throws Exception {
+        CountDownLatch releaseWriter = new CountDownLatch(1);
+        Fixture fixture = fixture(directory, Mode.BLOCK_FIRST_WRITE, releaseWriter, 2, 1);
+        SharedDatasetWriterPool pool = fixture.pool();
+        pool.submit(PageBatches.batch(0, 0, 0, 1));
+        fixture.format().writerEntered.await();
+        pool.submit(PageBatches.batch(0, 1, 1, 2));
+        await().atMost(Duration.ofSeconds(2))
+                .until(() -> pool.laneStatistics().get(1).waitingForWork());
+
+        CountDownLatch producerStarted = new CountDownLatch(1);
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            var blockedProducer = executor.submit(() -> {
+                producerStarted.countDown();
+                pool.submit(PageBatches.batch(0, 2, 2, 3));
+                return null;
+            });
+            producerStarted.await();
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                List<SharedDatasetWriterPool.LaneStatistics> lanes = pool.laneStatistics();
+                assertThat(lanes.get(0).submitBlockedCount()).isEqualTo(1L);
+                assertThat(lanes.get(0).submitBlockedNanos()).isPositive();
+                assertThat(lanes.get(0).headOfLineBlockedCount()).isEqualTo(1L);
+                assertThat(lanes.get(0).headOfLineBlockedNanos()).isPositive();
+                assertThat(lanes.get(1).queueDepth()).isZero();
+            });
+
+            releaseWriter.countDown();
+            blockedProducer.get();
+            pool.abort();
+        }
+
+        List<SharedDatasetWriterPool.LaneStatistics> lanes = pool.laneStatistics();
+        assertThat(lanes.get(0).queueDepthPeak()).isEqualTo(1);
+        assertThat(lanes.get(0).submitBlockedNanos()).isPositive();
+        assertThat(lanes.get(0).headOfLineBlockedNanos()).isPositive();
+        assertThat(lanes.get(1).submitBlockedCount()).isZero();
+        assertUnpublishedAndEmpty(directory);
+    }
+
+    @Test
+    void laneStatisticsAttributeSuccessfulRowsBatchesAndFinalization(
+            @TempDir Path directory) throws Exception {
+        SharedDatasetWriterPool pool = fixture(
+                directory, Mode.PASS_THROUGH, new CountDownLatch(0), 2, 8).pool();
+        pool.submit(PageBatches.batch(0, 0, 0, 3));
+        pool.submit(PageBatches.batch(1, 0, 3, 8));
+        pool.close();
+
+        List<SharedDatasetWriterPool.LaneStatistics> lanes = pool.laneStatistics();
+        assertThat(lanes).extracting(SharedDatasetWriterPool.LaneStatistics::rowsWritten)
+                .containsExactly(3L, 5L);
+        assertThat(lanes).extracting(SharedDatasetWriterPool.LaneStatistics::batchesWritten)
+                .containsExactly(1L, 1L);
+        assertThat(lanes).extracting(SharedDatasetWriterPool.LaneStatistics::partsFinalized)
+                .containsExactly(1L, 1L);
+        assertThat(lanes).extracting(SharedDatasetWriterPool.LaneStatistics::finalizeCount)
+                .containsExactly(1L, 1L);
+        assertThat(lanes).extracting(SharedDatasetWriterPool.LaneStatistics::queueDepth)
+                .containsOnly(0);
+    }
+
+    @Test
     void interruptPromptlyCancelsSubmitBlockedOnSaturatedQueueAndCallerCanRestoreStatus(
             @TempDir Path directory) throws Exception {
         CountDownLatch releaseWriter = new CountDownLatch(1);
@@ -174,6 +273,9 @@ class SharedDatasetWriterPoolFailureTest {
         assertThat(promptlyReleased).as("interrupt releases the saturated put promptly").isTrue();
         assertThat(result.get()).isInstanceOf(InterruptedException.class);
         assertThat(restoredInterrupt.get()).isTrue();
+        SharedDatasetWriterPool.LaneStatistics lane = pool.laneStatistics().get(0);
+        assertThat(lane.submitBlockedCount()).isEqualTo(1L);
+        assertThat(lane.submitBlockedNanos()).isPositive();
         assertUnpublishedAndEmpty(directory);
     }
 
@@ -187,12 +289,17 @@ class SharedDatasetWriterPoolFailureTest {
 
     private static Fixture fixture(Path directory, Mode mode, CountDownLatch releaseWriter)
             throws IOException {
+        return fixture(directory, mode, releaseWriter, 1, 1);
+    }
+
+    private static Fixture fixture(Path directory, Mode mode, CountDownLatch releaseWriter,
+            int writers, int queueCapacity) throws IOException {
         Files.createDirectories(directory);
         BlockingFormat format = new BlockingFormat(mode, releaseWriter);
         DatasetWriterPoolConfig config = new DatasetWriterPoolConfig(
                 "test", "bucket", PartListener.NONE, List.of(), 0, 0, null);
-        SharedDatasetWriterPool pool = new SharedDatasetWriterPool(directory, format, "hash", 1,
-                Long.MAX_VALUE, 1, config);
+        SharedDatasetWriterPool pool = new SharedDatasetWriterPool(directory, format, "hash", writers,
+                Long.MAX_VALUE, queueCapacity, config);
         return new Fixture(pool, format);
     }
 
@@ -205,8 +312,8 @@ class SharedDatasetWriterPoolFailureTest {
     }
 
     private enum Mode {
-        WRITE_FAIL, WRITE_AND_DISCARD_FAIL, FINALIZE_FAIL, BLOCK_FIRST_WRITE,
-        OPEN_THEN_DISCARD_FAIL
+        PASS_THROUGH, WRITE_FAIL, WRITE_AND_DISCARD_FAIL, FINALIZE_FAIL, BLOCK_FIRST_WRITE,
+        BLOCK_EVERY_FIRST_WRITE, OPEN_THEN_DISCARD_FAIL
     }
 
     private record Fixture(SharedDatasetWriterPool pool, BlockingFormat format) {
@@ -215,11 +322,12 @@ class SharedDatasetWriterPoolFailureTest {
     private static final class BlockingFormat implements DatasetFormat {
         private final Mode mode;
         private final CountDownLatch releaseWriter;
-        private final CountDownLatch writerEntered = new CountDownLatch(1);
+        private final CountDownLatch writerEntered;
 
         BlockingFormat(Mode mode, CountDownLatch releaseWriter) {
             this.mode = mode;
             this.releaseWriter = releaseWriter;
+            this.writerEntered = new CountDownLatch(mode == Mode.BLOCK_EVERY_FIRST_WRITE ? 2 : 1);
         }
 
         @Override public String partSuffix() { return ".test"; }
@@ -241,7 +349,9 @@ class SharedDatasetWriterPoolFailureTest {
                         awaitRelease();
                         throw new IOException("write failed");
                     }
-                    if (mode == Mode.BLOCK_FIRST_WRITE && rows == 0) {
+                    if (rows == 0 && (mode == Mode.BLOCK_EVERY_FIRST_WRITE
+                            || (mode == Mode.BLOCK_FIRST_WRITE
+                                    && path.getFileName().toString().startsWith("part-w0-")))) {
                         writerEntered.countDown();
                         awaitRelease();
                     }

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
@@ -201,8 +201,8 @@ class ParquetWriterPoolMetricsTest {
      * The lanes' own encode/write work is a client-service-cost span in its own right
      * ({@code swath.parquet.write.latency} → {@code client_cost[].parquet_write}). Without it a
      * Parquet run's measured client cost is the pool DISPATCH alone — what the consumer stage's
-     * {@code emit} span sees, a rounding error next to the encode the lanes then do — so summed
-     * spans cannot account for the process CPU a Parquet run actually burns.
+     * {@code emit} span sees, a rounding error next to the encode/write stretch the lanes then do.
+     * The elapsed span reveals active lane service; JFR, not this timer, attributes actual CPU.
      */
     @Test
     void laneEncodeWorkIsRecordedAsItsOwnClientCostSpan(@TempDir Path dir) throws Exception {
@@ -229,10 +229,20 @@ class ParquetWriterPoolMetricsTest {
         // record more, shorter, unrelated stretches.
         assertThat(laneWork.max(TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(
                 registry.get("swath.parquet.finalize.latency").timer().max(TimeUnit.NANOSECONDS));
-        assertThat(ctx.metrics().summary(Duration.ofSeconds(1), "work_stealing", 0L, 0L).clientCost())
+        RunSummary summary = ctx.metrics().summary(Duration.ofSeconds(1), "work_stealing", 0L, 0L);
+        assertThat(summary.clientCost())
                 .as("readable from the run summary's client_cost[], where the accounting is done")
                 .extracting(RunSummary.ClientCostSpan::span)
                 .contains(RunMetrics.CLIENT_COST_SPAN_PARQUET_WRITE);
+        assertThat(summary.parquetWriter()).isNotNull();
+        assertThat(summary.parquetWriter().lanes()).singleElement().satisfies(lane -> {
+            assertThat(lane.rowsWritten()).isEqualTo(3_000L);
+            assertThat(lane.batchesWritten()).isEqualTo(3L);
+            assertThat(lane.finalizedBytes()).isPositive();
+            assertThat(lane.partsFinalized()).isEqualTo(1L);
+            assertThat(lane.finalizeCount()).isEqualTo(1L);
+            assertThat(lane.activeElapsedNanos()).isPositive();
+        });
     }
 
     @Test

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
@@ -234,8 +234,9 @@ class ParquetWriterPoolMetricsTest {
                 .as("readable from the run summary's client_cost[], where the accounting is done")
                 .extracting(RunSummary.ClientCostSpan::span)
                 .contains(RunMetrics.CLIENT_COST_SPAN_PARQUET_WRITE);
-        assertThat(summary.parquetWriter()).isNotNull();
-        assertThat(summary.parquetWriter().lanes()).singleElement().satisfies(lane -> {
+        assertThat(summary.datasetWriter()).isNotNull();
+        assertThat(summary.datasetWriter().format()).isEqualTo("parquet");
+        assertThat(summary.datasetWriter().lanes()).singleElement().satisfies(lane -> {
             assertThat(lane.rowsWritten()).isEqualTo(3_000L);
             assertThat(lane.batchesWritten()).isEqualTo(3L);
             assertThat(lane.finalizedBytes()).isPositive();

--- a/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.luben.zstd.ZstdInputStream;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.observability.RunSummary;
 import io.varve.swath.output.CountingWriter;
 import io.varve.swath.output.OutputFormat;
 import io.varve.swath.output.parquet.DatasetLayout;
@@ -22,6 +23,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -205,6 +207,11 @@ final class TextWriterPoolTest {
         assertThat(registry.timer("swath.text_dataset.finalize.latency").count()).isEqualTo(1);
         assertThat(registry.timer("swath.text_dataset.write.latency").count()).isGreaterThanOrEqualTo(1);
         assertThat(metrics.progressSignal()).isGreaterThan(progressBefore);
+        RunSummary summary = metrics.summary(Duration.ofSeconds(1), "work_stealing", 0L, 0L);
+        assertThat(summary.datasetWriter()).isNotNull();
+        assertThat(summary.datasetWriter().format()).isEqualTo("jsonl");
+        assertThat(summary.datasetWriter().lanes()).extracting(RunSummary.DatasetWriterLane::rowsWritten)
+                .containsExactlyInAnyOrder(1L, 0L);
     }
 
     private static TextWriterPool pool(Path dir, TextCompression compression, int writers)


### PR DESCRIPTION
## What & why

Closes #121.

Direct Parquet and partitioned TSV/JSONL output share a single-consumer, bounded, sticky-lane writer pool. Existing elapsed-time metrics could not distinguish selected-lane admission stalls, idle-writer head-of-line blocking, general writer saturation, lane imbalance, or actual CPU consumption. Sorted output uses a different listing-phase sink, so its throughput cannot by itself establish a listing-engine or final-dataset-writer bottleneck.

This change adds an optional, format-labelled `dataset_writer` block to JSON run summaries for direct Parquet and directory TSV/JSONL output. It reports aggregate and per-lane rows, batches, finalized bytes and parts, active elapsed time, queue state and peak depth, blocked submissions, idle-writer head-of-line blocking, and finalization timing. The successful submit path remains one queue operation; clock reads, lane scans, and contention accounting occur only after the selected lane is full.

It also corrects elapsed-versus-CPU terminology and documents a retained JDK 25 JFR CPU-time profile and the signals needed to connect writer admission pressure to upstream backpressure.

This PR deliberately does not change sticky routing or the 2-4 writer limits. Parquet lane count is coupled to the bounded row-group memory budget, while text has different costs; the new evidence distinguishes aggregate sink saturation from dispatch head-of-line blocking before either policy is changed.

## How it was tested

- `./gradlew build -x :swath-replay:test`
- Focused writer-pool, summary assembly, JSON serialization, text-output, lane saturation, interruption, finalization, and crash/resume tests
- Instrumentation drift guard
- JDK 25 JFR configuration and startup validation with CPU-time sampling enabled
- Anonymous live S3 diagnostic over 9,919,142 objects with four direct Parquet lanes; exact row count and no blocked lane submissions on that I/O-bound run

A plain `./gradlew build` currently reaches a pre-existing `SortedModeConformanceTest` replay-fixture XML mismatch. The isolated failure reproduces from unchanged main; the full build excluding `:swath-replay:test` passes.

## Checklist

- [x] Commits are signed off (DCO)
- [ ] `./gradlew build` passes (blocked by the pre-existing replay conformance failure described above)
- [x] Added or updated tests where appropriate
- [x] Updated observability and performance documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run summaries now include optional dataset-writer performance details for Parquet, TSV, and JSONL outputs.
  * Added per-lane visibility into queue depth, throughput, active elapsed time, backpressure, head-of-line blocking, and finalization.
  * JSON run summaries now identify the output format and provide expanded writer diagnostics.
* **Documentation**
  * Clarified writer elapsed-time metrics and capacity interpretation.
  * Added Linux/JDK 25 JFR CPU-profiling guidance and recommendations for diagnosing writer bottlenecks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->