### PR TITLE
Fix writer shutdown admission liveness

### DIFF
--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -401,7 +401,15 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
   occupy a *contiguous* run of that writer's parts (which finalize in order)
   — this is what makes the `durable_cursor` advance (algorithms.md §4.5)
   sound. A part file holds pages from many nodes and a node's pages may span
-  several parts; **there is no one-part-per-node rule.**
+  several parts; **there is no one-part-per-node rule.** Admission is closed
+  atomically before shutdown queues each lane's poison sentinel. A submitter
+  blocked by a full sticky lane waits only on that lane's bounded-space
+  condition, never while holding the lifecycle admission barrier: close or abort can
+  therefore revoke admission and wake it even if the lane's writer is wedged.
+  On wake, the submitter rechecks the barrier before enqueueing, so no batch
+  can land behind poison. Already-admitted batches drain before a graceful
+  close publishes; a submitter still waiting for a full lane when close starts
+  is rejected rather than becoming an implicit part of that successful close.
 - Each writer rotates its open part by **target size** (default 256 MB), or,
   whichever fires first, by **time-open** or **row count** (`--part-rotation-
   interval` / `--part-rotation-max-rows`, default 30 s / 2M rows) —

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -46,8 +48,10 @@ import org.apache.commons.codec.digest.DigestUtils;
  *
  * <p><b>Publication.</b> A part becomes consumer-visible only after {@link
  * DatasetPartWriter#close()} succeeds; every finalized part is added to the atomic {@code
- * manifest.json}. On {@link #close()} (success) each lane finalizes its open part and writes
- * {@code _SUCCESS} last. On {@link #abort()} (failure) each lane discards its open part. When a
+ * manifest.json}. On {@link #close()} (success) each already-admitted lane batch drains, each
+ * lane finalizes its open part, and {@code _SUCCESS} is written last. A concurrent submitter
+ * still waiting for a full lane when close begins is rejected rather than admitted into that
+ * successful close. On {@link #abort()} (failure) each lane discards its open part. When a
  * durable listener is configured (the Parquet sink), it advances the checkpoint before manifest
  * publication so resume retains only finalized parts. Text datasets deliberately provide no
  * resume contract in this release.
@@ -246,38 +250,15 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
 
     /** Route a batch to its sticky lane (blocking on a full lane queue — backpressure). */
     public void submit(PageBatch batch) throws OutputException, InterruptedException {
-        lifecycleLock.readLock().lockInterruptibly();
-        try {
-            if (shutdownMode.get() != ShutdownMode.OPEN) {
-                throw new OutputException(sinkName + " writer pool is shutting down");
-            }
-            checkFailure();
-            int laneId = (int) Math.floorMod(batch.nodeId(), numWriters);
-            Lane lane = lanes[laneId];
-            if (!lane.queue.offer(batch)) {
-                // Pay for the clock and bounded cross-lane scan only on the saturated path. This is the
-                // missing middle link between consumer-side emit and worker-side channel wait.
-                lane.queueDepthPeak.getAndAccumulate(lane.queueCapacity, Math::max);
-                boolean headOfLine = anotherLaneIsWaitingForWork(laneId);
-                long startedAt = nanoClock.getAsLong();
-                lane.startSubmitBlock(startedAt, headOfLine);
-                try {
-                    lane.queue.put(batch);
-                } finally {
-                    long blockedNanos = Math.max(0L, nanoClock.getAsLong() - startedAt);
-                    lane.finishSubmitBlock(startedAt, blockedNanos, headOfLine);
-                }
-            }
-            checkFailure();
-        } finally {
-            lifecycleLock.readLock().unlock();
-        }
+        int laneId = (int) Math.floorMod(batch.nodeId(), numWriters);
+        lanes[laneId].admit(batch);
+        checkFailure();
     }
 
     /** Whether this blocked sticky lane stranded another writer that had no queued work. */
     private boolean anotherLaneIsWaitingForWork(int selectedLane) {
         for (Lane lane : lanes) {
-            if (lane.id != selectedLane && lane.waitingForWork && lane.queue.isEmpty()) {
+            if (lane.id != selectedLane && lane.waitingForWork && lane.isEmpty()) {
                 return true;
             }
         }
@@ -335,16 +316,16 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             while (true) {
                 // Floor the poll WAIT (never the staleness check in rotationReason()) so a tiny
                 // positive rotationIntervalNanos can't spin this thread — see ROTATION_POLL_FLOOR_NANOS.
-                PageBatch batch = lane.queue.poll();
+                PageBatch batch = lane.dequeueNow();
                 if (batch == null) {
                     // The busy path still pays for one queue operation and no waiting-state
                     // writes. Publish idleness only after an immediate poll finds no work.
                     lane.waitingForWork = true;
                     try {
                         batch = rotationIntervalNanos > 0
-                                ? lane.queue.poll(Math.max(rotationIntervalNanos, ROTATION_POLL_FLOOR_NANOS),
+                                ? lane.dequeueWithin(Math.max(rotationIntervalNanos, ROTATION_POLL_FLOOR_NANOS),
                                         TimeUnit.NANOSECONDS)
-                                : lane.queue.take();
+                                : lane.dequeue();
                     } finally {
                         lane.waitingForWork = false;
                     }
@@ -673,11 +654,23 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
 
     /** Close admission atomically; the first close/abort request owns the terminal mode. */
     private void beginShutdown(ShutdownMode requested) {
+        boolean changed;
         lifecycleLock.writeLock().lock();
         try {
-            shutdownMode.compareAndSet(ShutdownMode.OPEN, requested);
+            changed = shutdownMode.compareAndSet(ShutdownMode.OPEN, requested);
         } finally {
             lifecycleLock.writeLock().unlock();
+        }
+        if (changed) {
+            // A submitter never holds lifecycleLock while waiting for a saturated lane: that
+            // would stop this transition from starting. Do not take a lane admission lock until
+            // AFTER releasing the lifecycle write lock — submitters take them in the opposite
+            // order around their guarded offer. Signal after OPEN has been revoked so a waiter
+            // retries its guarded offer, observes the terminal mode, and cannot enqueue behind
+            // the poison sentinel that drainAndJoin() will install.
+            for (Lane lane : lanes) {
+                lane.signalAdmissionWaiters();
+            }
         }
     }
 
@@ -710,7 +703,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             Throwable terminal = null;
             try {
                 for (Lane lane : lanes) {
-                    lane.queue.put(POISON);
+                    lane.enqueuePoison();
                 }
                 for (Future<?> f : laneFutures) {
                     f.get();
@@ -773,7 +766,13 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     private final class Lane {
         final int id;
         final int queueCapacity;
-        final BlockingQueue<PageBatch> queue;
+        private final BlockingQueue<PageBatch> queue;
+        // Serializes admission to this queue. A full submitter waits on notFullOrShutdown
+        // without holding lifecycleLock; dequeue and shutdown both signal it to retry the
+        // lifecycle-guarded offer. Keeping the two locks distinct is what lets abort begin even
+        // when the lane's writer is wedged.
+        final ReentrantLock admissionLock = new ReentrantLock();
+        final Condition notFullOrShutdown = admissionLock.newCondition();
         final AtomicInteger queueDepthPeak = new AtomicInteger();
         volatile boolean waitingForWork;
         // The lane thread is the sole writer for service/finalize counters; volatile makes
@@ -808,6 +807,96 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             this.queue = queue;
         }
 
+        /**
+         * Enqueue only while the lifecycle read lock proves admission remains open. On a full
+         * queue, wait on the lane-local condition instead of retaining that read lock: shutdown
+         * can then revoke OPEN, wake us, and install poison without waiting for the writer.
+         */
+        void admit(PageBatch batch) throws OutputException, InterruptedException {
+            admissionLock.lockInterruptibly();
+            boolean blocked = false;
+            boolean headOfLine = false;
+            long startedAt = 0L;
+            try {
+                while (true) {
+                    lifecycleLock.readLock().lockInterruptibly();
+                    try {
+                        if (shutdownMode.get() != ShutdownMode.OPEN) {
+                            throw new OutputException(sinkName + " writer pool is shutting down");
+                        }
+                        checkFailure();
+                        if (queue.offer(batch)) {
+                            return;
+                        }
+                    } finally {
+                        lifecycleLock.readLock().unlock();
+                    }
+                    if (!blocked) {
+                        // Pay for the clock and bounded cross-lane scan only on the saturated path. This is the
+                        // missing middle link between consumer-side emit and worker-side channel wait.
+                        queueDepthPeak.getAndAccumulate(queueCapacity, Math::max);
+                        headOfLine = anotherLaneIsWaitingForWork(id);
+                        startedAt = nanoClock.getAsLong();
+                        startSubmitBlock(startedAt, headOfLine);
+                        blocked = true;
+                    }
+                    notFullOrShutdown.await();
+                }
+            } finally {
+                if (blocked) {
+                    long blockedNanos = Math.max(0L, nanoClock.getAsLong() - startedAt);
+                    finishSubmitBlock(startedAt, blockedNanos, headOfLine);
+                }
+                admissionLock.unlock();
+            }
+        }
+
+        /** Notify one or more saturated submitters after space becomes available or OPEN closes. */
+        void signalAdmissionWaiters() {
+            admissionLock.lock();
+            try {
+                notFullOrShutdown.signalAll();
+            } finally {
+                admissionLock.unlock();
+            }
+        }
+
+        /** Remove work and wake a potentially blocked submitter after every successful dequeue. */
+        PageBatch dequeueNow() {
+            PageBatch batch = queue.poll();
+            if (batch != null) {
+                signalAdmissionWaiters();
+            }
+            return batch;
+        }
+
+        PageBatch dequeueWithin(long timeout, TimeUnit unit) throws InterruptedException {
+            PageBatch batch = queue.poll(timeout, unit);
+            if (batch != null) {
+                signalAdmissionWaiters();
+            }
+            return batch;
+        }
+
+        PageBatch dequeue() throws InterruptedException {
+            PageBatch batch = queue.take();
+            signalAdmissionWaiters();
+            return batch;
+        }
+
+        /** Shutdown has already revoked admission, so poison is the one permitted terminal enqueue. */
+        void enqueuePoison() throws InterruptedException {
+            queue.put(POISON);
+        }
+
+        boolean isEmpty() {
+            return queue.isEmpty();
+        }
+
+        int queueDepth() {
+            return queue.size();
+        }
+
         void startSubmitBlock(long startedAtNanos, boolean headOfLine) {
             synchronized (submitStatisticsLock) {
                 submitBlockedCount++;
@@ -838,7 +927,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             // Sampling happens on the periodic/terminal reporter, never on the sole dispatcher.
             // A saturated admission records capacity exactly in submit(); otherwise this is a
             // best-effort high-water mark at report cadence.
-            int queueDepth = queue.size();
+            int queueDepth = queueDepth();
             queueDepthPeak.getAndAccumulate(queueDepth, Math::max);
             long blockedCount;
             long blockedNanos;

--- a/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/dataset/SharedDatasetWriterPoolFailureTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import io.varve.swath.error.OutputException;
 import io.varve.swath.model.ListEntry;
 import io.varve.swath.output.parquet.DatasetLayout;
 import io.varve.swath.output.parquet.PartListener;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -134,6 +136,50 @@ class SharedDatasetWriterPoolFailureTest {
             blockedProducer.get();
             pool.abort();
         }
+        assertUnpublishedAndEmpty(directory);
+    }
+
+    @Test
+    void abortRevokesAdmissionWhileASaturatedLaneWriterIsStillBlocked(@TempDir Path directory)
+            throws Exception {
+        CountDownLatch releaseWriter = new CountDownLatch(1);
+        Fixture fixture = fixture(directory, Mode.BLOCK_FIRST_WRITE, releaseWriter);
+        SharedDatasetWriterPool pool = fixture.pool();
+        pool.submit(PageBatches.batch(0, 0, 0, 1));
+        fixture.format().writerEntered.await();
+        pool.submit(PageBatches.batch(0, 1, 1, 2));   // fill the only queue slot
+
+        AtomicReference<Throwable> submitResult = new AtomicReference<>();
+        Thread blockedSubmitter = Thread.ofPlatform().start(() -> {
+            try {
+                pool.submit(PageBatches.batch(0, 2, 2, 3));
+                submitResult.set(new AssertionError("submit behind a saturated lane unexpectedly completed"));
+            } catch (Throwable failure) {
+                submitResult.set(failure);
+            }
+        });
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                assertThat(pool.laneStatistics().get(0).submitBlockedCount()).isEqualTo(1L));
+
+        Thread aborter = Thread.ofPlatform().start(pool::abort);
+
+        assertThat(blockedSubmitter.join(Duration.ofSeconds(2)))
+                .as("abort must revoke OPEN and release a saturated submit without waiting for the writer")
+                .isTrue();
+        assertThat(submitResult.get()).isInstanceOf(OutputException.class)
+                .hasMessageContaining("shutting down");
+        assertThat(aborter.join(Duration.ofMillis(200)))
+                .as("the abort is draining the wedged lane after it has changed admission")
+                .isFalse();
+        assertThatThrownBy(() -> pool.submit(PageBatches.batch(0, 3, 3, 4)))
+                .isInstanceOf(OutputException.class)
+                .hasMessageContaining("shutting down");
+
+        releaseWriter.countDown();
+        assertThat(aborter.join(Duration.ofSeconds(2))).isTrue();
+        assertThat(fixture.format().writeCount())
+                .as("the already queued batch is discarded after abort; the rejected batch was never admitted")
+                .isEqualTo(1);
         assertUnpublishedAndEmpty(directory);
     }
 
@@ -323,6 +369,7 @@ class SharedDatasetWriterPoolFailureTest {
         private final Mode mode;
         private final CountDownLatch releaseWriter;
         private final CountDownLatch writerEntered;
+        private final AtomicInteger writes = new AtomicInteger();
 
         BlockingFormat(Mode mode, CountDownLatch releaseWriter) {
             this.mode = mode;
@@ -344,6 +391,7 @@ class SharedDatasetWriterPoolFailureTest {
                 @Override public long bufferedDataSize() { return rows; }
 
                 @Override public void write(ListEntry entry) throws IOException {
+                    writes.incrementAndGet();
                     if (mode == Mode.WRITE_FAIL || mode == Mode.WRITE_AND_DISCARD_FAIL) {
                         writerEntered.countDown();
                         awaitRelease();
@@ -383,6 +431,10 @@ class SharedDatasetWriterPoolFailureTest {
                     }
                 }
             };
+        }
+
+        int writeCount() {
+            return writes.get();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Release saturated writer-pool submitters as soon as close or abort revokes admission.
- Retain the guarded no-enqueue-after-shutdown barrier and bounded sticky queues.
- Add a deterministic wedged-writer abort race covering rejected admission and no queued write after abort.
- Document graceful-close behavior for submitters already waiting on a full lane.

## Verification

- `./gradlew :swath-core:test --tests 'io.varve.swath.output.dataset.SharedDatasetWriterPoolFailureTest' --tests 'io.varve.swath.output.parquet.ParquetWriterPoolTest'`
- `TZ=UTC ./gradlew --no-daemon build`

The default-zone build also reproduced only the separate replay timestamp defect fixed by #127.

## Review

Claude Opus performed a read-only concurrency review. Valid encapsulation, adversarial-test, and contract findings were incorporated; no blocking issue remained.
