### PR TITLE
Fix replay timestamps outside UTC

### DIFF
--- a/swath-replay/src/main/java/io/varve/swath/replay/store/DuckDbListingStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/DuckDbListingStore.java
@@ -149,7 +149,8 @@ public final class DuckDbListingStore implements ListingStore {
 
     private static Query buildQuery(ByteKey from, boolean fromInclusive, ByteKey toExclusive) {
         StringBuilder sql = new StringBuilder("""
-                SELECT hex(key) AS key_hex, size, last_modified, etag, storage_class, owner_id,
+                SELECT hex(key) AS key_hex, size, epoch_us(last_modified) AS last_modified_epoch_micros,
+                       etag, storage_class, owner_id,
                        owner_display_name, checksum_algorithm, checksum_type
                 FROM listing_objects
                 WHERE 1 = 1

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/RowMapper.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/RowMapper.java
@@ -9,45 +9,36 @@ import io.varve.swath.replay.protocol.ByteKeys;
 import io.varve.swath.replay.protocol.ListedObject;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Calendar;
-import java.util.TimeZone;
 
 /**
- * Shared DuckDB {@link ResultSet} → {@link ListedObject} mapping for every {@link ListingStore} that
- * queries a swath capture through DuckDB. Both {@link DuckDbListingStore} (role 1, materialised) and
- * {@link SortedParquetStore} (role 2, bounded {@code read_parquet}) SELECT the same nine column
- * aliases in the same order, so the row shape lives here once rather than in each store — the point
- * of the seam is that a differential attributes disagreements to <em>routing</em>, never to a
- * divergent row decode.
+ * DuckDB {@link ResultSet} → {@link ListedObject} mapping for {@link DuckDbListingStore}. The
+ * query projection and its epoch-microsecond timestamp conversion live together, so JDBC conversion
+ * cannot introduce a JVM-default-timezone dependency at the storage seam.
  */
 final class RowMapper {
-
-    /** {@code last_modified} is a UTC timestamp in the capture; read it in UTC to avoid a TZ shift. */
-    private static final Calendar UTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
     private RowMapper() {
     }
 
     /**
-     * Reads one row from a result set whose columns are exactly {@code key_hex, size, last_modified,
-     * etag, storage_class, owner_id, owner_display_name, checksum_algorithm, checksum_type}.
+     * Reads one row from a result set whose columns are exactly {@code key_hex, size,
+     * last_modified_epoch_micros, etag, storage_class, owner_id, owner_display_name,
+     * checksum_algorithm, checksum_type}.
+     *
+     * <p>The SQL projection uses DuckDB's {@code epoch_us(last_modified)} rather than JDBC's
+     * {@code Timestamp} conversion. The latter has varied with the JVM default timezone for
+     * Parquet {@code TIMESTAMPTZ} values; an epoch count is the capture's canonical UTC instant.
      */
     static ListedObject read(ResultSet rs) throws SQLException {
         byte[] key = ByteKeys.fromHex(rs.getString("key_hex"));
-        return new ListedObject(key, rs.getLong("size"), micros(rs.getTimestamp("last_modified", UTC)),
+        long lastModifiedEpochMicros = rs.getLong("last_modified_epoch_micros");
+        if (rs.wasNull()) {
+            lastModifiedEpochMicros = 0L;
+        }
+        return new ListedObject(key, rs.getLong("size"), lastModifiedEpochMicros,
                 rs.getString("etag"), rs.getString("storage_class"),
                 rs.getString("owner_id"), rs.getString("owner_display_name"),
                 rs.getString("checksum_algorithm"), rs.getString("checksum_type"));
-    }
-
-    private static long micros(Timestamp timestamp) {
-        if (timestamp == null) {
-            return 0L;
-        }
-        Instant instant = timestamp.toInstant();
-        return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
     }
 
     /** SQL single-quoted string literal with embedded quotes doubled. */

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
@@ -16,10 +16,6 @@ import io.varve.swath.sort.SortedRangeReader;
 import io.varve.swath.sort.SortedRowGroupReader;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -191,9 +187,7 @@ public final class SortedParquetStore implements ListingStore {
                 for (SortedRowGroupReader.ObjectRow row :
                         rangeReader(file).range(startBlock, lower, inclusive, upper,
                                 limit - out.size(), projection.owner())) {
-                    out.add(new ListedObject(row.key(), row.size(), row.lastModifiedEpochMicros(),
-                            row.etag(), row.storageClass(), row.ownerId(), row.ownerDisplayName(),
-                            row.checksumAlgorithm(), row.checksumType()));
+                    out.add(toListedObject(row));
                 }
                 lower = null;
                 inclusive = true;
@@ -578,34 +572,9 @@ public final class SortedParquetStore implements ListingStore {
     }
 
     private static ListedObject toListedObject(SortedRowGroupReader.ObjectRow row) {
-        return new ListedObject(row.key(), row.size(), rowMapperCompatibleMicros(row.lastModifiedEpochMicros()),
+        return new ListedObject(row.key(), row.size(), row.lastModifiedEpochMicros(),
                 row.etag(), row.storageClass(), row.ownerId(), row.ownerDisplayName(),
                 row.checksumAlgorithm(), row.checksumType());
-    }
-
-    /**
-     * Reproduces, bit for bit, what {@link RowMapper#read} derives for {@code last_modified} — not
-     * the true UTC instant the row actually stores. DuckDB's JDBC driver, for a Parquet-sourced
-     * {@code TIMESTAMPTZ} column, does not honor the {@link java.util.Calendar} passed to {@code
-     * ResultSet.getTimestamp(column, calendar)}: it takes the value's own UTC wall-clock digits and
-     * re-interprets them as wall-clock digits in the <b>JVM's default zone</b> instead — a shift by
-     * that zone's offset at the instant in question, a no-op only when the JVM default zone is UTC.
-     * {@link RowMapper} unavoidably inherits this because it explicitly requests a UTC calendar (to
-     * defend against a different, legitimate shift on a plain un-zoned {@code TIMESTAMP} column, which
-     * {@link DuckDbListingStore}'s materialized table can produce for an older capture). Both existing
-     * stores go through {@link RowMapper}, so they already agree with each other on the shifted value;
-     * this store's native decode must reproduce the very same shift, not the true instant, to stay
-     * byte-identical to the DuckDB-backed range walk the differential suite compares it against.
-     */
-    private static long rowMapperCompatibleMicros(long trueEpochMicros) {
-        if (trueEpochMicros == 0L) {
-            return 0L;   // RowMapper's own sentinel for "no timestamp" (a null column)
-        }
-        Instant trueInstant = Instant.ofEpochSecond(
-                Math.floorDiv(trueEpochMicros, 1_000_000L), Math.floorMod(trueEpochMicros, 1_000_000L) * 1_000L);
-        LocalDateTime utcWallClock = LocalDateTime.ofInstant(trueInstant, ZoneOffset.UTC);
-        Instant shifted = utcWallClock.atZone(ZoneId.systemDefault()).toInstant();
-        return shifted.getEpochSecond() * 1_000_000L + shifted.getNano() / 1_000L;
     }
 
     private static void validateIndexWithinFiles(List<IndexEntry> index, List<Path> files) {

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingDifferentialTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingDifferentialTest.java
@@ -21,8 +21,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * A mini-differential (the full adversarial matrix is SortedServingFullDifferentialTest):
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
  * HTTP with identical requests, asserting byte-identical XML page-for-page in both the flat and the
  * delimiter (seek-to-successor) paths.
  */
+@Isolated // One test changes java.util.TimeZone's JVM-global default.
 class SortedServingDifferentialTest {
 
     @Test
@@ -50,6 +53,39 @@ class SortedServingDifferentialTest {
             assertThat(walk(sortedServer, null, 25)).isEqualTo(walk(duckServer, null, 25));
             // Delimiter listing exercises the seek-to-successor hybrid + CommonPrefixes rollup.
             assertThat(walk(sortedServer, "/", 4)).isEqualTo(walk(duckServer, "/", 4));
+        }
+    }
+
+    /**
+     * A non-UTC default zone used to make the DuckDB JDBC timestamp conversion disagree with the
+     * native sorted readers. Keep this in-process (rather than relying on a CI runner's zone) so a
+     * UTC-only runner cannot mask that regression.
+    */
+    @Test
+    void sortedAndDuckDbServeTheTrueUtcTimestampOutsideUtcDefaultZone(@TempDir Path dir) throws Exception {
+        TimeZone original = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+        try {
+            Path sorted = sortedFixture(dir);
+
+            try (ReplayServer sortedServer = new ReplayServer(
+                    "127.0.0.1", 0, "bucket", sorted, 2, ServingMode.SORTED);
+                 ReplayServer duckServer = new ReplayServer(
+                         "127.0.0.1", 0, "bucket", sorted, 2, ServingMode.DUCKDB)) {
+                sortedServer.start();
+                duckServer.start();
+
+                List<String> sortedFlat = walk(sortedServer, null, 25);
+                List<String> duckFlat = walk(duckServer, null, 25);
+                assertThat(sortedFlat).isEqualTo(duckFlat);
+                // ObjectEntries.withOwner fixes this fixture's mtime at 1_700_000_000_000_000 µs.
+                assertThat(HttpProbe.extractTag(sortedFlat.getFirst(), "LastModified"))
+                        .isEqualTo("2023-11-14T22:13:20.000Z");
+
+                assertThat(walk(sortedServer, "/", 4)).isEqualTo(walk(duckServer, "/", 4));
+            }
+        } finally {
+            TimeZone.setDefault(original);
         }
     }
 

--- a/swath-replay/src/test/java/io/varve/swath/replay/store/DuckDbListingStoreTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/store/DuckDbListingStoreTest.java
@@ -20,9 +20,12 @@ import java.sql.PreparedStatement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
+@Isolated // The legacy-timestamp regression test changes java.util.TimeZone's JVM-global default.
 class DuckDbListingStoreTest {
 
     @Test
@@ -71,32 +74,39 @@ class DuckDbListingStoreTest {
 
     @Test
     void loadsLegacyParquetWithoutOwnerDisplayNameOrChecksumType(@TempDir Path dir) throws Exception {
-        Path parquet = dir.resolve("legacy.parquet");
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
-             var st = connection.createStatement()) {
-            st.execute("""
-                    COPY (
-                        SELECT
-                            'OBJECT'::VARCHAR AS row_type,
-                            'legacy/1'::BLOB AS key,
-                            10::BIGINT AS size,
-                            TIMESTAMP '2026-01-01 00:00:00' AS last_modified,
-                            'etag-10'::VARCHAR AS etag,
-                            'STANDARD'::VARCHAR AS storage_class,
-                            'owner-10'::VARCHAR AS owner_id,
-                            'CRC32'::VARCHAR AS checksum_algorithm
-                    ) TO %s (FORMAT PARQUET)
-                    """.formatted(sqlString(parquet)));
-        }
+        TimeZone original = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+        try {
+            Path parquet = dir.resolve("legacy.parquet");
+            try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+                 var st = connection.createStatement()) {
+                st.execute("""
+                        COPY (
+                            SELECT
+                                'OBJECT'::VARCHAR AS row_type,
+                                'legacy/1'::BLOB AS key,
+                                10::BIGINT AS size,
+                                TIMESTAMP '2026-01-01 00:00:00' AS last_modified,
+                                'etag-10'::VARCHAR AS etag,
+                                'STANDARD'::VARCHAR AS storage_class,
+                                'owner-10'::VARCHAR AS owner_id,
+                                'CRC32'::VARCHAR AS checksum_algorithm
+                        ) TO %s (FORMAT PARQUET)
+                        """.formatted(sqlString(parquet)));
+            }
 
-        try (DuckDbListingStore store = new DuckDbListingStore(parquet)) {
-            List<ListedObject> rows = store.rows(null, true, null, 1000, Projection.WITH_OWNER);
-            ListedObject object = rows.getFirst();
-            assertThat(ByteKeys.utf8(object.key())).isEqualTo("legacy/1");
-            assertThat(object.ownerId()).isEqualTo("owner-10");
-            assertThat(object.ownerDisplayName()).isNull();
-            assertThat(object.checksumAlgorithm()).isEqualTo("CRC32");
-            assertThat(object.checksumType()).isEqualTo("FULL_OBJECT");
+            try (DuckDbListingStore store = new DuckDbListingStore(parquet)) {
+                List<ListedObject> rows = store.rows(null, true, null, 1000, Projection.WITH_OWNER);
+                ListedObject object = rows.getFirst();
+                assertThat(ByteKeys.utf8(object.key())).isEqualTo("legacy/1");
+                assertThat(object.lastModifiedEpochMicros()).isEqualTo(1_767_225_600_000_000L);
+                assertThat(object.ownerId()).isEqualTo("owner-10");
+                assertThat(object.ownerDisplayName()).isNull();
+                assertThat(object.checksumAlgorithm()).isEqualTo("CRC32");
+                assertThat(object.checksumType()).isEqualTo("FULL_OBJECT");
+            }
+        } finally {
+            TimeZone.setDefault(original);
         }
     }
 


### PR DESCRIPTION
## Summary

- Read DuckDB timestamps as canonical epoch microseconds instead of using timezone-sensitive JDBC `Timestamp` conversion.
- Make both native sorted paths use the stored epoch microseconds and remove the compatibility shift.
- Add isolated non-UTC regressions for canonical `TIMESTAMPTZ` and legacy unzoned `TIMESTAMP` captures.

## Verification

- `./gradlew build`
- Differential and conformance suites under `UTC`.
- The same suites under `America/Los_Angeles`.

## Review

Claude Opus performed a read-only review. All four valid findings were addressed: unified native mapping, real test isolation, a legacy non-UTC assertion, and fixture timestamp traceability.
