### PR TITLE
Centralize dataset publication ownership

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -103,7 +103,9 @@ The output consumer determines the delivery contract:
 
 - stdout and file text are one-shot streams;
 - direct managed Parquet routes each node consistently to one of a small fixed number of
-  writers, finalizes parts, advances durable cursors, and atomically replaces the manifest;
+  writers. Each lane owns encoding and durable close; after its checkpoint callback commits, one
+  synchronous publication coordinator owns the monotone part set and atomically replaces the
+  manifest. The coordinator is a serialized object, not another queued worker or shutdown path;
 - sorted Parquet packs pages into bounded segments and performs a resource-bounded external
   merge before publication.
 

--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -419,8 +419,10 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
   RPO gap). The time/row triggers never fire on an empty (0-row) open part, so
   an idle lane never produces empty parts; both are disabled (`0`) for a
   single-file `-o *.parquet` destination, which must stay exactly one part. On `close()` (footer
-  fsynced) the part is marked `finalized` and added to the manifest, and
-  `durable_cursor` advances for every node whose pages it held. The cadence
+  fsynced), the lane commits its checkpoint callback first; one synchronous publication owner then
+  adds the part to its monotone set and atomically replaces the manifest. It has no queue or thread
+  of its own, so lane failures remain synchronous and shutdown has no second drain protocol.
+  `durable_cursor` advances for every node whose pages the part held. The cadence
   is evaluated on the lane's **own writer thread** — both on write (inside
   `writeBatch`) and, when a rotation interval is set, on an **idle-timeout
   wakeup** (the thread polls its queue with the interval as the timeout, so
@@ -465,6 +467,8 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
   measured envelope emit an operator warning, and `part_digest_*` / `manifest_write_*` in
   `dataset_writer` measure the resulting streamed byte-exact digest work and serialized manifest
   work directly.
+  The same publication owner writes the final state and symlink artifacts and `_SUCCESS` last,
+  after every lane has joined; its terminal state rejects any later part publication.
   **Resume bookkeeping stays out of the consumer manifest**: `args_hash` and
   the checkpoint `run_id` live in the internal `.swath-state.json` (same
   atomic write). For every directory format, swath creates and fsyncs that

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetPublication.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/DatasetPublication.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+import io.varve.swath.error.OutputException;
+import io.varve.swath.output.parquet.Manifest;
+import io.varve.swath.output.parquet.PartInfo;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+/**
+ * Single owner of an unsorted dataset's published part set and root artifacts.
+ *
+ * <p>Lane threads close and fsync their own parts, compute immutable metadata, and commit the
+ * checkpoint before calling {@link #publishFinalizedPart}. This object then serializes the
+ * consumer-visible transition: add the part to its monotone in-memory set and atomically replace
+ * {@code manifest.json}. It deliberately owns no thread or queue; adding either would create a
+ * second failure and shutdown protocol merely to serialize work that already occurs only at part
+ * boundaries.
+ *
+ * <p>{@link #publishSuccess} is the terminal transition. It rewrites the full manifest, writes the
+ * state and symlink artifacts, and writes {@code _SUCCESS} last. Once that transition succeeds or
+ * fails, no later part can be published.
+ */
+final class DatasetPublication {
+    private final Path dir;
+    private final String bucket;
+    private final DatasetFormat format;
+    private final String argsHash;
+    private final LongSupplier nanoClock;
+    private final List<PartInfo> committedParts;
+    private final AtomicLong committedPartCount;
+    private final AtomicLong committedBytes;
+    private final AtomicLong manifestWriteCount = new AtomicLong();
+    private final AtomicLong manifestWriteNanos = new AtomicLong();
+
+    private boolean successPublished;
+    private Throwable terminalFailure;
+
+    DatasetPublication(Path dir, String bucket, DatasetFormat format, String argsHash,
+            List<PartInfo> existingParts, LongSupplier nanoClock) {
+        this.dir = dir;
+        this.bucket = bucket;
+        this.format = format;
+        this.argsHash = argsHash;
+        this.nanoClock = nanoClock;
+        this.committedParts = new ArrayList<>(existingParts);
+        this.committedPartCount = new AtomicLong(existingParts.size());
+        this.committedBytes = new AtomicLong(
+                existingParts.stream().mapToLong(PartInfo::bytes).sum());
+    }
+
+    /**
+     * Publish one already-durable, already-checkpointed part.
+     *
+     * <p>The part stays in the owned set if the manifest replacement fails. Its checkpoint record
+     * is already authoritative, so rolling it back here would make a later full publication omit a
+     * committed part. Another lane's later replacement may therefore make this part visible even
+     * though this call failed; the pool still records and surfaces the original failure.
+     */
+    void publishFinalizedPart(PartInfo part) throws IOException {
+        long startedAt = nanoClock.getAsLong();
+        boolean attemptedWrite = false;
+        try {
+            synchronized (this) {
+                ensureAcceptingParts();
+                committedParts.add(part);
+                committedPartCount.incrementAndGet();
+                committedBytes.addAndGet(part.bytes());
+                attemptedWrite = true;
+                writeManifestLocked();
+            }
+        } finally {
+            if (attemptedWrite) {
+                recordManifestWrite(startedAt);
+            }
+        }
+    }
+
+    /** Publish the whole-snapshot artifacts exactly once; concurrent callers serialize here. */
+    synchronized void publishSuccess() throws OutputException {
+        if (successPublished) {
+            return;
+        }
+        if (terminalFailure != null) {
+            throw publicationFailure(terminalFailure);
+        }
+        try {
+            long startedAt = nanoClock.getAsLong();
+            try {
+                writeManifestLocked();
+            } finally {
+                recordManifestWrite(startedAt);
+            }
+            List<PartInfo> snapshot = List.copyOf(committedParts);
+            Manifest.writeState(dir, argsHash, null);
+            Manifest.writeSymlink(dir, snapshot);
+            Manifest.writeSuccess(dir);   // LAST — the whole-snapshot completion marker
+            successPublished = true;
+        } catch (Throwable failure) {
+            terminalFailure = failure;
+            throw publicationFailure(failure);
+        }
+    }
+
+    long committedPartCount() {
+        return committedPartCount.get();
+    }
+
+    long committedBytes() {
+        return committedBytes.get();
+    }
+
+    long manifestWriteCount() {
+        return manifestWriteCount.get();
+    }
+
+    long manifestWriteNanos() {
+        return manifestWriteNanos.get();
+    }
+
+    private void ensureAcceptingParts() {
+        if (successPublished) {
+            throw new IllegalStateException("cannot publish a dataset part after _SUCCESS");
+        }
+        if (terminalFailure != null) {
+            throw new IllegalStateException("cannot publish a dataset part after publication failed",
+                    terminalFailure);
+        }
+    }
+
+    /** Caller holds this object's monitor, making every emitted manifest a monotone snapshot. */
+    private void writeManifestLocked() throws IOException {
+        Manifest.write(dir, bucket, format.manifestFormat(), format.manifestSchema(),
+                committedParts, false, null);
+    }
+
+    private void recordManifestWrite(long startedAt) {
+        manifestWriteCount.incrementAndGet();
+        manifestWriteNanos.addAndGet(Math.max(0L, nanoClock.getAsLong() - startedAt));
+    }
+
+    private static OutputException publicationFailure(Throwable failure) {
+        return new OutputException("failed to write manifest", failure);
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
+++ b/swath-core/src/main/java/io/varve/swath/output/dataset/SharedDatasetWriterPool.java
@@ -10,14 +10,12 @@ import io.varve.swath.error.OutputException;
 import io.varve.swath.model.ListEntry;
 import io.varve.swath.model.PageBatch;
 import io.varve.swath.output.parquet.DatasetLayout;
-import io.varve.swath.output.parquet.Manifest;
 import io.varve.swath.output.parquet.PartInfo;
 import io.varve.swath.output.parquet.PartListener;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -131,12 +129,10 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
      */
     private static final long ROTATION_POLL_FLOOR_NANOS = 50_000_000L;   // 50 ms
 
-    private final Path dir;
     private final String sinkName;
     private final DatasetLayout layout;
     private final DatasetFormat format;
-    private final String argsHash;
-    private final String bucket;
+    private final DatasetPublication publication;
     private final int numWriters;
     private final long targetBytes;
     private final long rotationIntervalNanos;
@@ -163,11 +159,6 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
     private final AtomicLong partDigestCount = new AtomicLong();
     private final AtomicLong partDigestNanos = new AtomicLong();
-    private final AtomicLong manifestWriteCount = new AtomicLong();
-    private final AtomicLong manifestWriteNanos = new AtomicLong();
-
-    private final List<PartInfo> committedParts = Collections.synchronizedList(new ArrayList<>());
-    private final Object manifestLock = new Object();
     private enum ShutdownMode { OPEN, CLOSE, ABORT }
 
     /**
@@ -179,8 +170,6 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             new AtomicReference<>(ShutdownMode.OPEN);
     private final AtomicBoolean joinInitiated = new AtomicBoolean();
     private final CompletableFuture<Void> joined = new CompletableFuture<>();
-    private final AtomicBoolean publicationInitiated = new AtomicBoolean();
-    private final CompletableFuture<Void> published = new CompletableFuture<>();
 
     /** The pool owns scheduling and publication; the adapter owns encoding. */
     public SharedDatasetWriterPool(Path dir, DatasetFormat format, String argsHash,
@@ -203,13 +192,10 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
                     + numWriters + ", queueCapacity=" + queueCapacity + ", aggregate="
                     + (long) numWriters * queueCapacity + ")");
         }
-        this.dir = dir;
         this.sinkName = config.sinkName();
         this.scope = Scope.ofPlatformThreads(sinkName + "-writer");
         this.layout = DatasetLayout.of(dir);
         this.format = format;
-        this.argsHash = argsHash;
-        this.bucket = config.bucket();
         this.numWriters = numWriters;
         this.targetBytes = targetBytes;
         this.rotationIntervalNanos = config.rotationIntervalNanos();
@@ -217,7 +203,8 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         this.nanoClock = nanoClock;
         this.partListener = config.partListener();
         this.observer = config.observer();
-        this.committedParts.addAll(config.existingParts());
+        this.publication = new DatasetPublication(dir, config.bucket(), format, argsHash,
+                config.existingParts(), nanoClock);
         this.lanes = new Lane[this.numWriters];
         for (int i = 0; i < this.numWriters; i++) {
             lanes[i] = new Lane(i, queueCapacity, new ArrayBlockingQueue<>(queueCapacity));
@@ -274,23 +261,19 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
     }
 
     public long committedPartCount() {
-        synchronized (committedParts) {
-            return committedParts.size();
-        }
+        return publication.committedPartCount();
     }
 
     public long committedBytes() {
-        synchronized (committedParts) {
-            return committedParts.stream().mapToLong(PartInfo::bytes).sum();
-        }
+        return publication.committedBytes();
     }
 
     long rotationIntervalNanos() { return rotationIntervalNanos; }
     long rotationMaxRows() { return rotationMaxRows; }
     long partDigestCount() { return partDigestCount.get(); }
     long partDigestNanos() { return partDigestNanos.get(); }
-    long manifestWriteCount() { return manifestWriteCount.get(); }
-    long manifestWriteNanos() { return manifestWriteNanos.get(); }
+    long manifestWriteCount() { return publication.manifestWriteCount(); }
+    long manifestWriteNanos() { return publication.manifestWriteNanos(); }
 
     private void checkFailure() throws OutputException {
         Throwable t = failure.get();
@@ -533,7 +516,9 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         lane.partNodeMaxKey.clear();
         partListener.onFinalized(new PartListener.PartFinalizedEvent(
                 lane.id, relPath, rows, bytes, contributions));
-        committedParts.add(new PartInfo(relPath, lane.id, rows, bytes, md5));
+        // Account the durable part before manifest I/O, preserving failure-run statistics even if
+        // the atomic manifest replacement fails. The checkpoint callback above is still the
+        // exactly-once boundary; the publication owner below retains the part on such a failure.
         observer.recordPart("finalized");
         lane.finalizedBytes += bytes;
         lane.partsFinalized++;
@@ -543,7 +528,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         // longer than the stall window and get falsely aborted (worse: it could force the STUCK
         // exit 75 over what should have been a clean --max-duration exit 0).
         observer.markProgress();
-        writeManifest();   // atomic, on each finalize
+        publication.publishFinalizedPart(new PartInfo(relPath, lane.id, rows, bytes, md5));
     }
 
     private void discardCurrent(Lane lane) throws IOException {
@@ -578,48 +563,6 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
         }
     }
 
-    private void writeManifest() throws IOException {
-        long startedAt = nanoClock.getAsLong();
-        try {
-            synchronized (manifestLock) {
-                // Snapshot under the publication lock. Otherwise lane A can snapshot an older
-                // part set, lane B can publish a newer set, and A can then overwrite it after
-                // finally acquiring this lock.
-                writeManifestLocked(snapshotParts());
-            }
-        } finally {
-            recordManifestWrite(startedAt);
-        }
-    }
-
-    /** Includes time queued behind another lane on {@link #manifestLock}. */
-    private void writeManifest(List<PartInfo> parts) throws IOException {
-        long startedAt = nanoClock.getAsLong();
-        try {
-            synchronized (manifestLock) {
-                writeManifestLocked(parts);
-            }
-        } finally {
-            recordManifestWrite(startedAt);
-        }
-    }
-
-    private void writeManifestLocked(List<PartInfo> parts) throws IOException {
-        Manifest.write(dir, bucket, format.manifestFormat(), format.manifestSchema(),
-                parts, false, null);
-    }
-
-    private void recordManifestWrite(long startedAt) {
-        manifestWriteCount.incrementAndGet();
-        manifestWriteNanos.addAndGet(Math.max(0L, nanoClock.getAsLong() - startedAt));
-    }
-
-    private List<PartInfo> snapshotParts() {
-        synchronized (committedParts) {
-            return new ArrayList<>(committedParts);
-        }
-    }
-
     /**
      * Graceful completion: finalize every lane's open part, commit the consumer manifest, then write
      * the final-commit artifacts: {@code .swath-state.json} (with a null run id — the
@@ -633,7 +576,7 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             throw new OutputException(sinkName + " writer pool was aborted");
         }
         checkFailure();
-        publishSuccess();
+        publication.publishSuccess();
     }
 
     /** Failure path: discard open (non-finalized) parts; finalized parts + their manifest remain. */
@@ -665,30 +608,6 @@ public final class SharedDatasetWriterPool implements DatasetWriterPool {
             for (Lane lane : lanes) {
                 lane.signalAdmissionWaiters();
             }
-        }
-    }
-
-    /** Publish final metadata once; idempotent concurrent {@link #close()} callers await it. */
-    private void publishSuccess() throws OutputException {
-        if (publicationInitiated.compareAndSet(false, true)) {
-            try {
-                List<PartInfo> snapshot = snapshotParts();
-                writeManifest(snapshot);   // ensure a manifest exists
-                Manifest.writeState(dir, argsHash, null);
-                Manifest.writeSymlink(dir, snapshot);
-                Manifest.writeSuccess(dir);   // LAST — the whole-snapshot completion marker
-                published.complete(null);
-            } catch (Throwable t) {
-                published.completeExceptionally(t);
-            }
-        }
-        try {
-            published.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new OutputException("interrupted publishing " + sinkName + " dataset", e);
-        } catch (ExecutionException e) {
-            throw new OutputException("failed to write manifest", e.getCause());
         }
     }
 

--- a/swath-core/src/test/java/io/varve/swath/output/dataset/DatasetPublicationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/dataset/DatasetPublicationTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.output.dataset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.varve.swath.error.OutputException;
+import io.varve.swath.output.parquet.Manifest;
+import io.varve.swath.output.parquet.PartInfo;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Concurrency guards for the one owner of consumer-facing dataset publication. These deliberately
+ * exercise the coordinator directly, apart from lane scheduling, because a lost manifest update
+ * would silently make finalized data unreachable to a consumer.
+ */
+class DatasetPublicationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final DatasetFormat FORMAT = new DatasetFormat() {
+        @Override public String partSuffix() { return ".test"; }
+        @Override public String manifestFormat() { return "test"; }
+        @Override public String manifestSchema() { return "test-schema"; }
+        @Override public DatasetPartWriter openPart(Path path) {
+            throw new AssertionError("DatasetPublication must not open part writers");
+        }
+    };
+
+    @Test
+    void concurrentFinalizesNeverLoseOrRegressPublishedParts(@TempDir Path dir) throws Exception {
+        int partCount = 24;
+        DatasetPublication publication = publication(dir, List.of());
+        publication.publishFinalizedPart(part(0));
+
+        CountDownLatch startingLine = new CountDownLatch(1);
+        AtomicBoolean watch = new AtomicBoolean(true);
+        AtomicReference<Throwable> watcherFailure = new AtomicReference<>();
+        try (ExecutorService executor = Executors.newFixedThreadPool(partCount)) {
+            Future<?> watcher = executor.submit(() -> {
+                Set<String> lastSeen = Set.of();
+                try {
+                    while (watch.get()) {
+                        Set<String> current = new LinkedHashSet<>(manifestPaths(dir));
+                        if (!current.containsAll(lastSeen)) {
+                            throw new AssertionError("manifest regressed from " + lastSeen + " to " + current);
+                        }
+                        lastSeen = current;
+                        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                    }
+                } catch (Throwable failure) {
+                    watcherFailure.compareAndSet(null, failure);
+                }
+            });
+
+            List<Future<?>> finalizers = new ArrayList<>();
+            for (int i = 1; i < partCount; i++) {
+                int part = i;
+                finalizers.add(executor.submit(() -> {
+                    startingLine.await();
+                    publication.publishFinalizedPart(part(part));
+                    return null;
+                }));
+            }
+            try {
+                startingLine.countDown();
+                for (Future<?> finalizer : finalizers) {
+                    finalizer.get(10, TimeUnit.SECONDS);
+                }
+            } finally {
+                watch.set(false);
+            }
+            watcher.get(10, TimeUnit.SECONDS);
+        }
+
+        assertThat(watcherFailure.get()).isNull();
+        assertThat(manifestPaths(dir)).containsExactlyInAnyOrderElementsOf(partPaths(partCount));
+        assertThat(publication.committedPartCount()).isEqualTo(partCount);
+        assertThat(publication.committedBytes()).isEqualTo(bytesFor(partCount));
+        assertThat(publication.manifestWriteCount()).isEqualTo(partCount);
+    }
+
+    @Test
+    void finalizedPartIsRejectedAfterSuccessWithoutMutatingPublishedArtifacts(@TempDir Path dir)
+            throws Exception {
+        DatasetPublication publication = publication(dir, List.of());
+        publication.publishFinalizedPart(part(0));
+        publication.publishSuccess();
+        Map<String, byte[]> before = artifacts(dir);
+
+        assertThatThrownBy(() -> publication.publishFinalizedPart(part(1)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("after _SUCCESS");
+
+        assertThat(artifacts(dir)).satisfies(after -> before.forEach((name, bytes) ->
+                assertThat(after.get(name)).as(name).isEqualTo(bytes)));
+        assertThat(manifestPaths(dir)).containsExactly(part(0).path());
+        assertThat(publication.committedPartCount()).isEqualTo(1);
+    }
+
+    @Test
+    void existingPartsSeedCountersAndRemainUniqueInFinalManifest(@TempDir Path dir) throws Exception {
+        List<PartInfo> existing = List.of(part(2), part(5));
+        DatasetPublication publication = publication(dir, existing);
+
+        assertThat(publication.committedPartCount()).isEqualTo(existing.size());
+        assertThat(publication.committedBytes()).isEqualTo(existing.stream().mapToLong(PartInfo::bytes).sum());
+
+        publication.publishFinalizedPart(part(9));
+        publication.publishSuccess();
+
+        List<String> paths = manifestPaths(dir);
+        assertThat(paths).containsExactlyInAnyOrder(part(2).path(), part(5).path(), part(9).path());
+        assertThat(new LinkedHashSet<>(paths)).hasSameSizeAs(paths);
+        assertThat(Files.readAllLines(dir.resolve(Manifest.SYMLINK_FILE_NAME)))
+                .containsExactlyInAnyOrderElementsOf(paths);
+    }
+
+    @Test
+    void finalizedPartIsRejectedAfterTerminalPublicationFailure(@TempDir Path dir) throws Exception {
+        Path notADirectory = dir.resolve("not-a-directory");
+        Files.writeString(notADirectory, "not a directory");
+        DatasetPublication publication = publication(notADirectory, List.of());
+
+        assertThatThrownBy(publication::publishSuccess).isInstanceOf(OutputException.class);
+        assertThatThrownBy(() -> publication.publishFinalizedPart(part(0)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("publication failed");
+    }
+
+    @Test
+    void failedPartManifestWriteRetainsThePartAndAllowsALaterMonotoneRewrite(@TempDir Path dir)
+            throws Exception {
+        DatasetPublication publication = publication(dir, List.of());
+        Path blockedTempFile = dir.resolve(Manifest.FILE_NAME + ".tmp");
+        Files.createDirectory(blockedTempFile);
+
+        assertThatThrownBy(() -> publication.publishFinalizedPart(part(0)))
+                .isInstanceOf(IOException.class);
+        assertThat(publication.committedPartCount()).isEqualTo(1);
+        assertThat(publication.committedBytes()).isEqualTo(part(0).bytes());
+
+        Files.delete(blockedTempFile);
+        publication.publishFinalizedPart(part(1));
+
+        assertThat(manifestPaths(dir)).containsExactly(part(0).path(), part(1).path());
+        assertThat(publication.manifestWriteCount())
+                .as("the failed replacement and its successful retry are both measured")
+                .isEqualTo(2);
+    }
+
+    @Test
+    void concurrentSuccessPublishesOneTerminalSnapshot(@TempDir Path dir) throws Exception {
+        DatasetPublication publication = publication(dir, List.of());
+        publication.publishFinalizedPart(part(0));
+        CountDownLatch startingLine = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            Future<?> first = executor.submit(() -> {
+                startingLine.await();
+                publication.publishSuccess();
+                return null;
+            });
+            Future<?> second = executor.submit(() -> {
+                startingLine.await();
+                publication.publishSuccess();
+                return null;
+            });
+            startingLine.countDown();
+            first.get(10, TimeUnit.SECONDS);
+            second.get(10, TimeUnit.SECONDS);
+        }
+
+        assertThat(dir.resolve(Manifest.SUCCESS_FILE_NAME)).exists();
+        assertThat(manifestPaths(dir)).containsExactly(part(0).path());
+        assertThat(publication.manifestWriteCount())
+                .as("one finalize and exactly one terminal snapshot write")
+                .isEqualTo(2);
+    }
+
+    private static DatasetPublication publication(Path dir, List<PartInfo> existing) {
+        AtomicLong ticks = new AtomicLong();
+        return new DatasetPublication(dir, "bucket", FORMAT, "args-hash", existing,
+                ticks::incrementAndGet);
+    }
+
+    private static PartInfo part(int number) {
+        return new PartInfo("data/part-" + number + ".test", number % 3, number + 1L,
+                100L + number, String.format("%032x", number));
+    }
+
+    private static List<String> partPaths(int count) {
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            paths.add(part(i).path());
+        }
+        return paths;
+    }
+
+    private static long bytesFor(int count) {
+        long bytes = 0;
+        for (int i = 0; i < count; i++) {
+            bytes += part(i).bytes();
+        }
+        return bytes;
+    }
+
+    private static List<String> manifestPaths(Path dir) throws IOException {
+        JsonNode files = MAPPER.readTree(Files.readString(dir.resolve(Manifest.FILE_NAME))).get("files");
+        List<String> paths = new ArrayList<>();
+        for (JsonNode file : files) {
+            paths.add(file.get("key").textValue());
+        }
+        return paths;
+    }
+
+    private static Map<String, byte[]> artifacts(Path dir) throws IOException {
+        Map<String, byte[]> artifacts = new LinkedHashMap<>();
+        for (String name : List.of(Manifest.FILE_NAME, Manifest.STATE_FILE_NAME,
+                Manifest.SYMLINK_FILE_NAME, Manifest.SUCCESS_FILE_NAME)) {
+            artifacts.put(name, Files.readAllBytes(dir.resolve(name)));
+        }
+        return artifacts;
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/MultiLaneIdleRotationCadenceTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/MultiLaneIdleRotationCadenceTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.io.TempDir;
  * lane; this drives {@code numWriters=3} with one node sticky-routed to each lane, all
  * three lanes holding a non-empty open part and going idle at once, so the idle-timeout
  * fires concurrently on three independent lane threads — exercising per-lane poll
- * wakeups, {@code writeManifest()}'s shared {@code manifestLock}, and the {@link
- * PartListener} callback all firing concurrently without corrupting the manifest or
+ * wakeups, the shared publication coordinator, and the {@link PartListener} callback all
+ * firing concurrently without corrupting the manifest or
  * dropping/duplicating a lane's contribution.
  */
 class MultiLaneIdleRotationCadenceTest {


### PR DESCRIPTION
## Summary

- Extract one synchronous owner for the committed part set, per-part manifest replacement, and terminal dataset artifacts.
- Remove the pool's synchronized-list/manifest-lock split ownership and its separate publication future/latch pair.
- Preserve checkpoint-before-manifest ordering, per-finalize atomic manifests, failure retention, and `_SUCCESS`-last.
- Keep progress counters lock-free during manifest and fsync I/O, and reject publication after a terminal success or failure.
- Add no publisher thread, queue, poison, executor, or configuration.

## Integration

Originally stacked on #128 because both changes touch part finalization. After #128 and #129 were squash-merged, this branch was rebased directly onto `main` and the combined tree was retested before merge.

## Verification

- `./gradlew --no-daemon :swath-core:test --tests 'io.varve.swath.output.dataset.DatasetPublicationTest' --tests 'io.varve.swath.output.dataset.SharedDatasetWriterPoolFailureTest' --tests 'io.varve.swath.output.parquet.ParquetWriterPoolTest' --tests 'io.varve.swath.output.text.TextWriterPoolTest' --tests 'io.varve.swath.output.parquet.ParquetWriterPoolMetricsTest'`
- `./gradlew --no-daemon build`

## Review

The adversarial publication tests were independently authored. Claude Opus performed two read-only passes: its initial contract, accounting, contention, and failure-test findings were addressed; the follow-up verdict was approve with no P0/P1 findings.
