### PR TITLE
Stream dataset part digests

### DIFF
--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -455,7 +455,8 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
   outside the active-buffer bound in I11. Because the time/row cadence is per lane, more active
   writers can also create more sub-target parts and amplify this publication path. Counts above the
   measured envelope emit an operator warning, and `part_digest_*` / `manifest_write_*` in
-  `dataset_writer` measure the resulting full-part reads and serialized manifest work directly.
+  `dataset_writer` measure the resulting streamed byte-exact digest work and serialized manifest
+  work directly.
   **Resume bookkeeping stays out of the consumer manifest**: `args_hash` and
   the checkpoint `run_id` live in the internal `.swath-state.json` (same
   atomic write). For every directory format, swath creates and fsyncs that

--- a/docs/internals/metrics-internals.md
+++ b/docs/internals/metrics-internals.md
@@ -295,8 +295,8 @@ a span with zero observations is omitted, never a fabricated all-zero row.
 | `checkpoint_commit` | `swath.checkpoint.commit.latency` | per writer-thread BATCH: op execution + `conn.commit()` (the WAL-fsync critical path). |
 | `emit` | `swath.emit.latency` | per page: the consumer stage's whole sink write (format+write for text, pool dispatch for Parquet, lane admission for `--sort`), including that stage's own row tally. |
 | `writer_backpressure` | `swath.queue.wait` | per page: the fetch worker blocked handing the page onto a full downstream channel. |
-| `parquet_write` | `swath.parquet.write.latency` | per stretch of Parquet WRITER-LANE work: the encode+write of a batch's rows into the open part, plus any finalize it triggered (footer fsync, part MD5, manifest rewrite), timed on the lane's own thread between two waits on its queue. **Elapsed time, not CPU time**: it can include filesystem/checkpoint I/O and manifest-lock waits. **Not page-scoped** and **not on the page's critical path**: one observation per batch written, plus one per idle-cadence rotation and one per lane's drain-time finalize/discard, so its count is `>=` the page count on a clean run (an aborted/failed run drains its queued batches without writing them, and those record nothing). Parquet-sink runs only. |
-| `text_dataset_write` | `swath.text_dataset.write.latency` | the equivalent WRITER-LANE stretch for a partitioned TSV/JSONL dataset: format+compress+write, plus any close/trailer/fsync, MD5, and manifest rewrite it triggers. It has the same off-page-critical-path and observation-count semantics as `parquet_write`; ordinary single-stream text output remains fully represented by `emit`. |
+| `parquet_write` | `swath.parquet.write.latency` | per stretch of Parquet WRITER-LANE work: the encode+write of a batch's rows into the open part, plus any finalize it triggered (footer fsync, manifest rewrite), timed on the lane's own thread between two waits on its queue. Part MD5 is incrementally maintained on this write path, not reread after close. **Elapsed time, not CPU time**: it can include filesystem/checkpoint I/O and manifest-lock waits. **Not page-scoped** and **not on the page's critical path**: one observation per batch written, plus one per idle-cadence rotation and one per lane's drain-time finalize/discard, so its count is `>=` the page count on a clean run (an aborted/failed run drains its queued batches without writing them, and those record nothing). Parquet-sink runs only. |
+| `text_dataset_write` | `swath.text_dataset.write.latency` | the equivalent WRITER-LANE stretch for a partitioned TSV/JSONL dataset: format+compress+write, plus any close/trailer/fsync and manifest rewrite it triggers. The byte-exact part MD5 is incrementally maintained below the compressor, not reread after close. It has the same off-page-critical-path and observation-count semantics as `parquet_write`; ordinary single-stream text output remains fully represented by `emit`. |
 
 **Reading it.** The spans are percentile-bearing precisely because a per-page cost read as a MEAN
 cannot distinguish an iid per-page cost from a queue behind a shared single writer — whose tail grows
@@ -358,7 +358,9 @@ the pinned 64 MiB uncompressed row-group threshold, while the multiplier exposes
 overshoot allowance used by the plan—multiplying only writer count by the target is not a heap
 estimate.
 
-`part_digest_count`/`part_digest_ms` measure the full-part checksum read after close.
+`part_digest_count` counts finalized parts with byte-exact streamed MD5 metadata.
+`part_digest_ms` is CPU time spent incrementally maintaining/finalizing those digests on the
+physical-write path; it is not elapsed time and does not include a post-close file reread.
 `manifest_write_count`/`manifest_write_ms` measure atomic complete-manifest rewrites, including time
 queued behind another lane on the global manifest lock. The count includes the final ensure-write at
 successful publication. These fields isolate the two per-part costs that grow when more active lanes

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -163,7 +163,7 @@ key samples. Treat it as operational data and redact it before sharing.
 sorted output, which do not construct the shared pool. Its aggregate resource fields report the
 configured writer count, total lane-queue capacity, JVM maximum heap, and—for Parquet—the pinned
 row-group target, its conservative allowance multiplier, and the heap-admission plan. It also reports
-the part-rotation configuration, full-part digest work, and complete-manifest rewrite count/time; the
+the part-rotation configuration, streamed full-part digest work, and complete-manifest rewrite count/time; the
 manifest duration includes lock wait. The Parquet-only fields are null for text. Its aggregate
 `submit_blocked_*` fields measure full sticky-lane admission waits;
 `head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -147,8 +147,8 @@ comparing runs.
 
 Higher counts are not monotonic throughput scaling. Dividing the fixed budget gives each lane fewer
 queue slots, which can expose sticky-dispatch head-of-line blocking sooner. The default time/row
-rotation is also per lane: more active lanes can create more sub-target parts, each of which performs
-a full-part digest and rewrites the complete manifest under one lock. Compare `part_digest_ms`,
+rotation is also per lane: more active lanes can create more sub-target parts, each of which maintains
+a streamed full-part digest and rewrites the complete manifest under one lock. Compare `part_digest_ms`,
 `manifest_write_ms`, part count, `submit_blocked_ms`, and `head_of_line_blocked_ms` at 4/8/16 before
 adopting an expert count. If manifest time or HOL blocking rises faster than throughput, more writers
 are making the sink worse.

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetPartWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetPartWriter.java
@@ -17,4 +17,10 @@ public interface DatasetPartWriter {
     void write(ListEntry entry) throws IOException;
     void close() throws IOException;
     void discard() throws IOException;
+
+    /** Byte-exact MD5 of the physical part, available only after {@link #close()} returns. */
+    String md5();
+
+    /** CPU time spent maintaining {@link #md5()} on the physical-write path. */
+    long digestNanos();
 }

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DigestingOutputStream.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DigestingOutputStream.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** An output-stream decorator that records only bytes successfully accepted by its delegate. */
+public final class DigestingOutputStream extends FilterOutputStream {
+    private final PartDigest digest;
+
+    public DigestingOutputStream(OutputStream delegate, PartDigest digest) {
+        super(delegate);
+        this.digest = digest;
+    }
+
+    @Override
+    public void write(int value) throws IOException {
+        out.write(value);
+        digest.update(value);
+    }
+
+    @Override
+    public void write(byte[] bytes) throws IOException {
+        write(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void write(byte[] bytes, int offset, int length) throws IOException {
+        out.write(bytes, offset, length);
+        digest.update(bytes, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+        digest.streamClosed();
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/PartDigest.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/PartDigest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Incremental MD5 of a physical dataset part, exposed only after its writer has made that part
+ * durable. Format adapters feed this with the bytes that reach the file: parquet feeds its
+ * {@code OutputFile}; compressed text feeds the stream below its compressor.
+ */
+public final class PartDigest {
+    private final MessageDigest digest;
+    private long bytes;
+    private long digestNanos;
+    private boolean streamClosed;
+    private boolean durable;
+    private String md5;
+
+    public PartDigest() {
+        try {
+            digest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("JVM has no MD5 provider", e);
+        }
+    }
+
+    public synchronized void update(byte[] bytes, int offset, int length) {
+        requireOpenStream();
+        long startedAt = System.nanoTime();
+        digest.update(bytes, offset, length);
+        digestNanos += System.nanoTime() - startedAt;
+        this.bytes += length;
+    }
+
+    public synchronized void update(int value) {
+        requireOpenStream();
+        long startedAt = System.nanoTime();
+        digest.update((byte) value);
+        digestNanos += System.nanoTime() - startedAt;
+        bytes++;
+    }
+
+    /** Marks that the producing stream closed successfully; this alone does not expose metadata. */
+    public synchronized void streamClosed() {
+        streamClosed = true;
+    }
+
+    /** Makes metadata available only after close and the writer's durability barrier both succeeded. */
+    public synchronized void markDurable() {
+        if (!streamClosed) {
+            throw new IllegalStateException("part digest marked durable before its output stream closed");
+        }
+        durable = true;
+    }
+
+    public synchronized long bytes() {
+        requireDurable();
+        return bytes;
+    }
+
+    /** Digest CPU time accrued on the physical-write path, not a post-close reread. */
+    public synchronized long digestNanos() {
+        requireDurable();
+        return digestNanos;
+    }
+
+    public synchronized String md5() {
+        requireDurable();
+        if (md5 == null) {
+            long startedAt = System.nanoTime();
+            md5 = HexFormat.of().formatHex(digest.digest());
+            digestNanos += System.nanoTime() - startedAt;
+        }
+        return md5;
+    }
+
+    private void requireDurable() {
+        if (!durable) {
+            throw new IllegalStateException("part digest requested before durable close");
+        }
+    }
+
+    private void requireOpenStream() {
+        if (streamClosed) {
+            throw new IllegalStateException("part digest updated after its output stream closed");
+        }
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
-import org.apache.commons.codec.digest.DigestUtils;
 
 /**
  * A format-neutral, decoupled dataset writer pool: a bounded number of {@code numWriters} lanes
@@ -541,17 +540,12 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         long bytes = Files.size(path);
         // Canonical relative form: data/<filename>, shared verbatim by the consumer
         // manifest files[].key, the checkpoint part_file.path (via the event's fileName), and the
-        // resume disk-sweep. MD5 is computed ONCE here, at finalize — never on every
-        // manifest rewrite (which would be O(n²)).
+        // resume disk-sweep. The format writer captured the exact physical-byte MD5 as it wrote
+        // this part; close-before-publication makes that immutable metadata safe to consume here.
         String relPath = DatasetLayout.key(path.getFileName().toString());
-        String md5;
-        long digestStartedAt = nanoClock.getAsLong();
-        try (var in = Files.newInputStream(path)) {
-            md5 = DigestUtils.md5Hex(in);
-        } finally {
-            partDigestCount.incrementAndGet();
-            partDigestNanos.addAndGet(Math.max(0L, nanoClock.getAsLong() - digestStartedAt));
-        }
+        String md5 = w.md5();
+        partDigestCount.incrementAndGet();
+        partDigestNanos.addAndGet(w.digestNanos());
         // When the sink wires a durable listener, its checkpoint commit (record part + advance
         // durable_cursor) is the exactly-once boundary BEFORE the manifest. Text wires NONE.
         Map<Long, byte[]> contributions = Map.copyOf(lane.partNodeMaxKey);

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/DigestingOutputFile.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/DigestingOutputFile.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.parquet;
+
+import io.varve.swath.output.dataset.PartDigest;
+import java.io.IOException;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+
+/** Sequential {@link OutputFile} decorator that digests the exact bytes parquet-mr emits. */
+public final class DigestingOutputFile implements OutputFile {
+    private final OutputFile delegate;
+    private final PartDigest digest = new PartDigest();
+    private boolean opened;
+
+    public DigestingOutputFile(OutputFile delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+        return tracking(delegate.create(blockSizeHint));
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+        return tracking(delegate.createOrOverwrite(blockSizeHint));
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+        return delegate.supportsBlockSize();
+    }
+
+    @Override
+    public long defaultBlockSize() {
+        return delegate.defaultBlockSize();
+    }
+
+    /** Called only after the parquet footer and the file/parent fsync barrier have succeeded. */
+    public void markDurable() {
+        digest.markDurable();
+    }
+
+    public long bytes() {
+        return digest.bytes();
+    }
+
+    public long digestNanos() {
+        return digest.digestNanos();
+    }
+
+    public String md5() {
+        return digest.md5();
+    }
+
+    private synchronized PositionOutputStream tracking(PositionOutputStream out) {
+        if (opened) {
+            throw new IllegalStateException("Parquet output stream opened more than once");
+        }
+        opened = true;
+        return new PositionOutputStream() {
+            @Override
+            public long getPos() throws IOException {
+                return out.getPos();
+            }
+
+            @Override
+            public void write(int value) throws IOException {
+                out.write(value);
+                digest.update(value);
+            }
+
+            @Override
+            public void write(byte[] bytes) throws IOException {
+                out.write(bytes);
+                digest.update(bytes, 0, bytes.length);
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                out.write(bytes, offset, length);
+                digest.update(bytes, offset, length);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                out.flush();
+            }
+
+            @Override
+            public void close() throws IOException {
+                out.close();
+                digest.streamClosed();
+            }
+        };
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/PartWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/PartWriter.java
@@ -35,13 +35,15 @@ public final class PartWriter implements AutoCloseable, DatasetPartWriter {
 
     private final Path path;
     private final ParquetWriter<ListEntry> writer;
+    private final DigestingOutputFile output;
     private long rows;
 
     public PartWriter(Path path, MessageType schema) throws IOException {
         this.path = path;
         Configuration conf = new Configuration(false);
         conf.setInt("parquet.compression.codec.zstd.level", ZSTD_LEVEL);
-        this.writer = new Builder(new LocalOutputFile(path), schema)
+        output = new DigestingOutputFile(new LocalOutputFile(path));
+        this.writer = new Builder(output, schema)
                 .withConf(conf)
                 .withCompressionCodec(CompressionCodecName.ZSTD)
                 .withRowGroupSize(ROW_GROUP_BYTES)
@@ -79,6 +81,7 @@ public final class PartWriter implements AutoCloseable, DatasetPartWriter {
     public void close() throws IOException {
         writer.close();
         DurableFiles.fileAndParent(path);
+        output.markDurable();
     }
 
     /**
@@ -99,6 +102,16 @@ public final class PartWriter implements AutoCloseable, DatasetPartWriter {
         } catch (IOException ignored) {
             // about to be deleted — releasing the handle is all that matters
         }
+    }
+
+    @Override
+    public String md5() {
+        return output.md5();
+    }
+
+    @Override
+    public long digestNanos() {
+        return output.digestNanos();
     }
 
     private static final class Builder extends ParquetWriter.Builder<ListEntry, Builder> {

--- a/swath-core/src/main/java/io/varve/swath/output/text/TextDatasetFormat.java
+++ b/swath-core/src/main/java/io/varve/swath/output/text/TextDatasetFormat.java
@@ -13,7 +13,9 @@ import io.varve.swath.output.Formatters;
 import io.varve.swath.output.OutputFormat;
 import io.varve.swath.output.dataset.DatasetFormat;
 import io.varve.swath.output.dataset.DatasetPartWriter;
+import io.varve.swath.output.dataset.DigestingOutputStream;
 import io.varve.swath.output.dataset.DurableFiles;
+import io.varve.swath.output.dataset.PartDigest;
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -63,11 +65,13 @@ public record TextDatasetFormat(OutputFormat format, TextCompression compression
         private final Path path;
         private final CountingWriter counting;
         private final EntryFormatter formatter;
+        private final PartDigest digest;
         private long rows;
 
         TextPartWriter(Path path, EncoderFactory encoderFactory) throws IOException {
             this.path = path;
-            OpenedTextPart opened = open(path, encoderFactory);
+            digest = new PartDigest();
+            OpenedTextPart opened = open(path, encoderFactory, digest);
             counting = opened.counting();
             formatter = opened.formatter();
         }
@@ -91,6 +95,7 @@ public record TextDatasetFormat(OutputFormat format, TextCompression compression
             if (failure == null) {
                 try {
                     DurableFiles.fileAndParent(path);
+                    digest.markDurable();
                 } catch (IOException e) {
                     failure = e;
                 }
@@ -103,14 +108,17 @@ public record TextDatasetFormat(OutputFormat format, TextCompression compression
         @Override public void discard() throws IOException {
             counting.close();
         }
+
+        @Override public String md5() { return digest.md5(); }
+        @Override public long digestNanos() { return digest.digestNanos(); }
     }
 
     /** Open the whole encoder stack transactionally so constructor failure cannot leak the file. */
-    private OpenedTextPart open(Path path, EncoderFactory encoderFactory) throws IOException {
+    private OpenedTextPart open(Path path, EncoderFactory encoderFactory, PartDigest digest) throws IOException {
         OutputStream stream = null;
         CountingWriter counting = null;
         try {
-            stream = new BufferedOutputStream(Files.newOutputStream(path));
+            stream = new BufferedOutputStream(new DigestingOutputStream(Files.newOutputStream(path), digest));
             counting = encoderFactory.open(stream, compression);
             EntryFormatter formatter = Formatters.text(format, counting, escape);
             formatter.writeHeader();

--- a/swath-core/src/main/java/io/varve/swath/sort/ListEntryParquetWriters.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/ListEntryParquetWriters.java
@@ -6,13 +6,11 @@
 package io.varve.swath.sort;
 
 import io.varve.swath.model.ListEntry;
+import io.varve.swath.output.parquet.DigestingOutputFile;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetFileWriter;
@@ -21,7 +19,6 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.LocalOutputFile;
 import org.apache.parquet.io.OutputFile;
-import org.apache.parquet.io.PositionOutputStream;
 
 /**
  * Shared {@link ParquetWriter} scaffolding for {@link SegmentParquetSink} and
@@ -85,130 +82,6 @@ final class ListEntryParquetWriters {
     }
 
     record TrackedWriter(ParquetWriter<ListEntry> writer, DigestingOutputFile output) {
-    }
-
-    /** Sequential {@link OutputFile} decorator that digests the exact bytes parquet-mr emits. */
-    static final class DigestingOutputFile implements OutputFile {
-        private final OutputFile delegate;
-        private final MessageDigest digest;
-        private long bytes;
-        private long digestNanos;
-        private boolean opened;
-        private boolean finished;
-        private String md5;
-
-        DigestingOutputFile(OutputFile delegate) {
-            this.delegate = delegate;
-            try {
-                this.digest = MessageDigest.getInstance("MD5");
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalStateException("JVM has no MD5 provider", e);
-            }
-        }
-
-        @Override
-        public PositionOutputStream create(long blockSizeHint) throws IOException {
-            return tracking(delegate.create(blockSizeHint));
-        }
-
-        @Override
-        public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
-            return tracking(delegate.createOrOverwrite(blockSizeHint));
-        }
-
-        @Override
-        public boolean supportsBlockSize() {
-            return delegate.supportsBlockSize();
-        }
-
-        @Override
-        public long defaultBlockSize() {
-            return delegate.defaultBlockSize();
-        }
-
-        synchronized long bytes() {
-            requireFinished();
-            return bytes;
-        }
-
-        synchronized long digestNanos() {
-            requireFinished();
-            return digestNanos;
-        }
-
-        synchronized String md5() {
-            requireFinished();
-            if (md5 == null) {
-                long start = System.nanoTime();
-                md5 = HexFormat.of().formatHex(digest.digest());
-                digestNanos += System.nanoTime() - start;
-            }
-            return md5;
-        }
-
-        private synchronized PositionOutputStream tracking(PositionOutputStream out) {
-            if (opened) {
-                throw new IllegalStateException("Parquet output stream opened more than once");
-            }
-            opened = true;
-            return new PositionOutputStream() {
-                @Override
-                public long getPos() throws IOException {
-                    return out.getPos();
-                }
-
-                @Override
-                public void write(int b) throws IOException {
-                    out.write(b);
-                    update(b);
-                }
-
-                @Override
-                public void write(byte[] b) throws IOException {
-                    out.write(b);
-                    update(b, 0, b.length);
-                }
-
-                @Override
-                public void write(byte[] b, int off, int len) throws IOException {
-                    out.write(b, off, len);
-                    update(b, off, len);
-                }
-
-                @Override
-                public void flush() throws IOException {
-                    out.flush();
-                }
-
-                @Override
-                public void close() throws IOException {
-                    out.close();
-                    synchronized (DigestingOutputFile.this) {
-                        finished = true;
-                    }
-                }
-            };
-        }
-
-        private synchronized void update(byte[] b, int off, int len) {
-            long start = System.nanoTime();
-            digest.update(b, off, len);
-            digestNanos += System.nanoTime() - start;
-            bytes += len;
-        }
-
-        private synchronized void update(int b) {
-            long start = System.nanoTime();
-            digest.update((byte) b);
-            digestNanos += System.nanoTime() - start;
-            bytes++;
-        }
-
-        private void requireFinished() {
-            if (!finished) {
-                throw new IllegalStateException("final part metadata requested before durable close");
-            }
-        }
     }
 
     /**

--- a/swath-core/src/main/java/io/varve/swath/sort/SortedParquetWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortedParquetWriter.java
@@ -6,6 +6,7 @@
 package io.varve.swath.sort;
 
 import io.varve.swath.model.ListEntry;
+import io.varve.swath.output.parquet.DigestingOutputFile;
 import io.varve.swath.output.parquet.ListEntryWriteSupport;
 import io.varve.swath.output.parquet.ParquetSchema;
 import java.io.IOException;
@@ -77,7 +78,7 @@ public final class SortedParquetWriter implements SortedFileWriter {
 
     private final Path path;
     private final ParquetWriter<ListEntry> writer;
-    private final ListEntryParquetWriters.DigestingOutputFile output;
+    private final DigestingOutputFile output;
     private long rows;
     private long boundsBytes;
     private byte[] firstKey;
@@ -175,6 +176,7 @@ public final class SortedParquetWriter implements SortedFileWriter {
         // publishing a part with no stamp at all.
         long closeStart = System.nanoTime();
         ListEntryParquetWriters.closeWithDurability(path, writer);
+        output.markDurable();
         long closeNanos = System.nanoTime() - closeStart;
         finalMetadata = new FinalPartMetadata(rows, output.bytes(), output.md5(),
                 firstKey == null ? null : new String(firstKey, StandardCharsets.UTF_8),

--- a/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
@@ -16,7 +16,9 @@ import io.varve.swath.testkit.PageBatches;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -373,6 +375,16 @@ class SharedDatasetWriterPoolFailureTest {
                         throw new IOException("discard failed");
                     }
                 }
+
+                @Override public String md5() {
+                    try {
+                        return HexFormat.of().formatHex(MessageDigest.getInstance("MD5").digest());
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                }
+
+                @Override public long digestNanos() { return 0L; }
 
                 private void awaitRelease() throws IOException {
                     try {

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/PartWriterStreamingDigestTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/PartWriterStreamingDigestTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.varve.swath.testkit.PageBatches;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class PartWriterStreamingDigestTest {
+
+    @Test
+    void streamsTheExactFinalParquetBytesAndExposesThemOnlyAfterDurableClose(@TempDir Path dir)
+            throws Exception {
+        Path path = dir.resolve("part.parquet");
+        PartWriter writer = new PartWriter(path, ParquetSchema.canonical());
+        writer.write(PageBatches.batch(0, 0, 0, 1).entries().getFirst());
+
+        assertThatThrownBy(writer::md5).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("before durable close");
+        writer.close();
+
+        assertThat(writer.md5()).isEqualTo(DigestUtils.md5Hex(Files.readAllBytes(path)));
+        assertThat(writer.digestNanos()).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    void discardCannotExposeADigest(@TempDir Path dir) throws Exception {
+        PartWriter writer = new PartWriter(dir.resolve("part.parquet"), ParquetSchema.canonical());
+        writer.write(PageBatches.batch(0, 0, 0, 1).entries().getFirst());
+
+        writer.discard();
+
+        assertThatThrownBy(writer::md5).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("before durable close");
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/text/TextWriterPoolTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.zip.GZIPInputStream;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -78,6 +79,36 @@ final class TextWriterPoolTest {
         try (InputStream in = new ZstdInputStream(Files.newInputStream(part))) {
             assertThat(new String(in.readAllBytes(), StandardCharsets.UTF_8).lines()).hasSize(4);
         }
+    }
+
+    @Test
+    void streamingDigestMatchesExactPhysicalPartBytesForEveryTextCompression(@TempDir Path dir)
+            throws Exception {
+        for (TextCompression compression : TextCompression.values()) {
+            Path part = dir.resolve("part-" + compression + ".jsonl");
+            TextDatasetFormat format = new TextDatasetFormat(OutputFormat.JSONL, compression, true);
+            var writer = format.openPart(part);
+            writer.write(PageBatches.batch(0, 0, 0, 1).entries().getFirst());
+
+            assertThatThrownBy(writer::md5).isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("before durable close");
+            writer.close();
+
+            assertThat(writer.md5()).isEqualTo(DigestUtils.md5Hex(Files.readAllBytes(part)));
+            assertThat(writer.digestNanos()).isGreaterThanOrEqualTo(0L);
+        }
+    }
+
+    @Test
+    void textAbortCannotExposeADigest(@TempDir Path dir) throws Exception {
+        TextDatasetFormat format = new TextDatasetFormat(OutputFormat.JSONL, TextCompression.GZIP, true);
+        var writer = format.openPart(dir.resolve("part.jsonl.gz"));
+        writer.write(PageBatches.batch(0, 0, 0, 1).entries().getFirst());
+
+        writer.discard();
+
+        assertThatThrownBy(writer::md5).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("before durable close");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Compute direct Parquet and partitioned-text part MD5 values as physical bytes are written.
- Retain the close-plus-fsync boundary before a digest can enter a manifest.
- Reuse the Parquet output decorator for sorted final metadata and document streamed digest metrics.
- Cover Parquet plus plain, gzip, and Zstandard text parts against full-file MD5 values.

## Verification

- Focused writer, text, failure, sorted, abort, and metrics suites.
- The full build ran; its only failures were the separate default-timezone replay defect fixed by #127.

## Review

Claude Opus performed a read-only review and found no P0/P1 lifecycle, physical-byte, manifest, or sorted-semantics issue. Its one valid unused-import finding was removed.
