### PR TITLE
Make direct dataset writer concurrency resource-aware

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ compression is internal. Table, TSV, and JSONL support optional compression as s
 or single-file streams. Only TSV and JSONL support bounded directory datasets; those
 datasets are non-resumable and require `--checkpoint none` in this release.
 
-Text directory datasets use `--text-writers` (default `3`, range `2..4`) and
+Text directory datasets use `--text-writers` (default `3`, range `2..64`) and
 `--text-part-size` (default `256mb`). At startup, unless stdout or `-q` suppresses it,
 swath echoes the resolved format, destination kind, compression, and destination so the
 effective choice is visible before listing begins.
@@ -102,7 +102,7 @@ The following table is machine-checked against the code registry.
 | --- | --- | --- | --- | --- | --- | --- |
 | `engine.readahead` | `on or off` | `off` | experimental | free | fresh list | Speculatively fetch ahead on sustained dense tails; can trade API calls and memory for lower wall time. |
 | `seed.mode` | `shallow, none, or hints` | `shallow` | stable (`hints` reserved) | identity | fresh list | Choose initial keyspace discovery. `hints` is reserved but not implemented. |
-| `parquet.writers` | `integer 2..4` | `3` | stable | free | fresh list | Set the bounded Parquet writer pool; FILE-kind Parquet still resolves to one writer. |
+| `parquet.writers` | `integer 2..64 (heap-admitted above 4)` | `3` | stable | free | fresh list | Set the bounded Parquet writer pool. Counts 2–4 retain the measured release envelope; 5–64 require `-Xmx` to cover the conservative writer-memory plan. FILE-kind Parquet still resolves to one writer. |
 | `summary.interval` | `positive duration` | `--progress-interval`, otherwise `30s` | stable | free | fresh list | Set `_swath_summary.json` heartbeat cadence; accepts values such as `2s`, `500ms`, or `PT2S`. |
 | `sort.ignore-disk-check` | `on or off` | `off` | diagnostic | free | fresh list and resume | Bypass sorted-output free-space checks. Size the staging volume independently first. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ The following table is machine-checked against the code registry.
 | --- | --- | --- | --- | --- | --- | --- |
 | `engine.readahead` | `on or off` | `off` | experimental | free | fresh list | Speculatively fetch ahead on sustained dense tails; can trade API calls and memory for lower wall time. |
 | `seed.mode` | `shallow, none, or hints` | `shallow` | stable (`hints` reserved) | identity | fresh list | Choose initial keyspace discovery. `hints` is reserved but not implemented. |
-| `parquet.writers` | `integer 2..64 (heap-admitted above 4)` | `3` | stable | free | fresh list | Set the bounded Parquet writer pool. Counts 2–4 retain the measured release envelope; 5–64 require `-Xmx` to cover the conservative writer-memory plan. FILE-kind Parquet still resolves to one writer. |
+| `parquet.writers` | `integer 2..64 (heap-admitted above 4)` | `3` | stable | free | fresh list | Set the bounded direct (unsorted) Parquet writer pool. Counts 2–4 retain the measured release envelope; 5–64 require the JVM maximum heap to cover the conservative writer-memory plan. Higher counts are an expert experiment: they shrink each lane's share of the fixed queue budget and can multiply time-rotated parts plus manifest work. FILE-kind Parquet still resolves to one writer. Sorted staging/finalization does not construct this pool, so this setting is inert under `--sort`. |
 | `summary.interval` | `positive duration` | `--progress-interval`, otherwise `30s` | stable | free | fresh list | Set `_swath_summary.json` heartbeat cadence; accepts values such as `2s`, `500ms`, or `PT2S`. |
 | `sort.ignore-disk-check` | `on or off` | `off` | diagnostic | free | fresh list and resume | Bypass sorted-output free-space checks. Size the staging volume independently first. |
 

--- a/docs/internals/algorithms.md
+++ b/docs/internals/algorithms.md
@@ -1045,7 +1045,7 @@ boundary distinct from listing progress, because a part file's rows are not
 durable until its footer is fsynced:
 
 - **Sticky node→writer:** every page of a given node goes to one writer (of
-  the 2–4, by `node_id % writers`). A writer serves many nodes and rotates
+  the configured bounded pool, by `node_id % writers`). A writer serves many nodes and rotates
   its part file by target size, or, whichever fires first, by time-open or
   row count (the bounded-cadence triggers, evaluated on the
   writer's own thread — on write and on an idle-timeout wakeup); a

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -132,7 +132,9 @@ The listing engine and outer pipeline intentionally use different structures:
   artifact does not require preview features.
 
 All SQLite mutations pass through one writer thread. Parquet encode/write concurrency is a
-separate pool of 2–4 writers, so object-store concurrency does not multiply file writers.
+separate bounded pool (default 3; expert range 2–64 with heap admission above 4), so object-store
+concurrency does not multiply file writers. A fixed whole-pool submission budget likewise prevents
+additional lanes from multiplying queued page batches.
 
 ## Checkpoint and publication boundaries
 

--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -388,9 +388,10 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
 - **2–64 writers**, default 3, decoupled from listing concurrency (not one per worker).
   Parquet counts 2–4 are the measured release envelope; expert counts 5–64 are admitted only when
   the JVM maximum heap covers the §7.2 planning allowance. Text uses the same process-resource ceiling without
-  inheriting Parquet's row-group gate. Production gives each lane `floor(256 / writers)` queue
-  slots, so aggregate queued batches are bounded by 256 (exactly 256 when the count divides it;
-  255 at the default three writers). Increasing concurrency therefore does not multiply queued page batches.
+  inheriting Parquet's row-group gate. Production gives each lane
+  `min(64, floor(256 / writers))` queue slots, preserving the 64-slot-per-lane compatibility
+  behavior through four writers while bounding aggregate queued batches by 256 (192 at the
+  default three writers). Increasing concurrency therefore does not multiply queued page batches.
   This is a memory bound, not a throughput promise: above four writers each lane gets fewer slots,
   so the sole sticky dispatcher can encounter head-of-line blocking sooner while another lane is
   idle. `submit_blocked_ms`, `head_of_line_blocked_ms`, and the lane queue peaks decide whether a

--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -385,7 +385,11 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
 
 ### 4.1 Multi-writer + manifest — **own manifest, not parquet `_metadata`**
 
-- **2–4 writers**, decoupled from listing concurrency (not one per worker).
+- **2–64 writers**, default 3, decoupled from listing concurrency (not one per worker).
+  Parquet counts 2–4 are the measured release envelope; expert counts 5–64 are admitted only when
+  `-Xmx` covers the §7.2 planning allowance. Text uses the same process-resource ceiling without
+  inheriting Parquet's row-group gate. Production divides one fixed 256-batch submission ceiling
+  across the configured lanes, so increasing concurrency does not multiply queued page batches.
   Workers emit `PageBatch`es into the writer pool. **Sticky assignment:** all
   pages of a node go to writer `node_id % numWriters`, so a node's pages
   occupy a *contiguous* run of that writer's parts (which finalize in order)
@@ -804,14 +808,14 @@ published.
 | seed delimiter levels | adaptive | a shallow `delimiter=/` seed that starts at the top level and **adaptively descends narrow sub-levels** while cut-point and probe budgets permit; a truncated flat-wide level is radix-banded rather than descended (algorithms.md §8) |
 | steal probe | `max_keys=1` | one key per split attempt |
 | AIMD | ×0.7 down on 503 / +1 up per clean 10 s | the 0.7/+1 numbers are DECIDED. The 10 s clean-window cool-down is re-armed **only by a REAL reduction** (`T` actually lowered); a **floor no-op** decrease (`floor(0.7·T) >= T`, i.e. `T` already at the floor) still casts its AIMD vote, still latches congestion, and still pauses stealing, but no longer resets the clean window. The re-arm write is **monotonic** (`max` with the prior timestamp): a concurrent, stale-timestamped decrease can never shorten an already-armed window. (algorithms.md §5) |
-| Parquet writers | 3 | decoupled from `T` |
+| Parquet writers | 3 (range 2–64; 5–64 heap-admitted) | decoupled from `T`; counts above the measured four-writer envelope must pass the §7.2 `-Xmx` plan |
 | Parquet part target size | 256 MB | rotate by size |
-| `--text-writers` | 3 (range 2–4) | bounded TSV/JSONL directory writer lanes; decoupled from `T` |
+| `--text-writers` | 3 (range 2–64) | bounded TSV/JSONL directory writer lanes; decoupled from `T` and from Parquet's row-group memory policy |
 | `--text-part-size` | 256 MB | per-lane TSV/JSONL part rotation target; zero is rejected |
 | `--compression` | `none` unless a text file suffix implies gzip/Zstandard | table/TSV/JSONL streams and TSV/JSONL dataset parts only; Parquet rejects it |
 | `--part-rotation-interval` | 30 s | rotate a lane's open part by time too, even below the size target, so `durable_cursor` advances on a bounded cadence instead of only when a part happens to fill up; `0`/`none` disables; forced to `0` for a single-file `-o *.parquet` destination; a positive value below the 100 ms minimum is rejected (spin-storm guard — see below); `ParquetWriterPool` additionally floors its idle-lane poll wait at 50 ms as defense-in-depth |
 | `--part-rotation-max-rows` | 2_000_000 | rotate by row count too, for bursts fast enough to write millions of small rows well inside the time interval; `0` disables; forced to `0` for a single-file `-o *.parquet` destination |
-| `parquet.block.size` / `page.size` | 64 MB / 1 MB | **pinned**, measured in the PERF gate. block.size chosen so the §7.2 active-buffer Parquet heap budget holds for the current 100,000-key test (3 writers × 64 MB × parquet-mr uncompressed-row-group overshoot). This is not an N-independent whole-run heap claim: finalized-part metadata is `O(parts)`. Raising it toward 128 MB improves compression/scan but risks the measured budget — re-measure if you do. |
+| `parquet.block.size` / `page.size` | 64 MB / 1 MB | **pinned**, measured in the PERF gate. block.size chosen so the §7.2 active-buffer Parquet heap budget holds for the current 100,000-key test at the four-writer release ceiling. This is not an N-independent whole-run heap claim: finalized-part metadata is `O(parts)`. Raising it toward 128 MB improves compression/scan but risks the measured budget — re-measure if you do. |
 | `--request-rate` | unset | Bucket4j; cancellable acquire |
 | SDK retry attempts / initial backoff (**internal constants — not CLI flags**) | 1 / 100 ms | `S3Config.DEFAULT_MAX_ATTEMPTS = 1` disables SDK-internal retry: swath's own gauge-aware fetch loop is the sole retrier, so the AIMD `ConcurrencyGauge` sees every real 503/5xx immediately instead of after the SDK silently absorbed several behind its own backoff. There is **no** `--aws-max-attempts` / `--initial-backoff-ms` Picocli option in v1.0 (the `S3Config.maxAttempts` plumbing exists but is not CLI-wired) — exposing them is a planned follow-up |
 | page-timeout retry budget | per-fetch bounded retry, cap 8 (`MAX_TRANSIENT_RETRIES`), resets each fetch; disposition on exhaustion depends on `RetryPolicy` (see below) | `apiCallAttemptTimeout` is the per-attempt **timeout duration** (not a count; **10 s base for scan-class worker, seed, and delimiter/structure requests**, **3 s for point-class pivot/one-key probes** unless an escalation override raises it, with each class doubling from its own base per-fetch on consecutive attempt-timeouts of the SAME logical fetch — `apiCallAttemptTimeoutOverride` in §2 and [`probe-budgets.md`](probe-budgets.md)). Above the per-attempt budget the SDK client also enforces a **60 s overall `apiCallTimeout`** (`S3Config.DEFAULT_API_CALL_TIMEOUT`, the primary liveness ceiling on a wedged logical call). `WorkStealingScan.GaugedFetcher` (and, on the seed/sequential paths, `TransientRetryFetcher`) retries a **non-AIMD-voting** transient (`ThrottleException.Kind.ATTEMPT_TIMEOUT` / `NETWORK` — a client-side attempt-timeout or exhausted network fault, neither of which is genuine S3 backpressure; `NETWORK` also covers a client-local socket-closure / `IOException`-wrapper fault that escaped the SDK call as a non-`SdkException` `RuntimeException` such as `UncheckedIOException(SocketException("Socket closed"))`, reclassified transient rather than escaping raw as an exit-1 / `error_class=unknown` crash) up to `MAX_TRANSIENT_RETRIES = 8` times with jittered exponential backoff; the counter is **per invocation of `fetchPage`** (i.e. per attempted page/probe fetch), not a cross-fetch/cross-node consecutive count (it does not persist across separate `fetchPage` calls the way a per-node counter would). **What happens once the cap is crossed depends on `RetryPolicy`, resolved once at CLI wiring time from whether a real `LivenessWatchdog` is armed** — the fix for the tail-stall that killed long-running large listings, where this cap (not the watchdog) was a second liveness policy that always won the race to end the run: under **`RIDE_OUT`** (a real watchdog is armed, the default) the cap **no longer cancels the run** — the fetch keeps retrying indefinitely (raised full-jitter backoff ceiling, 5 s→15 s, recording `TRANSIENT.storm_ride_out`) and the watchdog alone owns liveness death (crash-only, resumable exit-75); under **`BOUNDED`** (both watchdog windows disabled by flags — `LivenessWatchdog.arm()` returned its no-op, so nothing else could ever stop an unbounded retry) exhaustion keeps the legacy disposition: the fetch trips the run's cancellation with `StopReason.STUCK` (attributing `CancelSource.TRANSIENT_RETRY_CAP`, recording `TRANSIENT.retry_cap_stuck`) and aborts via `CancelledException` — the **resumable exit-75 (`EX_TEMPFAIL`) disposition**, the same code as a watchdog stop — so the checkpoint stays valid and `swath resume` can safely retry the bucket later, rather than escaping as a fatal `ListingException` (exit 1) that the CLI's guarded engine dispatch would mark `run_meta.fatal_error` and thereby **poison `swath resume`**; a fetch with **no `CancellationToken` wired** (degenerate/embedded use) is unaffected by `RetryPolicy` and stays count-bounded regardless, escaping as the fatal `ListingException` contract on exhaustion. The run records `stop_source`/`error_class` marker fields that this disposition drives. Either disposition aborts (or, under `RIDE_OUT`, never aborts) the whole run, never a selective "fail the node". The thief's structure/pivot **probe** fetches (`slotGated=false`) are exempt from this policy: they use a separate small fixed cap (`PROBE_TRANSIENT_RETRY_CAP = 1`), never cancel the run, and simply return the probe to its non-productive retry flow. A genuine AIMD-voting throttle (`SLOWDOWN` / `SERVER_5XX`, real 503/5xx) is retried **unbounded** by this counter regardless of `RetryPolicy` — AIMD's own multiplicative decrease paces it instead, bounded only by cancellation/`--max-duration` (the liveness contract) |
@@ -859,13 +863,22 @@ pins the engine (and `scan → WorkStealingScan`).
 
 ### 7.2 Peak-heap budget per output format (PERF gate)
 
-The release gate asserts measured peak heap stays under these, sized to the
-**2–4-writer** Parquet model (not the retired per-worker model):
+The release gate asserts measured peak heap stays under these at the **four-writer release
+envelope** (not the retired per-worker model):
 
 | Output | Budget (default config) | Composition |
 | --- | --- | --- |
 | stdout / TSV / JSONL / table | **< 256 MB** | bounded queues + JVM baseline |
-| Parquet | **< 1 GB** (the bound PERF-2 asserts at 100,000 keys, `ParquetPerf2Test`) | `Parquet writers (3) × block.size (64 MB) × parquet-mr overshoot` + bounded queues + baseline. parquet-mr buffers the **uncompressed** row group, so real overshoot runs hotter than the ~2–3× first modeled — measure it, don't model it. The implementation has no per-object heap accumulation (I11), but the public PERF-2 measurement covers 100,000 keys, not billion-object scale. |
+| Parquet | **< 1 GB** (the bound PERF-2 asserts at 100,000 keys, `ParquetPerf2Test`) | Four active writers × 64 MB row groups + parquet-mr overshoot + the production-derived queue share + baseline. parquet-mr buffers the **uncompressed** row group, so measure the actual peak. The implementation has no per-object heap accumulation (I11), but the public PERF-2 measurement covers 100,000 keys, not billion-object scale. |
+
+The default is still three writers. Counts 2–4 are accepted as the measured compatibility
+envelope. An expert request for 5–64 writers is admitted only when `Runtime.maxMemory()` covers the
+planning floor `256 MiB + writers × 64 MiB × 4`; this conservative gate is reported in
+`dataset_writer` and prevents a high count on a small heap, but it is not a promise that an admitted
+workload will remain below that number. The process-resource ceiling of 64 also bounds platform
+threads, open parts, and the saturated-path lane scan. The whole pool retains at most 256 queued
+batches in production: counts 1–4 preserve the existing 64 slots per lane, while higher counts
+divide the fixed ceiling and may leave a few slots unused.
 
 Lower the active-buffer budget by reducing `parquet.block.size`, writer count,
 or `T`. I11 does not erase metadata growth: finalized parts contribute

--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -387,9 +387,14 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
 
 - **2–64 writers**, default 3, decoupled from listing concurrency (not one per worker).
   Parquet counts 2–4 are the measured release envelope; expert counts 5–64 are admitted only when
-  `-Xmx` covers the §7.2 planning allowance. Text uses the same process-resource ceiling without
-  inheriting Parquet's row-group gate. Production divides one fixed 256-batch submission ceiling
-  across the configured lanes, so increasing concurrency does not multiply queued page batches.
+  the JVM maximum heap covers the §7.2 planning allowance. Text uses the same process-resource ceiling without
+  inheriting Parquet's row-group gate. Production gives each lane `floor(256 / writers)` queue
+  slots, so aggregate queued batches are bounded by 256 (exactly 256 when the count divides it;
+  255 at the default three writers). Increasing concurrency therefore does not multiply queued page batches.
+  This is a memory bound, not a throughput promise: above four writers each lane gets fewer slots,
+  so the sole sticky dispatcher can encounter head-of-line blocking sooner while another lane is
+  idle. `submit_blocked_ms`, `head_of_line_blocked_ms`, and the lane queue peaks decide whether a
+  higher count helped on a real run.
   Workers emit `PageBatch`es into the writer pool. **Sticky assignment:** all
   pages of a node go to writer `node_id % numWriters`, so a node's pages
   occupy a *contiguous* run of that writer's parts (which finalize in order)
@@ -446,7 +451,10 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
   retained file list and each manifest rewrite are `O(parts)` in memory/work;
   rewriting the complete list at every finalize makes cumulative manifest
   serialization `O(parts²)` over the run. Part-count metadata is therefore
-  outside the active-buffer bound in I11.
+  outside the active-buffer bound in I11. Because the time/row cadence is per lane, more active
+  writers can also create more sub-target parts and amplify this publication path. Counts above the
+  measured envelope emit an operator warning, and `part_digest_*` / `manifest_write_*` in
+  `dataset_writer` measure the resulting full-part reads and serialized manifest work directly.
   **Resume bookkeeping stays out of the consumer manifest**: `args_hash` and
   the checkpoint `run_id` live in the internal `.swath-state.json` (same
   atomic write). For every directory format, swath creates and fsyncs that
@@ -808,7 +816,7 @@ published.
 | seed delimiter levels | adaptive | a shallow `delimiter=/` seed that starts at the top level and **adaptively descends narrow sub-levels** while cut-point and probe budgets permit; a truncated flat-wide level is radix-banded rather than descended (algorithms.md §8) |
 | steal probe | `max_keys=1` | one key per split attempt |
 | AIMD | ×0.7 down on 503 / +1 up per clean 10 s | the 0.7/+1 numbers are DECIDED. The 10 s clean-window cool-down is re-armed **only by a REAL reduction** (`T` actually lowered); a **floor no-op** decrease (`floor(0.7·T) >= T`, i.e. `T` already at the floor) still casts its AIMD vote, still latches congestion, and still pauses stealing, but no longer resets the clean window. The re-arm write is **monotonic** (`max` with the prior timestamp): a concurrent, stale-timestamped decrease can never shorten an already-armed window. (algorithms.md §5) |
-| Parquet writers | 3 (range 2–64; 5–64 heap-admitted) | decoupled from `T`; counts above the measured four-writer envelope must pass the §7.2 `-Xmx` plan |
+| Parquet writers | 3 (range 2–64; 5–64 heap-admitted) | decoupled from `T`; counts above the measured four-writer envelope must pass the §7.2 maximum-heap plan |
 | Parquet part target size | 256 MB | rotate by size |
 | `--text-writers` | 3 (range 2–64) | bounded TSV/JSONL directory writer lanes; decoupled from `T` and from Parquet's row-group memory policy |
 | `--text-part-size` | 256 MB | per-lane TSV/JSONL part rotation target; zero is rejected |
@@ -863,12 +871,12 @@ pins the engine (and `scan → WorkStealingScan`).
 
 ### 7.2 Peak-heap budget per output format (PERF gate)
 
-The release gate asserts measured peak heap stays under these at the **four-writer release
-envelope** (not the retired per-worker model):
+The Parquet release gate measures the **four-writer release envelope** (not the retired per-worker
+model). The non-Parquet row describes its default configuration:
 
 | Output | Budget (default config) | Composition |
 | --- | --- | --- |
-| stdout / TSV / JSONL / table | **< 256 MB** | bounded queues + JVM baseline |
+| stdout / TSV / JSONL / table | **< 256 MB** | default writer count, bounded queues + JVM baseline; expert text counts also add platform-thread stacks, compression state, parts, and manifest work and must be measured separately |
 | Parquet | **< 1 GB** (the bound PERF-2 asserts at 100,000 keys, `ParquetPerf2Test`) | Four active writers × 64 MB row groups + parquet-mr overshoot + the production-derived queue share + baseline. parquet-mr buffers the **uncompressed** row group, so measure the actual peak. The implementation has no per-object heap accumulation (I11), but the public PERF-2 measurement covers 100,000 keys, not billion-object scale. |
 
 The default is still three writers. Counts 2–4 are accepted as the measured compatibility
@@ -878,7 +886,9 @@ planning floor `256 MiB + writers × 64 MiB × 4`; this conservative gate is rep
 workload will remain below that number. The process-resource ceiling of 64 also bounds platform
 threads, open parts, and the saturated-path lane scan. The whole pool retains at most 256 queued
 batches in production: counts 1–4 preserve the existing 64 slots per lane, while higher counts
-divide the fixed ceiling and may leave a few slots unused.
+divide the fixed ceiling and may leave a few slots unused. `Runtime.maxMemory()` is a heap ceiling,
+not a process-RSS or CPU admission model; an explicit JVM heap must still fit inside the container or
+host limit, and the operator must measure CPU, RSS, part count, queue blocking, and manifest time.
 
 Lower the active-buffer budget by reducing `parquet.block.size`, writer count,
 or `T`. I11 does not erase metadata growth: finalized parts contribute

--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -350,9 +350,19 @@ began. Requiring an actually idle writer distinguishes sticky-routing head-of-li
 the ordinary case where all writers are busy, without changing routing.
 
 The top level also reports `writer_count`, the sum of lane capacities as
-`total_queue_capacity`, and `jvm_max_heap_bytes`. Parquet adds `buffer_bytes_per_writer` (the pinned
-64 MiB row group) and `planned_heap_bytes` (the conservative admission plan); both are JSON null for
-text because its encoders do not own a comparable fixed row-group allocation.
+`total_queue_capacity`, `part_rotation_interval_ms`, `part_rotation_max_rows`, and
+`jvm_max_heap_bytes`. Parquet adds `row_group_target_bytes_per_writer`,
+`row_group_allowance_multiplier`, `planned_heap_bytes`, and `heap_admission_applied`; these are JSON
+null for text because its encoders do not own a comparable fixed row-group allocation. The target is
+the pinned 64 MiB uncompressed row-group threshold, while the multiplier exposes the conservative
+overshoot allowance used by the plan—multiplying only writer count by the target is not a heap
+estimate.
+
+`part_digest_count`/`part_digest_ms` measure the full-part checksum read after close.
+`manifest_write_count`/`manifest_write_ms` measure atomic complete-manifest rewrites, including time
+queued behind another lane on the global manifest lock. The count includes the final ensure-write at
+successful publication. These fields isolate the two per-part costs that grow when more active lanes
+produce more time/row-rotated parts; both durations remain elapsed time, not CPU.
 
 `lanes[]` contains one row per configured writer (1–64):
 
@@ -379,7 +389,8 @@ sink service is insufficient. Material `head_of_line_blocked_ms` instead shows t
 stranded an idle writer and calls for removing cross-lane dispatch coupling before adding buffers.
 Near-zero blocking means more lanes would not improve that run. Interpret lane active time as elapsed
 service, not as sustained capacity or CPU: short bursts can exclude later finalization, filesystem
-writeback, and GC costs.
+writeback, and GC costs. Rising `manifest_write_ms` and part count as writers increase identifies the
+serialized publication/small-file path; adding lanes cannot parallelize that lock.
 
 **Instrumentation cost.** The normal submit path performs one non-blocking `offer`, the same single
 queue-lock acquisition the former uncontended `put` required. It does not sample queue size, read

--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -349,7 +349,12 @@ admissions where at least one *other* lane was waiting for work with an empty qu
 began. Requiring an actually idle writer distinguishes sticky-routing head-of-line blocking from
 the ordinary case where all writers are busy, without changing routing.
 
-`lanes[]` contains one row per configured writer (1–4):
+The top level also reports `writer_count`, the sum of lane capacities as
+`total_queue_capacity`, and `jvm_max_heap_bytes`. Parquet adds `buffer_bytes_per_writer` (the pinned
+64 MiB row group) and `planned_heap_bytes` (the conservative admission plan); both are JSON null for
+text because its encoders do not own a comparable fixed row-group allocation.
+
+`lanes[]` contains one row per configured writer (1–64):
 
 | field | meaning |
 |---|---|
@@ -358,7 +363,7 @@ the ordinary case where all writers are busy, without changing routing.
 | `finalized_bytes`, `parts_finalized` | Actual file sizes and part count after successful finalize/durability handling. |
 | `active_elapsed_ms` | Sum of lane-thread stretches between queue waits. It includes encoding, file/checkpoint I/O, fsync, MD5/manifest work, and any internal waits; it is not CPU and can overlap other lanes. |
 | `submit_blocked_count`, `submit_blocked_ms` | This sticky lane's full-queue encounters and elapsed admission waits. Interrupted waits are still evidence and remain counted. |
-| `head_of_line_blocked_count`, `head_of_line_blocked_ms` | The subset whose wait began while another lane thread was waiting for work with an empty queue. The check scans at most four lanes and runs only after the selected lane is already full. Material time is strong evidence that sticky routing stranded an idle writer; zero only means that condition was not present at blocked-admission start. |
+| `head_of_line_blocked_count`, `head_of_line_blocked_ms` | The subset whose wait began while another lane thread was waiting for work with an empty queue. The bounded cross-lane scan runs only after the selected lane is already full. Material time is strong evidence that sticky routing stranded an idle writer; zero only means that condition was not present at blocked-admission start. |
 | `finalize_count`, `finalize_elapsed_ms` | `DatasetPartWriter.close()` attempts and elapsed close time, including failed attempts. Broader post-close MD5/checkpoint/manifest work remains in `active_elapsed_ms`. |
 
 Read the causal chain in order: lane `submit_blocked_ms` is contained in the consumer's `emit`
@@ -380,8 +385,8 @@ writeback, and GC costs.
 queue-lock acquisition the former uncontended `put` required. It does not sample queue size, read
 the clock, scan other lanes, or update blocked counters. The encode path updates single-writer
 volatile counters once per batch/lane stretch, not once per row. Only a failed `offer` reads the
-monotonic clock, scans the fixed 1–4 lane array, and updates blocked counters. Queue depth is sampled
-by the periodic/terminal reporter, which also copies that fixed lane array. Benchmark both arms with
+monotonic clock, scans the bounded lane array, and updates blocked counters. Queue depth is sampled
+by the periodic/terminal reporter, which also copies that bounded lane array. Benchmark both arms with
 identical instrumentation and JFR settings; the repository does not claim a universal measured
 overhead percentage for this workload.
 

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -160,7 +160,10 @@ key samples. Treat it as operational data and redact it before sharing.
 
 `dataset_writer` is present for direct Parquet and parallel directory TSV/JSONL output; its
 `format` is `parquet`, `tsv`, or `jsonl`. It is absent for stdout, single-file text, discard, and
-sorted output, which do not construct the shared pool. Its aggregate
+sorted output, which do not construct the shared pool. Its aggregate resource fields report the
+configured writer count, total lane-queue capacity, JVM maximum heap, and—for Parquet—the pinned
+row-group bytes per writer plus the conservative heap-admission plan. The Parquet-only fields are
+null for text. Its aggregate
 `submit_blocked_*` fields measure full sticky-lane admission waits;
 `head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty
 queue when that wait began. The bounded `lanes[]` array reports lane id, queue

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -162,8 +162,9 @@ key samples. Treat it as operational data and redact it before sharing.
 `format` is `parquet`, `tsv`, or `jsonl`. It is absent for stdout, single-file text, discard, and
 sorted output, which do not construct the shared pool. Its aggregate resource fields report the
 configured writer count, total lane-queue capacity, JVM maximum heap, and—for Parquet—the pinned
-row-group bytes per writer plus the conservative heap-admission plan. The Parquet-only fields are
-null for text. Its aggregate
+row-group target, its conservative allowance multiplier, and the heap-admission plan. It also reports
+the part-rotation configuration, full-part digest work, and complete-manifest rewrite count/time; the
+manifest duration includes lock wait. The Parquet-only fields are null for text. Its aggregate
 `submit_blocked_*` fields measure full sticky-lane admission waits;
 `head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty
 queue when that wait began. The bounded `lanes[]` array reports lane id, queue

--- a/docs/ops/dev/TESTING.md
+++ b/docs/ops/dev/TESTING.md
@@ -46,7 +46,8 @@ parallel/batched, and the populated volume **snapshotted and reused** — not re
   - **PERF-2** (`ParquetPerf2Test`): 100k keys through the real listing→parquet pipeline —
     **measured peak heap** < the §7.2 Parquet budget (1 GB), **measured peak RSS**
     (`/proc/self/status` `VmRSS`) under a bounded budget, and **no hot-path virtual-thread
-    pinning** (`jdk.VirtualThreadPinned` JFR events == 0).
+    pinning** (`jdk.VirtualThreadPinned` JFR events == 0). Its direct pool leg activates all four
+    release-envelope writers with the production 64-slot lane queues.
 - **`-Pdeep`** `./gradlew test -Pdeep` — runs **only** the `@Tag("deep")` tier:
   schedule-sensitive probe-budget tests + latency-injecting retry/AIMD/throttle/timeout
   timing tests, demoted off the per-commit gate because they are slow (real `Thread.sleep`)

--- a/docs/ops/dev/TESTING.md
+++ b/docs/ops/dev/TESTING.md
@@ -48,6 +48,14 @@ parallel/batched, and the populated volume **snapshotted and reused** — not re
     (`/proc/self/status` `VmRSS`) under a bounded budget, and **no hot-path virtual-thread
     pinning** (`jdk.VirtualThreadPinned` JFR events == 0). Its direct pool leg activates all four
     release-envelope writers with the production 64-slot lane queues.
+  - Fast writer-pool coverage separately constructs eight active Parquet lanes and a resume that
+    shrinks from eight lanes to three, asserting exact row union, unique part names, complete
+    manifests, sequence continuation for surviving lanes, and clean shutdown under the fixed queue
+    budget. This is correctness coverage, not evidence that eight writers improve throughput.
+  - `DatasetWriterScalingBenchmark` is an opt-in 4/8/16 diagnostic (`-PonlyPerf
+    -Dswath.bench=on`, filtered to that class). It prints `WRITER_BENCH_RESULT` rows for an encode/dispatch arm and a
+    row-rotation arm, including submit/HOL blocking plus digest/manifest time. Results are host and
+    workload evidence, never a relative-throughput assertion in CI.
 - **`-Pdeep`** `./gradlew test -Pdeep` — runs **only** the `@Tag("deep")` tier:
   schedule-sensitive probe-budget tests + latency-injecting retry/AIMD/throttle/timeout
   timing tests, demoted off the per-commit gate because they are slow (real `Thread.sleep`)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -140,9 +140,18 @@ workload.
 
 Direct Parquet uses `--tune parquet.writers=N`; counts 2–4 are the measured release envelope and
 5–64 must pass the JVM heap-admission plan described in the contracts. Directory TSV/JSONL uses
-`--text-writers N` over the independent 2–64 text range. Both retain the same fixed 256-batch
+`--text-writers N` over the independent 2–64 text range. Both retain the same 256-batch aggregate
 whole-pool submission ceiling as concurrency rises. Confirm the resolved `writer_count`,
-`total_queue_capacity`, and Parquet memory-plan fields in `dataset_writer` before comparing runs.
+`total_queue_capacity`, rotation settings, and Parquet memory-plan fields in `dataset_writer` before
+comparing runs.
+
+Higher counts are not monotonic throughput scaling. Dividing the fixed budget gives each lane fewer
+queue slots, which can expose sticky-dispatch head-of-line blocking sooner. The default time/row
+rotation is also per lane: more active lanes can create more sub-target parts, each of which performs
+a full-part digest and rewrites the complete manifest under one lock. Compare `part_digest_ms`,
+`manifest_write_ms`, part count, `submit_blocked_ms`, and `head_of_line_blocked_ms` at 4/8/16 before
+adopting an expert count. If manifest time or HOL blocking rises faster than throughput, more writers
+are making the sink worse.
 
 ### Size CPU and memory empirically
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -138,6 +138,12 @@ binding; material head-of-line blocking with idle lanes means dispatch coupling 
 neither appears, raising the writer count would only add memory and file-part overhead for that
 workload.
 
+Direct Parquet uses `--tune parquet.writers=N`; counts 2–4 are the measured release envelope and
+5–64 must pass the JVM heap-admission plan described in the contracts. Directory TSV/JSONL uses
+`--text-writers N` over the independent 2–64 text range. Both retain the same fixed 256-batch
+whole-pool submission ceiling as concurrency rises. Confirm the resolved `writer_count`,
+`total_queue_capacity`, and Parquet memory-plan fields in `dataset_writer` before comparing runs.
+
 ### Size CPU and memory empirically
 
 CPU cost per million keys is:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,7 +45,7 @@ file or stdout, and TSV/JSONL parts in a directory dataset. For files it is also
 inferred from `.gz` or `.zst`; stdout needs the explicit option. Parquet uses its own
 compression and rejects this option.
 
-TSV and JSONL directory datasets use 2–4 bounded writer lanes (`--text-writers`,
+TSV and JSONL directory datasets use 2–64 bounded writer lanes (`--text-writers`,
 default `3`) and rotate independent parts at `--text-part-size` (default `256mb`).
 Each compressed part is a complete gzip or Zstandard frame. The dataset publishes a
 manifest and writes `_SUCCESS` last, but is non-resumable in this release and therefore

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,7 +49,9 @@ TSV and JSONL directory datasets use 2–64 bounded writer lanes (`--text-writer
 default `3`) and rotate independent parts at `--text-part-size` (default `256mb`).
 Each compressed part is a complete gzip or Zstandard frame. The dataset publishes a
 manifest and writes `_SUCCESS` last, but is non-resumable in this release and therefore
-requires `--checkpoint none`.
+requires `--checkpoint none`. Counts above four are an expert tuning surface: per-lane queue shares
+shrink and per-lane rotation can multiply small parts and serialized manifest rewrites, so benchmark
+the `dataset_writer` blocked-time, part, digest, and manifest fields before adopting them.
 
 Use a managed Parquet directory when checkpoint/resume matters. Text file destinations
 are published atomically but are not resumable; compressed files are published only

--- a/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
@@ -197,6 +197,9 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
      */
     PageFetcher fetcherOverride;
 
+    /** Test-only deterministic maximum-heap seam for writer-admission ordering checks. */
+    Long maxHeapBytesOverride;
+
     /**
      * Test-only seam (package-private, null in production): when set, {@code call()} uses this
      * instead of a real {@link TerminalCapabilities} — no real controlling terminal is available
@@ -375,6 +378,12 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
         // exit 2 on --sort with a non-parquet EFFECTIVE format — for every case except a bare
         // swath resume with no explicit --format, BEFORE any checkpoint is opened.
         validateSortFlags(resolved);
+        // Fresh output is fully resolved here, so reject an impossible writer plan before the
+        // directory guard, checkpoint, metrics registry, or S3 client can have side effects. A
+        // resume whose effective output comes from the checkpoint is validated after restore below.
+        if (!checkpoint.resume) {
+            validateDatasetWriterConfiguration(resolved);
+        }
         // Directory-lifecycle safety: before a FRESH (non-resume) directory-dataset run touches
         // the -o dir at all — no checkpoint row, no seed probe, no file write — refuse a FOREIGN
         // non-empty dir or a DAMAGED manifest so we never write into / delete unowned files. A dir
@@ -746,6 +755,12 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
                             + "are non-resumable in this release; start a fresh run with "
                             + "--checkpoint none");
                 }
+            }
+            if (checkpoint.resume) {
+                // A resume can learn its effective format/destination only from the opened
+                // checkpoint. Keep the complementary admission check here, after any restore but
+                // before config/S3 construction, rather than coupling it to RunMeta's state shape.
+                validateDatasetWriterConfiguration(resolved);
             }
             // Build config AFTER any resume-context restore (region/profile/no-sign), and BEFORE the
             // resume-safety summary + the S3Client below are built from it.
@@ -1571,14 +1586,11 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
             throws InvalidConfigException, InvalidArgsException {
         boolean singleFile = output.resolvedKind == OutputOptions.DestinationKind.FILE;
         long targetBytes = output.partSizeBytes();
-        int writers = OutputOptions.resolveParquetWriters(output.resolvedKind, output.parquetWriters);
-        if (writers > ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS) {
-            log.warn("parquet_writer_expert_count writers={} planned_heap_bytes={} jvm_max_heap_bytes={} "
-                            + "measured_release_max={}",
-                    writers, ParquetWriterMemoryPlan.plannedHeapBytes(writers),
-                    Runtime.getRuntime().maxMemory(),
-                    ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS);
-        }
+        // Sorted output stages through SortLane and publishes through SortedParquetWriterFactory;
+        // it never constructs the direct dataset writer pool. Keep the otherwise-unused writer
+        // fields inert so an expert direct-sink setting cannot reject or warn on a sorted run.
+        int writers = sorting.sort ? 1 : OutputOptions.resolveParquetWriters(
+                output.resolvedKind, output.parquetWriters, maximumHeapBytes());
         long rotation = singleFile ? Long.MAX_VALUE : targetBytes;
         // A single-file destination (a .parquet extension on -o) must stay exactly
         // one part: the time/row-count cadence triggers are for the multi-part model
@@ -1595,6 +1607,56 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
     /** Equal per-lane share whose pool-wide product never exceeds the fixed production budget. */
     static int datasetWriterQueueCapacityPerLane(int writers) {
         return SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers);
+    }
+
+    /**
+     * Validate the effective dataset-writer plan at the earliest point where format and destination
+     * kind are authoritative. Counts above the measured envelope remain available, but the warning
+     * names both bounded resources this knob can stress: heap and per-finalize publication work.
+     */
+    private void validateDatasetWriterConfiguration(OutputFormat format)
+            throws InvalidConfigException {
+        if (sorting.sort) {
+            return;
+        }
+        if (output.resolvedKind == OutputOptions.DestinationKind.FILE) {
+            if (format == OutputFormat.PARQUET) {
+                OutputOptions.resolveParquetWriters(
+                        output.resolvedKind, output.parquetWriters, maximumHeapBytes());
+            }
+            return;
+        }
+
+        int writers;
+        Long plannedHeapBytes = null;
+        if (format == OutputFormat.PARQUET) {
+            writers = OutputOptions.resolveParquetWriters(
+                    output.resolvedKind, output.parquetWriters, maximumHeapBytes());
+            plannedHeapBytes = ParquetWriterMemoryPlan.plannedHeapBytes(writers);
+        } else if (output.resolvedKind == OutputOptions.DestinationKind.DIRECTORY
+                && (format == OutputFormat.TSV || format == OutputFormat.JSONL)) {
+            writers = output.resolveTextWriters();
+        } else {
+            return;
+        }
+
+        if (writers > ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS) {
+            Duration rotationInterval = output.resolvePartRotationInterval();
+            log.warn("dataset_writer_expert_count format={} writers={} queue_capacity_per_lane={} "
+                            + "part_rotation_interval_ms={} planned_heap_bytes={} jvm_max_heap_bytes={} "
+                            + "measured_release_max={} (more active lanes can create more time-rotated "
+                            + "small parts and amplify O(parts^2) manifest rewrites; benchmark "
+                            + "submit_blocked_ms, head_of_line_blocked_ms, manifest_write_ms, and part count)",
+                    format.name().toLowerCase(Locale.ROOT), writers,
+                    datasetWriterQueueCapacityPerLane(writers), rotationInterval.toMillis(),
+                    plannedHeapBytes, maximumHeapBytes(),
+                    ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS);
+        }
+    }
+
+    private long maximumHeapBytes() {
+        return maxHeapBytesOverride != null
+                ? maxHeapBytesOverride : Runtime.getRuntime().maxMemory();
     }
 
     /**

--- a/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/ListCommand.java
@@ -43,9 +43,11 @@ import io.varve.swath.observability.SafeInput;
 import io.varve.swath.observability.StopReason;
 import io.varve.swath.observability.TraceSink;
 import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import io.varve.swath.output.parquet.DatasetLayout;
 import io.varve.swath.output.parquet.Manifest;
 import io.varve.swath.output.parquet.ParquetResume;
+import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
 import io.varve.swath.output.parquet.PartInfo;
 import io.varve.swath.output.text.TextWriterPoolConfig;
 import io.varve.swath.runtime.ArgsHashFields;
@@ -122,8 +124,13 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
      */
     static final String SORT_STAGING_DIR = "_staging";
 
-    /** Per-writer submission-queue depth (in batches) for {@link ListRunner.ParquetSpec#writerQueueCapacity()}. */
-    private static final int DATASET_WRITER_QUEUE_CAPACITY = 64;
+    /**
+     * Whole-pool submission ceiling in batches. The former production setting was 64 per writer
+     * with at most four writers; retaining that 256-batch maximum keeps every existing path
+     * unchanged without multiplying pending memory when expert configurations add lanes.
+     */
+    static final int DATASET_WRITER_TOTAL_QUEUE_CAPACITY =
+            SharedDatasetWriterPool.MAX_TOTAL_QUEUE_CAPACITY;
 
     private DatasetDirGuard.FreshDirectoryState freshDatasetDirectoryState;
 
@@ -1299,10 +1306,12 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
     TextWriterPoolConfig textWriterPoolConfig(S3Uri s3uri, OutputFormat format, String argsHash)
             throws InvalidConfigException, InvalidArgsException {
         try {
+            int writers = output.resolveTextWriters();
             return new TextWriterPoolConfig(
                     Path.of(output.destination), format, output.resolvedCompression, !output.rawOutput,
-                    argsHash, s3uri.bucket(), output.resolveTextWriters(), output.textPartSizeBytes(),
-                    DATASET_WRITER_QUEUE_CAPACITY, output.resolvePartRotationInterval().toNanos(),
+                    argsHash, s3uri.bucket(), writers, output.textPartSizeBytes(),
+                    datasetWriterQueueCapacityPerLane(writers),
+                    output.resolvePartRotationInterval().toNanos(),
                     output.resolvePartRotationMaxRows());
         } catch (IllegalArgumentException e) {
             throw new InvalidConfigException(e.getMessage(), e);
@@ -1563,6 +1572,13 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
         boolean singleFile = output.resolvedKind == OutputOptions.DestinationKind.FILE;
         long targetBytes = output.partSizeBytes();
         int writers = OutputOptions.resolveParquetWriters(output.resolvedKind, output.parquetWriters);
+        if (writers > ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS) {
+            log.warn("parquet_writer_expert_count writers={} planned_heap_bytes={} jvm_max_heap_bytes={} "
+                            + "measured_release_max={}",
+                    writers, ParquetWriterMemoryPlan.plannedHeapBytes(writers),
+                    Runtime.getRuntime().maxMemory(),
+                    ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS);
+        }
         long rotation = singleFile ? Long.MAX_VALUE : targetBytes;
         // A single-file destination (a .parquet extension on -o) must stay exactly
         // one part: the time/row-count cadence triggers are for the multi-part model
@@ -1571,9 +1587,14 @@ public final class ListCommand implements Callable<Integer>, GlobalOptions.Carri
         long rotationMaxRows = singleFile ? 0L : output.resolvePartRotationMaxRows();
         return new ListRunner.ParquetSpec(
                 s3uri.prefix(), channelCapacity, pageMax, filterChain, writers, rotation,
-                DATASET_WRITER_QUEUE_CAPACITY, argsHash,
+                datasetWriterQueueCapacityPerLane(writers), argsHash,
                 liveness.resolveProgressInterval(), buildJsonSummaryConfig(OutputFormat.PARQUET, config, argsHash),
                 rotationIntervalNanos, rotationMaxRows, s3uri.bucket());
+    }
+
+    /** Equal per-lane share whose pool-wide product never exceeds the fixed production budget. */
+    static int datasetWriterQueueCapacityPerLane(int writers) {
+        return SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers);
     }
 
     /**

--- a/swath-cli/src/main/java/io/varve/swath/cli/OutputOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/OutputOptions.java
@@ -10,6 +10,8 @@ import io.varve.swath.error.InvalidArgsException;
 import io.varve.swath.error.InvalidConfigException;
 import io.varve.swath.filter.SizeParser;
 import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
+import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
 import io.varve.swath.output.text.TextCompression;
 import io.varve.swath.output.text.TextWriterPoolConfig;
 import java.io.BufferedOutputStream;
@@ -461,9 +463,9 @@ final class OutputOptions {
 
     String summaryJsonInterval;
 
-    /** Contract §4.1 / §7 memory model: 2–4 decoupled Parquet writers (default 3). */
+    /** Contract §4.1 / §7 memory model: bounded, decoupled Parquet writers (default 3). */
     static final int MIN_PARQUET_WRITERS = 2;
-    static final int MAX_PARQUET_WRITERS = 4;
+    static final int MAX_PARQUET_WRITERS = SharedDatasetWriterPool.MAX_WRITERS;
 
     /**
      * Rotation cadence defaults: bound the resume {@code durable_cursor} lag to a small
@@ -491,13 +493,19 @@ final class OutputOptions {
 
     /**
      * Resolve the Parquet writer-pool size, enforcing the contract's bounded memory model
-     * (contract §4.1 "2–4 writers", I11). A {@code -o path.parquet} single-file destination
+     * (contract §4.1 / §7, I11). A {@code -o path.parquet} single-file destination
      * -- replacing the old {@code --single-file} flag -- collapses to one lane; otherwise
-     * {@code --tune parquet.writers=N} must be in {@code [2,4]} — an out-of-range value would create that
-     * many row-group buffers and blow the heap budget, and {@code 1} for a directory dataset is the
-     * single-file model requested implicitly, which we reject so intent is explicit.
+     * the established 2-4 release envelope is always accepted. Expert counts above four are
+     * admitted only when the JVM maximum heap covers the conservative {@link
+     * ParquetWriterMemoryPlan}; {@code 1} for a directory dataset is the single-file model requested
+     * implicitly, which we reject so intent is explicit.
      */
     static int resolveParquetWriters(DestinationKind kind, int parquetWriters) throws InvalidConfigException {
+        return resolveParquetWriters(kind, parquetWriters, Runtime.getRuntime().maxMemory());
+    }
+
+    static int resolveParquetWriters(DestinationKind kind, int parquetWriters, long maxHeapBytes)
+            throws InvalidConfigException {
         if (kind == DestinationKind.FILE) {
             return 1;
         }
@@ -505,6 +513,14 @@ final class OutputOptions {
             throw new InvalidConfigException("--tune parquet.writers must be between " + MIN_PARQUET_WRITERS
                     + " and " + MAX_PARQUET_WRITERS + " (got " + parquetWriters
                     + "); use -o <path>.parquet for a single output part");
+        }
+        int heapLimit = ParquetWriterMemoryPlan.maxWritersForHeap(maxHeapBytes);
+        if (parquetWriters > heapLimit) {
+            long planned = ParquetWriterMemoryPlan.plannedHeapBytes(parquetWriters);
+            throw new InvalidConfigException("--tune parquet.writers=" + parquetWriters
+                    + " needs a conservative heap plan of " + planned + " bytes, but this JVM's -Xmx is "
+                    + maxHeapBytes + " bytes; use at most " + heapLimit + " writers, raise -Xmx, or use "
+                    + "--text-writers for a text dataset");
         }
         return parquetWriters;
     }

--- a/swath-cli/src/main/java/io/varve/swath/cli/OutputOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/OutputOptions.java
@@ -518,9 +518,9 @@ final class OutputOptions {
         if (parquetWriters > heapLimit) {
             long planned = ParquetWriterMemoryPlan.plannedHeapBytes(parquetWriters);
             throw new InvalidConfigException("--tune parquet.writers=" + parquetWriters
-                    + " needs a conservative heap plan of " + planned + " bytes, but this JVM's -Xmx is "
-                    + maxHeapBytes + " bytes; use at most " + heapLimit + " writers, raise -Xmx, or use "
-                    + "--text-writers for a text dataset");
+                    + " needs a conservative heap plan of " + planned + " bytes, but this JVM's maximum heap is "
+                    + maxHeapBytes + " bytes; use at most " + heapLimit + " writers, increase the JVM/container "
+                    + "memory limit, or use --text-writers for a text dataset");
         }
         return parquetWriters;
     }

--- a/swath-cli/src/main/java/io/varve/swath/cli/TuneOptions.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/TuneOptions.java
@@ -24,7 +24,7 @@ final class TuneOptions {
                     "experimental", ResumeClass.FREE, "fresh list"),
             new KeySpec("seed.mode", "enum", "shallow|none|hints", "shallow",
                     "stable (hints reserved)", ResumeClass.IDENTITY, "fresh list"),
-            new KeySpec("parquet.writers", "integer", "2..4", "3",
+            new KeySpec("parquet.writers", "integer", "2..64 (heap-admitted above 4)", "3",
                     "stable", ResumeClass.FREE, "fresh list"),
             new KeySpec("summary.interval", "duration",
                     "positive duration (for example 2s, 500ms, or PT2S)", "--progress-interval",

--- a/swath-cli/src/test/java/io/varve/swath/cli/OutputDatasetConfigValidationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/OutputDatasetConfigValidationTest.java
@@ -40,7 +40,7 @@ final class OutputDatasetConfigValidationTest {
     }
 
     @Test
-    void textWriterRangeComesFromTheCorePoolContract() {
+    void textWriterRangeComesFromTheCorePoolContract() throws Exception {
         OutputOptions below = new OutputOptions();
         below.textWriters = TextWriterPoolConfig.MIN_WRITERS - 1;
         assertThatThrownBy(below::resolveTextWriters)
@@ -48,11 +48,28 @@ final class OutputDatasetConfigValidationTest {
                 .hasMessageContaining(String.valueOf(TextWriterPoolConfig.MIN_WRITERS))
                 .hasMessageContaining(String.valueOf(TextWriterPoolConfig.MAX_WRITERS));
 
+        OutputOptions maximum = new OutputOptions();
+        maximum.textWriters = TextWriterPoolConfig.MAX_WRITERS;
+        assertThat(maximum.resolveTextWriters()).isEqualTo(TextWriterPoolConfig.MAX_WRITERS);
+
         OutputOptions above = new OutputOptions();
         above.textWriters = TextWriterPoolConfig.MAX_WRITERS + 1;
         assertThatThrownBy(above::resolveTextWriters)
                 .isInstanceOf(InvalidConfigException.class)
                 .hasMessageContaining(String.valueOf(TextWriterPoolConfig.MIN_WRITERS))
                 .hasMessageContaining(String.valueOf(TextWriterPoolConfig.MAX_WRITERS));
+    }
+
+    @Test
+    void productionWriterQueuesShareOneFixedPoolBudget() {
+        assertThat(ListCommand.datasetWriterQueueCapacityPerLane(3)).isEqualTo(64);
+        assertThat(ListCommand.datasetWriterQueueCapacityPerLane(4)).isEqualTo(64);
+        assertThat(ListCommand.datasetWriterQueueCapacityPerLane(8)).isEqualTo(32);
+        assertThat(ListCommand.datasetWriterQueueCapacityPerLane(64)).isEqualTo(4);
+
+        for (int writers = 1; writers <= 64; writers++) {
+            assertThat((long) writers * ListCommand.datasetWriterQueueCapacityPerLane(writers))
+                    .isLessThanOrEqualTo(ListCommand.DATASET_WRITER_TOTAL_QUEUE_CAPACITY);
+        }
     }
 }

--- a/swath-cli/src/test/java/io/varve/swath/cli/ParquetWriterAdmissionOrderingTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ParquetWriterAdmissionOrderingTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.varve.swath.checkpoint.NodeSpec;
+import io.varve.swath.checkpoint.RunKey;
+import io.varve.swath.checkpoint.RunMeta;
+import io.varve.swath.checkpoint.SoftRestoreContext;
+import io.varve.swath.checkpoint.SqliteCheckpointStore;
+import io.varve.swath.error.InvalidConfigException;
+import io.varve.swath.model.ListingMode;
+import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
+import io.varve.swath.runtime.ArgsHashFields;
+import io.varve.swath.store.ListPage;
+import io.varve.swath.store.PageFetcher;
+import io.varve.swath.store.PageRequest;
+import io.varve.swath.store.StoreCapabilities;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Writer heap admission must fail before external work at both effective-output resolution points. */
+final class ParquetWriterAdmissionOrderingTest {
+
+    private static final String BUCKET = "bucket";
+    private static final String PREFIX = "prefix/";
+
+    @Test
+    void freshRunRejectsBeforeCreatingCheckpointOrFetching(@TempDir Path dir) {
+        AtomicInteger fetches = new AtomicInteger();
+        ListCommand command = command(dir.resolve("dataset"), fetches);
+        Path checkpoint = CheckpointOptions.CheckpointMode.colocatedCheckpoint(
+                Path.of(command.output.destination));
+
+        assertThatThrownBy(command::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("needs a conservative heap plan");
+        assertThat(fetches).hasValue(0);
+        assertThat(checkpoint).doesNotExist();
+    }
+
+    @Test
+    void resumedRunRejectsAfterOutputRestoreButBeforeFetching(@TempDir Path dir) throws Exception {
+        AtomicInteger fetches = new AtomicInteger();
+        Path output = dir.resolve("dataset");
+        Path checkpoint = CheckpointOptions.CheckpointMode.colocatedCheckpoint(output);
+        Files.createDirectories(checkpoint.getParent());
+
+        String argsHash = ArgsHashFields.forListing(
+                "s3", "", BUCKET, PREFIX).hash();
+        RunKey key = new RunKey(
+                "s3", null, BUCKET, PREFIX.getBytes(StandardCharsets.UTF_8), argsHash,
+                "auto", ListingMode.OBJECTS, "", OutputFormat.PARQUET.name(),
+                new SoftRestoreContext(false, null, "us-east-1", false, false,
+                        output.toString(), false, "DIRECTORY", null), false);
+        try (SqliteCheckpointStore store = SqliteCheckpointStore.open(checkpoint)) {
+            RunMeta run = store.openRun(key, false, false);
+            store.insertNode(NodeSpec.rootRange(run.id()));
+        }
+
+        ListCommand command = command(output, fetches);
+        command.checkpoint.resume = true;
+        command.checkpoint.location = checkpoint.toString();
+
+        assertThatThrownBy(command::call)
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("needs a conservative heap plan");
+        assertThat(fetches).hasValue(0);
+    }
+
+    @Test
+    void sortedRunIgnoresDirectDatasetWriterAdmission(@TempDir Path dir) {
+        AtomicInteger fetches = new AtomicInteger();
+        ListCommand command = command(dir.resolve("dataset"), fetches);
+        command.sorting.sort = true;
+
+        assertThatThrownBy(command::call)
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("writer admission must happen before a fetch");
+        assertThat(fetches).hasValue(1);
+    }
+
+    private static ListCommand command(Path output, AtomicInteger fetches) {
+        ListCommand command = new ListCommand();
+        command.uri = "s3://" + BUCKET + "/" + PREFIX;
+        command.output.format = OutputFormat.PARQUET;
+        command.output.destination = output.toString();
+        command.output.parquetWriters = 5;
+        command.connection.region = "us-east-1";
+        command.maxHeapBytesOverride = ParquetWriterMemoryPlan.plannedHeapBytes(5) - 1;
+        command.fetcherOverride = countingFetcher(fetches);
+        return command;
+    }
+
+    private static PageFetcher countingFetcher(AtomicInteger fetches) {
+        return new PageFetcher() {
+            @Override public ListPage fetchPage(PageRequest request) {
+                fetches.incrementAndGet();
+                throw new AssertionError("writer admission must happen before a fetch");
+            }
+
+            @Override public StoreCapabilities capabilities() {
+                return StoreCapabilities.s3();
+            }
+        };
+    }
+}

--- a/swath-cli/src/test/java/io/varve/swath/cli/ParquetWritersValidationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ParquetWritersValidationTest.java
@@ -39,7 +39,8 @@ class ParquetWritersValidationTest {
                 writers, ParquetWriterMemoryPlan.plannedHeapBytes(writers) - 1))
                 .isInstanceOf(InvalidConfigException.class)
                 .hasMessageContaining("needs a conservative heap plan")
-                .hasMessageContaining("raise -Xmx");
+                .hasMessageContaining("maximum heap")
+                .hasMessageContaining("JVM/container memory limit");
     }
 
     @Test

--- a/swath-cli/src/test/java/io/varve/swath/cli/ParquetWritersValidationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ParquetWritersValidationTest.java
@@ -9,28 +9,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.varve.swath.error.InvalidConfigException;
+import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pins the Parquet writer-count bound ("2–4 writers", contract §7 memory
- * model / I11): {@code --tune parquet.writers=N} must be in {@code [2,4]} unless a single-file
- * destination (a {@code .parquet} extension on {@code -o}, replacing the old
- * {@code --single-file} flag) collapses it to one lane. An arbitrary count (e.g. {@code 1000})
- * would create that many row-group buffers and break the bounded-heap invariant.
+ * Pins the Parquet writer admission policy: the established 2-4 envelope is unconditional, while
+ * higher expert counts require enough configured heap for the conservative planning allowance.
  */
 class ParquetWritersValidationTest {
 
     @Test
-    void acceptsTheContractRangeTwoToFour() throws Exception {
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 2)).isEqualTo(2);
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 3)).isEqualTo(3);   // default
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 4)).isEqualTo(4);
+    void acceptsTheReleaseEnvelopeRegardlessOfHeap() throws Exception {
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 2, 1)).isEqualTo(2);
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 3, 1)).isEqualTo(3);
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, 4, 1)).isEqualTo(4);
     }
 
     @Test
-    void rejectsBelowRangeAndAboveRange() {
-        for (int bad : new int[]{0, 1, 5, 64, 1000}) {
-            assertThatThrownBy(() -> OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY, bad))
+    void admitsExpertCountWhenHeapCoversItsPlan() throws Exception {
+        int writers = 12;
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY,
+                writers, ParquetWriterMemoryPlan.plannedHeapBytes(writers))).isEqualTo(writers);
+    }
+
+    @Test
+    void rejectsExpertCountThatExceedsHeapPlan() {
+        int writers = 5;
+        assertThatThrownBy(() -> OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.DIRECTORY,
+                writers, ParquetWriterMemoryPlan.plannedHeapBytes(writers) - 1))
+                .isInstanceOf(InvalidConfigException.class)
+                .hasMessageContaining("needs a conservative heap plan")
+                .hasMessageContaining("raise -Xmx");
+    }
+
+    @Test
+    void rejectsBelowRangeAndAbsoluteResourceCeiling() {
+        for (int bad : new int[]{0, 1, ParquetWriterMemoryPlan.ABSOLUTE_MAX_WRITERS + 1, 1000}) {
+            assertThatThrownBy(() -> OutputOptions.resolveParquetWriters(
+                    OutputOptions.DestinationKind.DIRECTORY, bad, Long.MAX_VALUE))
                     .as("parquet.writers=%d must be rejected", bad)
                     .isInstanceOf(InvalidConfigException.class)
                     .hasMessageContaining("parquet.writers");
@@ -41,8 +57,8 @@ class ParquetWritersValidationTest {
     void singleFileDestinationCollapsesToOneLaneRegardlessOfTheCount() throws Exception {
         // A single-file -o (kind=FILE) is the explicit "one output part" request; it overrides
         // the count (and a value that would otherwise be out of range is irrelevant under it).
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 3)).isEqualTo(1);
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 1)).isEqualTo(1);
-        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 1000)).isEqualTo(1);
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 3, 1)).isEqualTo(1);
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 1, 1)).isEqualTo(1);
+        assertThat(OutputOptions.resolveParquetWriters(OutputOptions.DestinationKind.FILE, 1000, 1)).isEqualTo(1);
     }
 }

--- a/swath-cli/src/test/java/io/varve/swath/cli/TuneOptionsTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/TuneOptionsTest.java
@@ -58,7 +58,7 @@ class TuneOptionsTest {
         String[][] bad = {
                 {"engine.readahead=maybe", "on|off"},
                 {"seed.mode=random", "shallow|none|hints"},
-                {"parquet.writers=9", "integer 2..4"},
+                {"parquet.writers=65", "integer 2..64"},
                 {"summary.interval=zero", "positive duration"},
                 {"sort.ignore-disk-check=yes", "on|off"},
         };

--- a/swath-cli/src/test/resources/help/swath-list.txt
+++ b/swath-cli/src/test/resources/help/swath-list.txt
@@ -56,7 +56,7 @@ Output:
       --text-part-size=SIZE  Target uncompressed text part size (default:
                                256mb).
       --text-writers=N       Parallel writers for a TSV/JSONL directory dataset
-                               (default: 3; range: 2-4).
+                               (default: 3; range: 2-64).
 
 Connection:
       --bearer-token-command=CMD

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -844,6 +844,11 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
     private static void writeDatasetWriter(
             ObjectNode node, RunSummary.DatasetWriterSummary writer) {
         node.put("format", writer.format());
+        node.put("writer_count", writer.writerCount());
+        node.put("total_queue_capacity", writer.totalQueueCapacity());
+        node.put("jvm_max_heap_bytes", writer.jvmMaxHeapBytes());
+        putLongOrNullBoxed(node, "buffer_bytes_per_writer", writer.bufferBytesPerWriter());
+        putLongOrNullBoxed(node, "planned_heap_bytes", writer.plannedHeapBytes());
         node.put("submit_blocked_count", writer.submitBlockedCount());
         node.put("submit_blocked_ms", nanosToMillis(writer.submitBlockedNanos()));
         node.put("head_of_line_blocked_count", writer.headOfLineBlockedCount());
@@ -973,6 +978,14 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
             node.putNull(field);
         } else {
             node.put(field, value.doubleValue());
+        }
+    }
+
+    private static void putLongOrNullBoxed(ObjectNode node, String field, Long value) {
+        if (value == null) {
+            node.putNull(field);
+        } else {
+            node.put(field, value.longValue());
         }
     }
 

--- a/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/JsonRunSummaryWriter.java
@@ -846,9 +846,19 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
         node.put("format", writer.format());
         node.put("writer_count", writer.writerCount());
         node.put("total_queue_capacity", writer.totalQueueCapacity());
+        node.put("part_rotation_interval_ms", nanosToMillis(writer.partRotationIntervalNanos()));
+        node.put("part_rotation_max_rows", writer.partRotationMaxRows());
         node.put("jvm_max_heap_bytes", writer.jvmMaxHeapBytes());
-        putLongOrNullBoxed(node, "buffer_bytes_per_writer", writer.bufferBytesPerWriter());
+        putLongOrNullBoxed(node, "row_group_target_bytes_per_writer",
+                writer.rowGroupTargetBytesPerWriter());
+        putIntegerOrNull(node, "row_group_allowance_multiplier",
+                writer.rowGroupAllowanceMultiplier());
         putLongOrNullBoxed(node, "planned_heap_bytes", writer.plannedHeapBytes());
+        putBooleanOrNull(node, "heap_admission_applied", writer.heapAdmissionApplied());
+        node.put("part_digest_count", writer.partDigestCount());
+        node.put("part_digest_ms", nanosToMillis(writer.partDigestNanos()));
+        node.put("manifest_write_count", writer.manifestWriteCount());
+        node.put("manifest_write_ms", nanosToMillis(writer.manifestWriteNanos()));
         node.put("submit_blocked_count", writer.submitBlockedCount());
         node.put("submit_blocked_ms", nanosToMillis(writer.submitBlockedNanos()));
         node.put("head_of_line_blocked_count", writer.headOfLineBlockedCount());
@@ -986,6 +996,22 @@ public final class JsonRunSummaryWriter implements AutoCloseable {
             node.putNull(field);
         } else {
             node.put(field, value.longValue());
+        }
+    }
+
+    private static void putIntegerOrNull(ObjectNode node, String field, Integer value) {
+        if (value == null) {
+            node.putNull(field);
+        } else {
+            node.put(field, value);
+        }
+    }
+
+    private static void putBooleanOrNull(ObjectNode node, String field, Boolean value) {
+        if (value == null) {
+            node.putNull(field);
+        } else {
+            node.put(field, value);
         }
     }
 

--- a/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunMetrics.java
@@ -2482,7 +2482,7 @@ public final class RunMetrics {
                 // Per-page client-service-cost spans -- same shape and same cheapness (an empty
                 // list when no page was ever serviced); never null.
                 buildClientCostSummary(),
-                // Parallel directory datasets only. The supplier reads a fixed 1–4 lane array; no
+                // Parallel directory datasets only. The supplier reads a bounded lane array; no
                 // lane-id metric tags and no unbounded state. Null when no shared pool was constructed.
                 datasetWriterSummary(),
                 // Demand-gate T-vs-Tmax visibility -- null when OWNER_SPLIT.demand_gated never

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -118,9 +118,17 @@ public record RunSummary(
             String format,
             int writerCount,
             long totalQueueCapacity,
+            long partRotationIntervalNanos,
+            long partRotationMaxRows,
             long jvmMaxHeapBytes,
-            Long bufferBytesPerWriter,
+            Long rowGroupTargetBytesPerWriter,
+            Integer rowGroupAllowanceMultiplier,
             Long plannedHeapBytes,
+            Boolean heapAdmissionApplied,
+            long partDigestCount,
+            long partDigestNanos,
+            long manifestWriteCount,
+            long manifestWriteNanos,
             long submitBlockedCount,
             long submitBlockedNanos,
             long headOfLineBlockedCount,
@@ -131,13 +139,13 @@ public record RunSummary(
             lanes = List.copyOf(lanes);
         }
 
-        public static DatasetWriterSummary from(String format, List<DatasetWriterLane> lanes) {
-            return from(format, lanes, null, null);
-        }
-
         public static DatasetWriterSummary from(
                 String format, List<DatasetWriterLane> lanes,
-                Long bufferBytesPerWriter, Long plannedHeapBytes) {
+                long partRotationIntervalNanos, long partRotationMaxRows,
+                long partDigestCount, long partDigestNanos,
+                long manifestWriteCount, long manifestWriteNanos,
+                Long rowGroupTargetBytesPerWriter, Integer rowGroupAllowanceMultiplier,
+                Long plannedHeapBytes, Boolean heapAdmissionApplied) {
             long submitBlockedCount = 0L;
             long submitBlockedNanos = 0L;
             long headOfLineBlockedCount = 0L;
@@ -151,7 +159,10 @@ public record RunSummary(
                 headOfLineBlockedNanos += lane.headOfLineBlockedNanos();
             }
             return new DatasetWriterSummary(format, lanes.size(), totalQueueCapacity,
-                    Runtime.getRuntime().maxMemory(), bufferBytesPerWriter, plannedHeapBytes,
+                    partRotationIntervalNanos, partRotationMaxRows, Runtime.getRuntime().maxMemory(),
+                    rowGroupTargetBytesPerWriter, rowGroupAllowanceMultiplier, plannedHeapBytes,
+                    heapAdmissionApplied, partDigestCount, partDigestNanos,
+                    manifestWriteCount, manifestWriteNanos,
                     submitBlockedCount, submitBlockedNanos,
                     headOfLineBlockedCount, headOfLineBlockedNanos, lanes);
         }

--- a/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
+++ b/swath-core/src/main/java/io/varve/swath/observability/RunSummary.java
@@ -116,6 +116,11 @@ public record RunSummary(
      */
     public record DatasetWriterSummary(
             String format,
+            int writerCount,
+            long totalQueueCapacity,
+            long jvmMaxHeapBytes,
+            Long bufferBytesPerWriter,
+            Long plannedHeapBytes,
             long submitBlockedCount,
             long submitBlockedNanos,
             long headOfLineBlockedCount,
@@ -127,17 +132,27 @@ public record RunSummary(
         }
 
         public static DatasetWriterSummary from(String format, List<DatasetWriterLane> lanes) {
+            return from(format, lanes, null, null);
+        }
+
+        public static DatasetWriterSummary from(
+                String format, List<DatasetWriterLane> lanes,
+                Long bufferBytesPerWriter, Long plannedHeapBytes) {
             long submitBlockedCount = 0L;
             long submitBlockedNanos = 0L;
             long headOfLineBlockedCount = 0L;
             long headOfLineBlockedNanos = 0L;
+            long totalQueueCapacity = 0L;
             for (DatasetWriterLane lane : lanes) {
+                totalQueueCapacity += lane.queueCapacity();
                 submitBlockedCount += lane.submitBlockedCount();
                 submitBlockedNanos += lane.submitBlockedNanos();
                 headOfLineBlockedCount += lane.headOfLineBlockedCount();
                 headOfLineBlockedNanos += lane.headOfLineBlockedNanos();
             }
-            return new DatasetWriterSummary(format, submitBlockedCount, submitBlockedNanos,
+            return new DatasetWriterSummary(format, lanes.size(), totalQueueCapacity,
+                    Runtime.getRuntime().maxMemory(), bufferBytesPerWriter, plannedHeapBytes,
+                    submitBlockedCount, submitBlockedNanos,
                     headOfLineBlockedCount, headOfLineBlockedNanos, lanes);
         }
     }

--- a/swath-core/src/main/java/io/varve/swath/output/ParquetFormatter.java
+++ b/swath-core/src/main/java/io/varve/swath/output/ParquetFormatter.java
@@ -24,7 +24,7 @@ import org.apache.commons.codec.digest.DigestUtils;
  *
  * <p>This is the one-instance-per-sink realization of the sealed SPI. The {@code list} CLI's
  * default Parquet path is the decoupled multi-writer {@link io.varve.swath.output.parquet.ParquetWriterPool}
- * (§4.1/§7 memory model: 2–4 writers decoupled from {@code T}); this formatter is the
+ * (§4.1/§7 memory model: bounded writers decoupled from {@code T}); this formatter is the
  * single-writer sink that the {@code EntryFormatter} contract describes. Both emit the same
  * canonical schema and the same manifest shape, so either is readable by the INT-6 readers.
  */

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
@@ -7,10 +7,6 @@ package io.varve.swath.output.dataset;
 
 import io.varve.swath.observability.RunMetrics;
 import io.varve.swath.observability.RunSummary;
-import io.varve.swath.output.OutputFormat;
-import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
-import io.varve.swath.output.parquet.PartWriter;
-import java.util.Locale;
 
 /** Shared bounded-summary wiring for every parallel directory-dataset writer. */
 public final class DatasetWriterMetrics {
@@ -18,14 +14,11 @@ public final class DatasetWriterMetrics {
     }
 
     public static void registerSummary(
-            RunMetrics metrics, OutputFormat format, SharedDatasetWriterPool writerPool) {
+            RunMetrics metrics, String format, SharedDatasetWriterPool writerPool,
+            DatasetWriterResourcePlan resourcePlan) {
         if (metrics == null) {
             return;
         }
-        String summaryFormat = switch (format) {
-            case PARQUET, TSV, JSONL -> format.name().toLowerCase(Locale.ROOT);
-            case TABLE -> throw new IllegalArgumentException("parallel dataset format required");
-        };
         metrics.registerDatasetWriterSummary(() -> {
             var lanes = writerPool.laneStatistics().stream()
                         .map(s -> new RunSummary.DatasetWriterLane(
@@ -35,12 +28,14 @@ public final class DatasetWriterMetrics {
                                 s.headOfLineBlockedCount(), s.headOfLineBlockedNanos(),
                                 s.partsFinalized(), s.finalizeCount(), s.finalizeElapsedNanos()))
                         .toList();
-            Long bufferBytesPerWriter = format == OutputFormat.PARQUET
-                    ? PartWriter.ROW_GROUP_BYTES : null;
-            Long plannedHeapBytes = format == OutputFormat.PARQUET
-                    ? ParquetWriterMemoryPlan.plannedHeapBytes(lanes.size()) : null;
             return RunSummary.DatasetWriterSummary.from(
-                    summaryFormat, lanes, bufferBytesPerWriter, plannedHeapBytes);
+                    format, lanes,
+                    writerPool.rotationIntervalNanos(), writerPool.rotationMaxRows(),
+                    writerPool.partDigestCount(), writerPool.partDigestNanos(),
+                    writerPool.manifestWriteCount(), writerPool.manifestWriteNanos(),
+                    resourcePlan.rowGroupTargetBytesPerWriter(),
+                    resourcePlan.rowGroupAllowanceMultiplier(),
+                    resourcePlan.plannedHeapBytes(), resourcePlan.heapAdmissionApplied());
         });
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterMetrics.java
@@ -8,6 +8,8 @@ package io.varve.swath.output.dataset;
 import io.varve.swath.observability.RunMetrics;
 import io.varve.swath.observability.RunSummary;
 import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.parquet.ParquetWriterMemoryPlan;
+import io.varve.swath.output.parquet.PartWriter;
 import java.util.Locale;
 
 /** Shared bounded-summary wiring for every parallel directory-dataset writer. */
@@ -24,15 +26,21 @@ public final class DatasetWriterMetrics {
             case PARQUET, TSV, JSONL -> format.name().toLowerCase(Locale.ROOT);
             case TABLE -> throw new IllegalArgumentException("parallel dataset format required");
         };
-        metrics.registerDatasetWriterSummary(() -> RunSummary.DatasetWriterSummary.from(
-                summaryFormat,
-                writerPool.laneStatistics().stream()
+        metrics.registerDatasetWriterSummary(() -> {
+            var lanes = writerPool.laneStatistics().stream()
                         .map(s -> new RunSummary.DatasetWriterLane(
                                 s.lane(), s.queueCapacity(), s.queueDepth(), s.queueDepthPeak(),
                                 s.waitingForWork(), s.rowsWritten(), s.finalizedBytes(), s.batchesWritten(),
                                 s.activeElapsedNanos(), s.submitBlockedCount(), s.submitBlockedNanos(),
                                 s.headOfLineBlockedCount(), s.headOfLineBlockedNanos(),
                                 s.partsFinalized(), s.finalizeCount(), s.finalizeElapsedNanos()))
-                        .toList()));
+                        .toList();
+            Long bufferBytesPerWriter = format == OutputFormat.PARQUET
+                    ? PartWriter.ROW_GROUP_BYTES : null;
+            Long plannedHeapBytes = format == OutputFormat.PARQUET
+                    ? ParquetWriterMemoryPlan.plannedHeapBytes(lanes.size()) : null;
+            return RunSummary.DatasetWriterSummary.from(
+                    summaryFormat, lanes, bufferBytesPerWriter, plannedHeapBytes);
+        });
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterResourcePlan.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetWriterResourcePlan.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+/**
+ * Format-owned, static resource context for a parallel dataset writer pool. Fields are nullable
+ * when the format has no comparable fixed buffer or heap-admission model.
+ */
+public record DatasetWriterResourcePlan(
+        Long rowGroupTargetBytesPerWriter,
+        Integer rowGroupAllowanceMultiplier,
+        Long plannedHeapBytes,
+        Boolean heapAdmissionApplied) {
+
+    public static final DatasetWriterResourcePlan NONE =
+            new DatasetWriterResourcePlan(null, null, null, null);
+}

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
@@ -157,6 +158,10 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     private final Scope scope;
     private final List<Future<?>> laneFutures = new ArrayList<>();
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private final AtomicLong partDigestCount = new AtomicLong();
+    private final AtomicLong partDigestNanos = new AtomicLong();
+    private final AtomicLong manifestWriteCount = new AtomicLong();
+    private final AtomicLong manifestWriteNanos = new AtomicLong();
 
     private final List<PartInfo> committedParts = Collections.synchronizedList(new ArrayList<>());
     private final Object manifestLock = new Object();
@@ -188,6 +193,13 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             throw new IllegalArgumentException(
                     "numWriters must be 1.." + MAX_WRITERS + " (got " + numWriters + ")");
         }
+        if (queueCapacity < 1
+                || (long) numWriters * queueCapacity > MAX_TOTAL_QUEUE_CAPACITY) {
+            throw new IllegalArgumentException("queueCapacity must be at least 1 and keep aggregate "
+                    + "writer queue capacity <= " + MAX_TOTAL_QUEUE_CAPACITY + " batches (writers="
+                    + numWriters + ", queueCapacity=" + queueCapacity + ", aggregate="
+                    + (long) numWriters * queueCapacity + ")");
+        }
         this.dir = dir;
         this.sinkName = config.sinkName();
         this.scope = Scope.ofPlatformThreads(sinkName + "-writer");
@@ -205,8 +217,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         this.committedParts.addAll(config.existingParts());
         this.lanes = new Lane[this.numWriters];
         for (int i = 0; i < this.numWriters; i++) {
-            int capacity = Math.max(1, queueCapacity);
-            lanes[i] = new Lane(i, capacity, new ArrayBlockingQueue<>(capacity));
+            lanes[i] = new Lane(i, queueCapacity, new ArrayBlockingQueue<>(queueCapacity));
         }
         // Resume: continue each lane's part sequence PAST any carried-over part so a
         // resumed run never reuses (and so overwrites) a prior finalized part's filename.
@@ -293,6 +304,13 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             return committedParts.stream().mapToLong(PartInfo::bytes).sum();
         }
     }
+
+    long rotationIntervalNanos() { return rotationIntervalNanos; }
+    long rotationMaxRows() { return rotationMaxRows; }
+    long partDigestCount() { return partDigestCount.get(); }
+    long partDigestNanos() { return partDigestNanos.get(); }
+    long manifestWriteCount() { return manifestWriteCount.get(); }
+    long manifestWriteNanos() { return manifestWriteNanos.get(); }
 
     private void checkFailure() throws OutputException {
         Throwable t = failure.get();
@@ -527,8 +545,12 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         // manifest rewrite (which would be O(n²)).
         String relPath = DatasetLayout.key(path.getFileName().toString());
         String md5;
+        long digestStartedAt = nanoClock.getAsLong();
         try (var in = Files.newInputStream(path)) {
             md5 = DigestUtils.md5Hex(in);
+        } finally {
+            partDigestCount.incrementAndGet();
+            partDigestNanos.addAndGet(Math.max(0L, nanoClock.getAsLong() - digestStartedAt));
         }
         // When the sink wires a durable listener, its checkpoint commit (record part + advance
         // durable_cursor) is the exactly-once boundary BEFORE the manifest. Text wires NONE.
@@ -582,10 +604,39 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     }
 
     private void writeManifest() throws IOException {
-        synchronized (manifestLock) {
-            Manifest.write(dir, bucket, format.manifestFormat(), format.manifestSchema(),
-                    snapshotParts(), false, null);
+        long startedAt = nanoClock.getAsLong();
+        try {
+            synchronized (manifestLock) {
+                // Snapshot under the publication lock. Otherwise lane A can snapshot an older
+                // part set, lane B can publish a newer set, and A can then overwrite it after
+                // finally acquiring this lock.
+                writeManifestLocked(snapshotParts());
+            }
+        } finally {
+            recordManifestWrite(startedAt);
         }
+    }
+
+    /** Includes time queued behind another lane on {@link #manifestLock}. */
+    private void writeManifest(List<PartInfo> parts) throws IOException {
+        long startedAt = nanoClock.getAsLong();
+        try {
+            synchronized (manifestLock) {
+                writeManifestLocked(parts);
+            }
+        } finally {
+            recordManifestWrite(startedAt);
+        }
+    }
+
+    private void writeManifestLocked(List<PartInfo> parts) throws IOException {
+        Manifest.write(dir, bucket, format.manifestFormat(), format.manifestSchema(),
+                parts, false, null);
+    }
+
+    private void recordManifestWrite(long startedAt) {
+        manifestWriteCount.incrementAndGet();
+        manifestWriteNanos.addAndGet(Math.max(0L, nanoClock.getAsLong() - startedAt));
     }
 
     private List<PartInfo> snapshotParts() {
@@ -634,14 +685,11 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     private void publishSuccess() throws OutputException {
         if (publicationInitiated.compareAndSet(false, true)) {
             try {
-                synchronized (manifestLock) {
-                    List<PartInfo> snapshot = snapshotParts();
-                    Manifest.write(dir, bucket, format.manifestFormat(), format.manifestSchema(),
-                            snapshot, false, null);   // ensure a manifest exists
-                    Manifest.writeState(dir, argsHash, null);
-                    Manifest.writeSymlink(dir, snapshot);
-                    Manifest.writeSuccess(dir);   // LAST — the whole-snapshot completion marker
-                }
+                List<PartInfo> snapshot = snapshotParts();
+                writeManifest(snapshot);   // ensure a manifest exists
+                Manifest.writeState(dir, argsHash, null);
+                Manifest.writeSymlink(dir, snapshot);
+                Manifest.writeSuccess(dir);   // LAST — the whole-snapshot completion marker
                 published.complete(null);
             } catch (Throwable t) {
                 published.completeExceptionally(t);

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -36,8 +36,8 @@ import java.util.function.LongSupplier;
 import org.apache.commons.codec.digest.DigestUtils;
 
 /**
- * A format-neutral, decoupled dataset writer pool: {@code numWriters} lanes
- * (2–4, default 3), each on its own platform thread draining a bounded queue, so
+ * A format-neutral, decoupled dataset writer pool: a bounded number of {@code numWriters} lanes
+ * (default 3), each on its own platform thread draining a bounded queue, so
  * sink I/O runs away from the listing workers. <b>Sticky</b> assignment — every
  * page of a node goes to {@code writer = nodeId % numWriters}, so a node's pages
  * occupy a contiguous run of one lane's size-rotated parts (which finalize in
@@ -65,6 +65,27 @@ import org.apache.commons.codec.digest.DigestUtils;
  * either trigger.
  */
 public final class SharedDatasetWriterPool implements DatasetWriterPool {
+
+    /** Defensive process-resource ceiling; format-specific policy may admit fewer lanes. */
+    public static final int MAX_WRITERS = 64;
+
+    /**
+     * Whole-pool production submission ceiling in batches. This equals the former maximum of 64
+     * slots for each of four lanes, but no longer grows when an expert requests more writers.
+     */
+    public static final int MAX_TOTAL_QUEUE_CAPACITY = 4 * 64;
+
+    /** Preserve the existing queue depth for every count in the measured 1-4 lane envelope. */
+    public static final int DEFAULT_QUEUE_CAPACITY_PER_LANE = 64;
+
+    /** Equal per-lane share whose pool-wide product never exceeds the production budget. */
+    public static int defaultQueueCapacityPerLane(int writers) {
+        if (writers < 1 || writers > MAX_WRITERS) {
+            throw new IllegalArgumentException("writers must be 1.." + MAX_WRITERS);
+        }
+        return Math.max(1, Math.min(DEFAULT_QUEUE_CAPACITY_PER_LANE,
+                MAX_TOTAL_QUEUE_CAPACITY / writers));
+    }
 
     /**
      * A bounded snapshot of one writer lane. All durations are elapsed time, not CPU
@@ -163,6 +184,10 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     public SharedDatasetWriterPool(Path dir, DatasetFormat format, String argsHash,
                       int numWriters, long targetBytes, int queueCapacity,
                       DatasetWriterPoolConfig config, LongSupplier nanoClock) {
+        if (numWriters < 1 || numWriters > MAX_WRITERS) {
+            throw new IllegalArgumentException(
+                    "numWriters must be 1.." + MAX_WRITERS + " (got " + numWriters + ")");
+        }
         this.dir = dir;
         this.sinkName = config.sinkName();
         this.scope = Scope.ofPlatformThreads(sinkName + "-writer");
@@ -170,7 +195,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         this.format = format;
         this.argsHash = argsHash;
         this.bucket = config.bucket();
-        this.numWriters = Math.max(1, numWriters);
+        this.numWriters = numWriters;
         this.targetBytes = targetBytes;
         this.rotationIntervalNanos = config.rotationIntervalNanos();
         this.rotationMaxRows = config.rotationMaxRows();
@@ -219,7 +244,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             int laneId = (int) Math.floorMod(batch.nodeId(), numWriters);
             Lane lane = lanes[laneId];
             if (!lane.queue.offer(batch)) {
-                // Pay for the clock and the 2–4-lane scan only on the saturated path. This is the
+                // Pay for the clock and bounded cross-lane scan only on the saturated path. This is the
                 // missing middle link between consumer-side emit and worker-side channel wait.
                 lane.queueDepthPeak.getAndAccumulate(lane.queueCapacity, Math::max);
                 boolean headOfLine = anotherLaneIsWaitingForWork(laneId);

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlan.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlan.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.parquet;
+
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
+
+/**
+ * Conservative admission plan for Parquet writer concurrency above the measured release envelope.
+ *
+ * <p>The first four lanes retain the compatibility contract established by PERF-2. Counts above
+ * four are expert configuration: they are admitted only when {@code -Xmx} can cover a deliberately
+ * conservative planning allowance for every row-group buffer plus a fixed JVM/pipeline reserve.
+ * This is an admission guard, not a claim about actual peak heap; parquet-mr, compression, key
+ * shape, and the JVM still require measurement on the target workload.
+ */
+public final class ParquetWriterMemoryPlan {
+    public static final int RELEASE_ENVELOPE_MAX_WRITERS = 4;
+    public static final int ABSOLUTE_MAX_WRITERS = SharedDatasetWriterPool.MAX_WRITERS;
+
+    /** JVM, queue, model, and orchestration headroom retained before admitting extra lanes. */
+    public static final long BASE_HEAP_RESERVE_BYTES = 256L * 1024 * 1024;
+
+    /** parquet-mr can materially exceed the nominal uncompressed row-group size. */
+    public static final int ROW_GROUP_ALLOWANCE_MULTIPLIER = 4;
+
+    private ParquetWriterMemoryPlan() {
+    }
+
+    /** Planning allowance reported to operators; it is intentionally not an observed peak. */
+    public static long plannedHeapBytes(int writers) {
+        requireWriterRange(writers);
+        return BASE_HEAP_RESERVE_BYTES
+                + (long) writers * PartWriter.ROW_GROUP_BYTES * ROW_GROUP_ALLOWANCE_MULTIPLIER;
+    }
+
+    /** Largest expert count this heap admits, always preserving the established 2-4 envelope. */
+    public static int maxWritersForHeap(long maxHeapBytes) {
+        if (maxHeapBytes <= BASE_HEAP_RESERVE_BYTES) {
+            return RELEASE_ENVELOPE_MAX_WRITERS;
+        }
+        long perWriter = PartWriter.ROW_GROUP_BYTES * ROW_GROUP_ALLOWANCE_MULTIPLIER;
+        long heapLimited = (maxHeapBytes - BASE_HEAP_RESERVE_BYTES) / perWriter;
+        return (int) Math.min(ABSOLUTE_MAX_WRITERS,
+                Math.max(RELEASE_ENVELOPE_MAX_WRITERS, heapLimited));
+    }
+
+    private static void requireWriterRange(int writers) {
+        if (writers < 1 || writers > ABSOLUTE_MAX_WRITERS) {
+            throw new IllegalArgumentException(
+                    "writers must be 1.." + ABSOLUTE_MAX_WRITERS + " (got " + writers + ")");
+        }
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlan.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlan.java
@@ -11,7 +11,7 @@ import io.varve.swath.output.dataset.SharedDatasetWriterPool;
  * Conservative admission plan for Parquet writer concurrency above the measured release envelope.
  *
  * <p>The first four lanes retain the compatibility contract established by PERF-2. Counts above
- * four are expert configuration: they are admitted only when {@code -Xmx} can cover a deliberately
+ * four are expert configuration: they are admitted only when the JVM maximum heap can cover a deliberately
  * conservative planning allowance for every row-group buffer plus a fixed JVM/pipeline reserve.
  * This is an admission guard, not a claim about actual peak heap; parquet-mr, compression, key
  * shape, and the JVM still require measurement on the target workload.
@@ -36,7 +36,11 @@ public final class ParquetWriterMemoryPlan {
                 + (long) writers * PartWriter.ROW_GROUP_BYTES * ROW_GROUP_ALLOWANCE_MULTIPLIER;
     }
 
-    /** Largest expert count this heap admits, always preserving the established 2-4 envelope. */
+    /**
+     * Largest count this heap admits above the release envelope. The established 2-4 envelope is
+     * returned even when this planning formula would admit fewer, because compatibility counts are
+     * deliberately not subject to the expert gate.
+     */
     public static int maxWritersForHeap(long maxHeapBytes) {
         if (maxHeapBytes <= BASE_HEAP_RESERVE_BYTES) {
             return RELEASE_ENVELOPE_MAX_WRITERS;

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetWriterPool.java
@@ -14,6 +14,7 @@ import io.varve.swath.output.dataset.DatasetWriterMetrics;
 import io.varve.swath.output.dataset.DatasetWriterObserver;
 import io.varve.swath.output.dataset.DatasetWriterPool;
 import io.varve.swath.output.dataset.DatasetWriterPoolConfig;
+import io.varve.swath.output.dataset.DatasetWriterResourcePlan;
 import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import java.nio.file.Path;
 import java.util.function.LongSupplier;
@@ -33,7 +34,7 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                              ParquetWriterPoolConfig config) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config));
-        DatasetWriterMetrics.registerSummary(config.metrics(), OutputFormat.PARQUET, delegate);
+        registerSummary(config.metrics(), writers);
     }
 
     ParquetWriterPool(Path dir, MessageType schema, String argsHash,
@@ -41,7 +42,17 @@ public final class ParquetWriterPool implements DatasetWriterPool {
                       ParquetWriterPoolConfig config, LongSupplier nanoClock) {
         delegate = new SharedDatasetWriterPool(dir, new ParquetDatasetFormat(schema), argsHash,
                 writers, targetBytes, queueCapacity, sharedConfig(config), nanoClock);
-        DatasetWriterMetrics.registerSummary(config.metrics(), OutputFormat.PARQUET, delegate);
+        registerSummary(config.metrics(), writers);
+    }
+
+    private void registerSummary(RunMetrics metrics, int writers) {
+        var resourcePlan = new DatasetWriterResourcePlan(
+                PartWriter.ROW_GROUP_BYTES,
+                ParquetWriterMemoryPlan.ROW_GROUP_ALLOWANCE_MULTIPLIER,
+                ParquetWriterMemoryPlan.plannedHeapBytes(writers),
+                writers > ParquetWriterMemoryPlan.RELEASE_ENVELOPE_MAX_WRITERS);
+        DatasetWriterMetrics.registerSummary(metrics, OutputFormat.PARQUET.name().toLowerCase(),
+                delegate, resourcePlan);
     }
 
     private static DatasetWriterPoolConfig sharedConfig(ParquetWriterPoolConfig config) {

--- a/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPool.java
@@ -13,9 +13,11 @@ import io.varve.swath.output.dataset.DatasetWriterMetrics;
 import io.varve.swath.output.dataset.DatasetWriterObserver;
 import io.varve.swath.output.dataset.DatasetWriterPool;
 import io.varve.swath.output.dataset.DatasetWriterPoolConfig;
+import io.varve.swath.output.dataset.DatasetWriterResourcePlan;
 import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import io.varve.swath.output.parquet.PartListener;
 import java.util.List;
+import java.util.Locale;
 
 /** Text facade over the shared dataset writer implementation. */
 public final class TextWriterPool implements DatasetWriterPool {
@@ -29,7 +31,9 @@ public final class TextWriterPool implements DatasetWriterPool {
                 config.rotationIntervalNanos(), config.rotationMaxRows(), observer(config.metrics()));
         delegate = new SharedDatasetWriterPool(config.directory(), format, config.argsHash(),
                 config.writers(), config.targetBytes(), config.queueCapacity(), poolConfig);
-        DatasetWriterMetrics.registerSummary(config.metrics(), config.format(), delegate);
+        DatasetWriterMetrics.registerSummary(config.metrics(),
+                config.format().name().toLowerCase(Locale.ROOT), delegate,
+                DatasetWriterResourcePlan.NONE);
     }
 
     private static DatasetWriterObserver observer(RunMetrics metrics) {

--- a/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPoolConfig.java
+++ b/swath-core/src/main/java/io/varve/swath/output/text/TextWriterPoolConfig.java
@@ -7,6 +7,7 @@ package io.varve.swath.output.text;
 
 import io.varve.swath.observability.RunMetrics;
 import io.varve.swath.output.OutputFormat;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import java.nio.file.Path;
 
 /** Complete, validated construction input for a partitioned text dataset sink. */
@@ -15,7 +16,7 @@ public record TextWriterPoolConfig(
         String argsHash, String bucket, int writers, long targetBytes, int queueCapacity,
         long rotationIntervalNanos, long rotationMaxRows, RunMetrics metrics) {
     public static final int MIN_WRITERS = 2;
-    public static final int MAX_WRITERS = 4;
+    public static final int MAX_WRITERS = SharedDatasetWriterPool.MAX_WRITERS;
 
     public TextWriterPoolConfig(
             Path directory, OutputFormat format, TextCompression compression, boolean escape,

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -74,7 +74,9 @@ final class JsonRunSummaryWriterTest {
                 new RunSummary.DatasetWriterLane(
                         1, 8, 0, 4, true, 400L, 4000L, 4L, 8_000_000L,
                         0L, 0L, 0L, 0L, 1L, 1L, 2_000_000L)),
-                64L * 1024 * 1024, 768L * 1024 * 1024);
+                30_000_000_000L, 2_000_000L,
+                3L, 6_000_000L, 4L, 10_000_000L,
+                64L * 1024 * 1024, 4, 768L * 1024 * 1024, false);
     }
 
     private static RunSummary.ShapeSummary shape() {
@@ -250,9 +252,18 @@ final class JsonRunSummaryWriterTest {
         assertThat(datasetWriter.get("format").asText()).isEqualTo("parquet");
         assertThat(datasetWriter.get("writer_count").asInt()).isEqualTo(2);
         assertThat(datasetWriter.get("total_queue_capacity").asLong()).isEqualTo(16L);
+        assertThat(datasetWriter.get("part_rotation_interval_ms").asDouble()).isEqualTo(30_000.0);
+        assertThat(datasetWriter.get("part_rotation_max_rows").asLong()).isEqualTo(2_000_000L);
         assertThat(datasetWriter.get("jvm_max_heap_bytes").asLong()).isPositive();
-        assertThat(datasetWriter.get("buffer_bytes_per_writer").asLong()).isEqualTo(64L * 1024 * 1024);
+        assertThat(datasetWriter.get("row_group_target_bytes_per_writer").asLong())
+                .isEqualTo(64L * 1024 * 1024);
+        assertThat(datasetWriter.get("row_group_allowance_multiplier").asInt()).isEqualTo(4);
         assertThat(datasetWriter.get("planned_heap_bytes").asLong()).isEqualTo(768L * 1024 * 1024);
+        assertThat(datasetWriter.get("heap_admission_applied").asBoolean()).isFalse();
+        assertThat(datasetWriter.get("part_digest_count").asLong()).isEqualTo(3L);
+        assertThat(datasetWriter.get("part_digest_ms").asDouble()).isEqualTo(6.0);
+        assertThat(datasetWriter.get("manifest_write_count").asLong()).isEqualTo(4L);
+        assertThat(datasetWriter.get("manifest_write_ms").asDouble()).isEqualTo(10.0);
         assertThat(datasetWriter.get("submit_blocked_count").asLong()).isEqualTo(2L);
         assertThat(datasetWriter.get("submit_blocked_ms").asDouble()).isEqualTo(4.0);
         assertThat(datasetWriter.get("head_of_line_blocked_count").asLong()).isEqualTo(1L);

--- a/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/JsonRunSummaryWriterTest.java
@@ -73,7 +73,8 @@ final class JsonRunSummaryWriterTest {
                         2L, 4_000_000L, 1L, 3_000_000L, 2L, 2L, 5_000_000L),
                 new RunSummary.DatasetWriterLane(
                         1, 8, 0, 4, true, 400L, 4000L, 4L, 8_000_000L,
-                        0L, 0L, 0L, 0L, 1L, 1L, 2_000_000L)));
+                        0L, 0L, 0L, 0L, 1L, 1L, 2_000_000L)),
+                64L * 1024 * 1024, 768L * 1024 * 1024);
     }
 
     private static RunSummary.ShapeSummary shape() {
@@ -247,6 +248,11 @@ final class JsonRunSummaryWriterTest {
 
         JsonNode datasetWriter = root.get("dataset_writer");
         assertThat(datasetWriter.get("format").asText()).isEqualTo("parquet");
+        assertThat(datasetWriter.get("writer_count").asInt()).isEqualTo(2);
+        assertThat(datasetWriter.get("total_queue_capacity").asLong()).isEqualTo(16L);
+        assertThat(datasetWriter.get("jvm_max_heap_bytes").asLong()).isPositive();
+        assertThat(datasetWriter.get("buffer_bytes_per_writer").asLong()).isEqualTo(64L * 1024 * 1024);
+        assertThat(datasetWriter.get("planned_heap_bytes").asLong()).isEqualTo(768L * 1024 * 1024);
         assertThat(datasetWriter.get("submit_blocked_count").asLong()).isEqualTo(2L);
         assertThat(datasetWriter.get("submit_blocked_ms").asDouble()).isEqualTo(4.0);
         assertThat(datasetWriter.get("head_of_line_blocked_count").asLong()).isEqualTo(1L);

--- a/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/observability/RunMetricsSummaryAssemblyCharacterizationTest.java
@@ -86,12 +86,18 @@ final class RunMetricsSummaryAssemblyCharacterizationTest {
     void latestDatasetPoolRegistrationOwnsTheSummary() {
         RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
         metrics.registerDatasetWriterSummary(
-                () -> RunSummary.DatasetWriterSummary.from("parquet", List.of()));
+                () -> emptyDatasetWriter("parquet"));
         metrics.registerDatasetWriterSummary(
-                () -> RunSummary.DatasetWriterSummary.from("tsv", List.of()));
+                () -> emptyDatasetWriter("tsv"));
 
         assertThat(metrics.summary(Duration.ZERO, "work_stealing", 0L, 0L)
                 .datasetWriter().format()).isEqualTo("tsv");
+    }
+
+    private static RunSummary.DatasetWriterSummary emptyDatasetWriter(String format) {
+        return RunSummary.DatasetWriterSummary.from(
+                format, List.of(), 0L, 0L, 0L, 0L, 0L, 0L,
+                null, null, null, null);
     }
 
     @Test

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/DatasetWriterScalingBenchmark.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/DatasetWriterScalingBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.parquet;
+
+import static io.varve.swath.output.parquet.ParquetPoolTestSupport.batch;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.varve.swath.observability.RunMetrics;
+import io.varve.swath.observability.RunSummary;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Opt-in diagnostic sweep for the production dataset-writer queue/routing path. It deliberately
+ * asserts correctness only; relative throughput is machine/workload evidence, never a release
+ * threshold. The zero-rotation arm isolates dispatch plus encoding, while the row-rotation arm
+ * makes digest and complete-manifest rewrite costs visible.
+ *
+ * <p>Run with {@code ./gradlew :swath-core:test -PonlyPerf --tests
+ * 'io.varve.swath.output.parquet.DatasetWriterScalingBenchmark'
+ * -Dswath.bench=on}. Override rows with {@code -Dswath.bench.writer.rows=N}.
+ */
+@Tag("perf")
+@EnabledIfSystemProperty(named = "swath.bench", matches = "on")
+class DatasetWriterScalingBenchmark {
+
+    private static final int TOTAL_ROWS = Integer.getInteger("swath.bench.writer.rows", 500_000);
+    private static final int BATCH_ROWS = 1_000;
+    private static final List<Integer> WRITERS = List.of(4, 8, 16);
+    private static final List<Long> ROTATION_ROWS = List.of(0L, 20_000L);
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.MINUTES)
+    void writerScaling() throws Exception {
+        Path root = Files.createTempDirectory("swath-writer-scaling-");
+        System.out.printf("WRITER_BENCH_ENV rows=%d batch_rows=%d max_heap_bytes=%d processors=%d%n",
+                TOTAL_ROWS, BATCH_ROWS, Runtime.getRuntime().maxMemory(),
+                Runtime.getRuntime().availableProcessors());
+        try {
+            warmup(root.resolve("warmup"));
+            for (long rotationRows : ROTATION_ROWS) {
+                for (int writers : WRITERS) {
+                    runArm(root.resolve("writers-" + writers + "-rotation-" + rotationRows),
+                            writers, rotationRows);
+                }
+            }
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    private static void warmup(Path dir) throws Exception {
+        Files.createDirectories(dir);
+        try (var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "warmup",
+                1, Long.MAX_VALUE, 4)) {
+            pool.submit(batch(0, 0, 0, 1_000));
+        }
+    }
+
+    private static void runArm(Path dir, int writers, long rotationRows) throws Exception {
+        Files.createDirectories(dir);
+        RunMetrics metrics = new RunMetrics(new SimpleMeterRegistry());
+        var config = ParquetWriterPoolConfig.DEFAULT
+                .withRotationMaxRows(rotationRows)
+                .withMetrics(metrics);
+        long startedAt = System.nanoTime();
+        try (var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "bench",
+                writers, Long.MAX_VALUE,
+                SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers), config)) {
+            long sequence = 0L;
+            for (int from = 0; from < TOTAL_ROWS; from += BATCH_ROWS) {
+                int to = Math.min(TOTAL_ROWS, from + BATCH_ROWS);
+                long nodeId = sequence % writers;
+                pool.submit(batch(nodeId, sequence++, from, to));
+            }
+        }
+        long elapsedNanos = System.nanoTime() - startedAt;
+        RunSummary.DatasetWriterSummary writer = metrics
+                .summary(Duration.ofNanos(elapsedNanos), "writer_bench", 0L, 0L)
+                .datasetWriter();
+        long rows = writer.lanes().stream().mapToLong(RunSummary.DatasetWriterLane::rowsWritten).sum();
+        long activeNanos = writer.lanes().stream()
+                .mapToLong(RunSummary.DatasetWriterLane::activeElapsedNanos).sum();
+        long parts = DatasetLayout.of(dir).dataParts().size();
+
+        assertThat(rows).isEqualTo(TOTAL_ROWS);
+        assertThat(parts).isEqualTo(writer.lanes().stream()
+                .mapToLong(RunSummary.DatasetWriterLane::partsFinalized).sum());
+        System.out.printf("WRITER_BENCH_RESULT writers=%d rotation_rows=%d queue_total=%d "
+                        + "elapsed_ms=%.3f rows_per_sec=%.1f active_ms=%.3f submit_blocked_ms=%.3f "
+                        + "hol_blocked_ms=%.3f parts=%d digest_ms=%.3f manifest_writes=%d "
+                        + "manifest_ms=%.3f%n",
+                writers, rotationRows, writer.totalQueueCapacity(), elapsedNanos / 1_000_000.0,
+                TOTAL_ROWS * 1_000_000_000.0 / elapsedNanos, activeNanos / 1_000_000.0,
+                writer.submitBlockedNanos() / 1_000_000.0,
+                writer.headOfLineBlockedNanos() / 1_000_000.0, parts,
+                writer.partDigestNanos() / 1_000_000.0, writer.manifestWriteCount(),
+                writer.manifestWriteNanos() / 1_000_000.0);
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetPerf2Test.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetPerf2Test.java
@@ -12,6 +12,7 @@ import io.varve.swath.model.KeyBytes;
 import io.varve.swath.model.ListEntry;
 import io.varve.swath.model.ObjectEntry;
 import io.varve.swath.model.PageBatch;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import io.varve.swath.runtime.ListRunner;
 import io.varve.swath.runtime.RunContext;
 import io.varve.swath.testkit.Keyspaces;
@@ -151,17 +152,17 @@ class ParquetPerf2Test {
     }
 
     /**
-     * The 3-writer memory model with <b>all lanes active</b> (2–4 writers
-     * decoupled from {@code T}). The sequential {@code ScanProducer} emits a single
+     * The measured four-writer release envelope with <b>all lanes active</b>. The sequential
+     * {@code ScanProducer} emits a single
      * {@code nodeId=0}, so the real pipeline above drives only one lane; the multi-lane heap
      * budget is exercised here by submitting batches across distinct node ids (routing is
      * {@code nodeId % numWriters}). Heap stays a function of {@code writers × row-group}, not
      * object count (I11).
      */
     @Test
-    void threeWriterLanesStayUnderHeapBudget(@TempDir Path dir) throws Exception {
+    void maximumReleaseEnvelopeStaysUnderHeapBudget(@TempDir Path dir) throws Exception {
         int n = 100_000;
-        int writers = 3;
+        int writers = 4;
 
         AtomicBoolean done = new AtomicBoolean(false);
         AtomicLong peakHeap = new AtomicLong(0);
@@ -179,7 +180,8 @@ class ParquetPerf2Test {
 
         long written;
         try (ParquetWriterPool pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "perf",
-                writers, PartWriter.ROW_GROUP_BYTES * 4, 32)) {
+                writers, PartWriter.ROW_GROUP_BYTES * 4,
+                SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers))) {
             long seq = 0;
             int batchSize = 1000;
             for (int i = 0; i < n; i += batchSize) {
@@ -193,7 +195,7 @@ class ParquetPerf2Test {
         sampler.join(1000);
 
         assertThat(peakHeap.get())
-                .as("3-lane measured peak heap (%d MB) under §7.2 budget", peakHeap.get() / (1024 * 1024))
+                .as("4-lane measured peak heap (%d MB) under §7.2 budget", peakHeap.get() / (1024 * 1024))
                 .isLessThan(HEAP_BUDGET_BYTES);
 
         long rows = 0;

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlanTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterMemoryPlanTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ParquetWriterMemoryPlanTest {
+
+    @Test
+    void planningBytesScaleLinearlyFromOneFixedReserve() {
+        long perWriter = PartWriter.ROW_GROUP_BYTES
+                * ParquetWriterMemoryPlan.ROW_GROUP_ALLOWANCE_MULTIPLIER;
+
+        assertThat(ParquetWriterMemoryPlan.plannedHeapBytes(8))
+                .isEqualTo(ParquetWriterMemoryPlan.BASE_HEAP_RESERVE_BYTES + 8 * perWriter);
+    }
+
+    @Test
+    void heapAdmissionPreservesFourAndThenScalesToTheProcessCeiling() {
+        assertThat(ParquetWriterMemoryPlan.maxWritersForHeap(1)).isEqualTo(4);
+        assertThat(ParquetWriterMemoryPlan.maxWritersForHeap(
+                ParquetWriterMemoryPlan.plannedHeapBytes(8))).isEqualTo(8);
+        assertThat(ParquetWriterMemoryPlan.maxWritersForHeap(Long.MAX_VALUE))
+                .isEqualTo(ParquetWriterMemoryPlan.ABSOLUTE_MAX_WRITERS);
+    }
+
+    @Test
+    void planningRejectsCountsOutsideTheProcessResourceBound() {
+        assertThatThrownBy(() -> ParquetWriterMemoryPlan.plannedHeapBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ParquetWriterMemoryPlan.plannedHeapBytes(
+                ParquetWriterMemoryPlan.ABSOLUTE_MAX_WRITERS + 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
@@ -236,6 +236,12 @@ class ParquetWriterPoolMetricsTest {
                 .contains(RunMetrics.CLIENT_COST_SPAN_PARQUET_WRITE);
         assertThat(summary.datasetWriter()).isNotNull();
         assertThat(summary.datasetWriter().format()).isEqualTo("parquet");
+        assertThat(summary.datasetWriter().writerCount()).isEqualTo(1);
+        assertThat(summary.datasetWriter().totalQueueCapacity()).isEqualTo(8L);
+        assertThat(summary.datasetWriter().jvmMaxHeapBytes()).isPositive();
+        assertThat(summary.datasetWriter().bufferBytesPerWriter()).isEqualTo(PartWriter.ROW_GROUP_BYTES);
+        assertThat(summary.datasetWriter().plannedHeapBytes())
+                .isEqualTo(ParquetWriterMemoryPlan.plannedHeapBytes(1));
         assertThat(summary.datasetWriter().lanes()).singleElement().satisfies(lane -> {
             assertThat(lane.rowsWritten()).isEqualTo(3_000L);
             assertThat(lane.batchesWritten()).isEqualTo(3L);

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolMetricsTest.java
@@ -239,9 +239,17 @@ class ParquetWriterPoolMetricsTest {
         assertThat(summary.datasetWriter().writerCount()).isEqualTo(1);
         assertThat(summary.datasetWriter().totalQueueCapacity()).isEqualTo(8L);
         assertThat(summary.datasetWriter().jvmMaxHeapBytes()).isPositive();
-        assertThat(summary.datasetWriter().bufferBytesPerWriter()).isEqualTo(PartWriter.ROW_GROUP_BYTES);
+        assertThat(summary.datasetWriter().rowGroupTargetBytesPerWriter())
+                .isEqualTo(PartWriter.ROW_GROUP_BYTES);
+        assertThat(summary.datasetWriter().rowGroupAllowanceMultiplier())
+                .isEqualTo(ParquetWriterMemoryPlan.ROW_GROUP_ALLOWANCE_MULTIPLIER);
         assertThat(summary.datasetWriter().plannedHeapBytes())
                 .isEqualTo(ParquetWriterMemoryPlan.plannedHeapBytes(1));
+        assertThat(summary.datasetWriter().heapAdmissionApplied()).isFalse();
+        assertThat(summary.datasetWriter().partDigestCount()).isEqualTo(1L);
+        assertThat(summary.datasetWriter().partDigestNanos()).isPositive();
+        assertThat(summary.datasetWriter().manifestWriteCount()).isEqualTo(2L);
+        assertThat(summary.datasetWriter().manifestWriteNanos()).isPositive();
         assertThat(summary.datasetWriter().lanes()).singleElement().satisfies(lane -> {
             assertThat(lane.rowsWritten()).isEqualTo(3_000L);
             assertThat(lane.batchesWritten()).isEqualTo(3L);

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class ParquetWriterPoolTest {
         int writers = 8;
         var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "hash", writers,
                 Long.MAX_VALUE, SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers));
-        TreeSet<String> expected = new TreeSet<>();
+        List<String> expected = new ArrayList<>();
         for (int lane = 0; lane < writers; lane++) {
             PageBatch submitted = batch(lane, 0, lane * 10, lane * 10 + 10);
             submitted.entries().forEach(entry -> expected.add(entry.key().asString()));
@@ -48,11 +49,11 @@ class ParquetWriterPoolTest {
                 .doesNotHaveDuplicates()
                 .allMatch(name -> name.matches("part-w[0-7]-00000\\.parquet"));
 
-        TreeSet<String> actual = new TreeSet<>();
+        List<String> actual = new ArrayList<>();
         for (Path part : dataParts) {
             actual.addAll(ParquetReads.keys(part));
         }
-        assertThat(actual).isEqualTo(expected);
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
         JsonNode files = new ObjectMapper().readTree(DatasetLayout.of(dir).manifest().toFile())
                 .path("files");
         assertThat(files).hasSize(writers);

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetWriterPoolTest.java
@@ -8,11 +8,13 @@ package io.varve.swath.output.parquet;
 import static io.varve.swath.output.parquet.ParquetPoolTestSupport.batch;
 import static io.varve.swath.output.parquet.ParquetPoolTestSupport.parts;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.varve.swath.model.PageBatch;
+import io.varve.swath.output.dataset.SharedDatasetWriterPool;
 import io.varve.swath.testkit.ParquetReads;
 import java.math.BigInteger;
 import java.nio.file.Files;
@@ -26,6 +28,91 @@ import org.junit.jupiter.api.io.TempDir;
 
 /** Writer-pool unit checks: sticky routing, size rotation, manifest, exact-once parts. */
 class ParquetWriterPoolTest {
+
+    @Test
+    void eightLanePoolPublishesEveryRowAndUniquePart(@TempDir Path dir) throws Exception {
+        int writers = 8;
+        var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "hash", writers,
+                Long.MAX_VALUE, SharedDatasetWriterPool.defaultQueueCapacityPerLane(writers));
+        TreeSet<String> expected = new TreeSet<>();
+        for (int lane = 0; lane < writers; lane++) {
+            PageBatch submitted = batch(lane, 0, lane * 10, lane * 10 + 10);
+            submitted.entries().forEach(entry -> expected.add(entry.key().asString()));
+            pool.submit(submitted);
+        }
+        pool.close();
+
+        List<Path> dataParts = parts(dir);
+        assertThat(dataParts).hasSize(writers);
+        assertThat(dataParts.stream().map(path -> path.getFileName().toString()))
+                .doesNotHaveDuplicates()
+                .allMatch(name -> name.matches("part-w[0-7]-00000\\.parquet"));
+
+        TreeSet<String> actual = new TreeSet<>();
+        for (Path part : dataParts) {
+            actual.addAll(ParquetReads.keys(part));
+        }
+        assertThat(actual).isEqualTo(expected);
+        JsonNode files = new ObjectMapper().readTree(DatasetLayout.of(dir).manifest().toFile())
+                .path("files");
+        assertThat(files).hasSize(writers);
+    }
+
+    @Test
+    void resumeWithFewerWritersContinuesLiveLaneSequencesWithoutOverwritingCarriedParts(
+            @TempDir Path dir) throws Exception {
+        int initialWriters = 8;
+        var rotateEveryBatch = ParquetWriterPoolConfig.DEFAULT.withRotationMaxRows(1);
+        try (var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "hash",
+                initialWriters, Long.MAX_VALUE,
+                SharedDatasetWriterPool.defaultQueueCapacityPerLane(initialWriters),
+                rotateEveryBatch)) {
+            for (int lane = 0; lane < initialWriters; lane++) {
+                pool.submit(batch(lane, 0, lane, lane + 1));
+            }
+        }
+
+        List<PartInfo> carried = parts(dir).stream().map(path -> {
+            String name = path.getFileName().toString();
+            int writerId = Integer.parseInt(name.substring("part-w".length(), name.indexOf('-', 6)));
+            try {
+                return new PartInfo(DatasetLayout.key(name), writerId, 1L, Files.size(path), "");
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }).toList();
+        assertThat(carried).hasSize(initialWriters);
+
+        int resumedWriters = 3;
+        var resumedConfig = rotateEveryBatch.withExistingParts(carried);
+        try (var pool = new ParquetWriterPool(dir, ParquetSchema.canonical(), "hash",
+                resumedWriters, Long.MAX_VALUE,
+                SharedDatasetWriterPool.defaultQueueCapacityPerLane(resumedWriters), resumedConfig)) {
+            for (int lane = 0; lane < resumedWriters; lane++) {
+                pool.submit(batch(lane, 1, 100 + lane, 101 + lane));
+            }
+        }
+
+        List<String> names = parts(dir).stream().map(path -> path.getFileName().toString()).toList();
+        assertThat(names).hasSize(initialWriters + resumedWriters);
+        assertThat(names).doesNotHaveDuplicates();
+        for (int lane = 0; lane < resumedWriters; lane++) {
+            assertThat(names).contains("part-w" + lane + "-00000.parquet",
+                    "part-w" + lane + "-00001.parquet");
+        }
+        for (int lane = resumedWriters; lane < initialWriters; lane++) {
+            assertThat(names).contains("part-w" + lane + "-00000.parquet");
+        }
+    }
+
+    @Test
+    void rejectsQueueCapacityThatExceedsWholePoolBudget(@TempDir Path dir) {
+        assertThatThrownBy(() -> new ParquetWriterPool(
+                dir, ParquetSchema.canonical(), "hash", 64, Long.MAX_VALUE, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("aggregate writer queue capacity <= 256")
+                .hasMessageContaining("aggregate=320");
+    }
 
     @Test
     void rotatesBySizeAndUnionEqualsInput(@TempDir Path dir) throws Exception {

--- a/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
@@ -210,6 +210,11 @@ final class TextWriterPoolTest {
         RunSummary summary = metrics.summary(Duration.ofSeconds(1), "work_stealing", 0L, 0L);
         assertThat(summary.datasetWriter()).isNotNull();
         assertThat(summary.datasetWriter().format()).isEqualTo("jsonl");
+        assertThat(summary.datasetWriter().writerCount()).isEqualTo(2);
+        assertThat(summary.datasetWriter().totalQueueCapacity()).isEqualTo(16L);
+        assertThat(summary.datasetWriter().jvmMaxHeapBytes()).isPositive();
+        assertThat(summary.datasetWriter().bufferBytesPerWriter()).isNull();
+        assertThat(summary.datasetWriter().plannedHeapBytes()).isNull();
         assertThat(summary.datasetWriter().lanes()).extracting(RunSummary.DatasetWriterLane::rowsWritten)
                 .containsExactlyInAnyOrder(1L, 0L);
     }

--- a/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
@@ -213,8 +213,12 @@ final class TextWriterPoolTest {
         assertThat(summary.datasetWriter().writerCount()).isEqualTo(2);
         assertThat(summary.datasetWriter().totalQueueCapacity()).isEqualTo(16L);
         assertThat(summary.datasetWriter().jvmMaxHeapBytes()).isPositive();
-        assertThat(summary.datasetWriter().bufferBytesPerWriter()).isNull();
+        assertThat(summary.datasetWriter().rowGroupTargetBytesPerWriter()).isNull();
+        assertThat(summary.datasetWriter().rowGroupAllowanceMultiplier()).isNull();
         assertThat(summary.datasetWriter().plannedHeapBytes()).isNull();
+        assertThat(summary.datasetWriter().heapAdmissionApplied()).isNull();
+        assertThat(summary.datasetWriter().partDigestCount()).isEqualTo(1L);
+        assertThat(summary.datasetWriter().manifestWriteCount()).isEqualTo(2L);
         assertThat(summary.datasetWriter().lanes()).extracting(RunSummary.DatasetWriterLane::rowsWritten)
                 .containsExactlyInAnyOrder(1L, 0L);
     }


### PR DESCRIPTION
## Summary

- allow direct directory Parquet, TSV, and JSONL datasets to use 2–64 writer lanes
- preserve the measured 2–4 Parquet release envelope and heap-admit higher Parquet counts with a conservative per-writer memory plan
- divide a fixed 256-batch whole-pool queue ceiling across lanes instead of multiplying pending memory with writer count
- report writer count, queue/rotation geometry, heap plan, part-digest work, manifest work, submit blocking, strict head-of-line blocking, and per-lane activity
- reject invalid fresh and resumed plans before checkpoint or S3 side effects
- serialize each manifest snapshot with publication so concurrent lanes cannot overwrite a newer manifest with a stale snapshot

This follows #121 by making higher direct-sink concurrency testable on faster listing environments without making it the default or assuming that more writers are always faster.

## Scope and behavior

- the default remains three writers
- the existing 2–4 behavior remains the measured compatibility envelope
- counts above four are expert configurations; Parquet requires sufficient JVM maximum heap
- the absolute 64-lane ceiling bounds threads and concurrently open parts
- direct text and Parquet share the same bounded pool, while retaining format-specific encoders and memory costs
- `parquet.writers` is intentionally inert under `--sort`, whose spool and final-publish paths do not use the direct writer pool

## Evidence

A direct, unsorted Parquet sweep against a 9,919,142-object public bucket completed correctly at 4, 8, and 16 writers. DuckDB verified exact row counts and distinct keys in every output. All three runs reported zero writer submit blocking, zero strict head-of-line blocking, and zero lane queue peaks, so the writer sink was not the bottleneck at the observed 26–30k keys/s. The differing live wall times are not treated as writer-count speedups because upstream S3 concurrency and request conditions differed.

Higher counts did have measurable costs: parts increased from 52 to 95 to 172, and peak memory increased. A focused 500k-row local sweep showed that eight writers could eliminate observed admission pressure, while sixteen was not monotonically faster and accumulated substantially more manifest-lock time. These results support configurability and direct observability, not a default change.

## Validation

- `./gradlew build -x :swath-replay:test`
- `./gradlew :swath-core:test -PonlyPerf --tests 'io.varve.swath.output.parquet.ParquetPerf2Test'`
- `./gradlew :swath-core:test -PonlyPerf --tests 'io.varve.swath.output.parquet.DatasetWriterScalingBenchmark' -Dswath.bench=on`
- focused fresh/resume admission, 8-lane exact-union, 8-to-3 resume, queue-bound, summary, JSON, text-writer, and formatting tests

A plain `./gradlew build` reaches the existing sorted replay differential failures; no replay source or fixture is changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Parquet and text dataset writers now support configurable pools of 2–64 writers; the default remains 3.
  - Higher Parquet writer counts are admitted based on available JVM heap, with clear configuration warnings when limits are exceeded.
  - Writer queues now maintain a shared capacity budget across lanes.
  - Run summaries include row-group, heap-admission, part-digest, rotation, and manifest-publication metrics.

- **Documentation**
  - Updated usage, performance, configuration, metrics, and architecture guidance for writer sizing and benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->