### PR TITLE
Accelerate sorted replay serving

### DIFF
--- a/docs/ops/dev/field-investigations.md
+++ b/docs/ops/dev/field-investigations.md
@@ -179,3 +179,99 @@ far longer to accumulate splits. The equal-duration rounds are the honest compar
 splits went **up 3.5×** (146/154 vs 42/42 in the same 110 s). Suppressing hopeless probes does not
 cost parallelism — it buys it, because the thief stops spending its steal attempts on regions that
 cannot answer.
+
+---
+
+## 2026-08-24 — sorted replay-server capacity
+
+This investigation sized the standalone replay server before using it as a benchmark dependency.
+It is replay capacity evidence, not a comparative Swath result and not a throughput SLA.
+
+### Environment and method
+
+- Host: 32 logical CPUs / 16 physical Intel Xeon Platinum 8581C cores, 62 GiB RAM.
+- Server: Temurin JDK 25.0.4+7, pinned to eight physical cores; the byte-counting load client was
+  pinned to the other eight physical cores.
+- Large fixture: 1,049,162,031 object rows, 32 Parquet files, 27.997 GiB. Its routing index contained
+  3,874 row-group entries; deriving it took 2.691 seconds in the startup measurement.
+- Each reported capacity point followed a warm-up. The storage page cache was warm, so the results
+  characterize serving and decode capacity, not cold-disk bandwidth.
+- Worker responses used `max-keys=1000`. The client parsed HTTP framing without allocating a UTF-16
+  response String, and server metrics plus process CPU verified that it did not cap the eight-core
+  server.
+
+### Request shapes
+
+Capacity pressure covered the three shapes Swath emits:
+
+| Shape | Request | Important server path |
+| --- | --- | --- |
+| `worker_page` | ordinary listing page, normally 1,000 objects | continuation walk and prefetch |
+| `pivot_probe` | delimiter-free request with `max-keys<=1` | random/far key seek, normally no useful prefetch |
+| `structure_probe` | `delimiter=/` request | routing bounds plus native row-group skip-scan when needed |
+
+The mixed test used 93% worker pages, 5% far pivots outside the active worker windows, and 2% real
+parent-prefix structure probes. This corrected an earlier locality-optimistic test whose pivots were
+usually cache hits and whose delimiter probes targeted the empty root prefix.
+
+This is request-*shape* coverage, not a claim that one synthetic ratio represents every Swath run.
+Protocol correctness is covered separately and more broadly by the conformance harness and
+adversarial tests: prefix, delimiter, start-after, continuation token, truncation, empty results,
+URL encoding, owner/no-owner responses, and XML escaping. A future trace-driven load command should
+replay a captured Swath arrival stream when an exact production distribution matters.
+
+### Capacity results
+
+All rows below used eight physical server cores, reader pool 8, and zero HTTP errors:
+
+| Fixture/workload | Prefetch | Heap/windows | Result |
+| --- | --- | --- | ---: |
+| 9,919,142-row fixture, distributed warm random pages | off | 4 GiB / n/a | **6.126M rows/s** |
+| 1.049B-row fixture, 16 sequential continuation walks | on | 8 GiB / 24 | **5.517M rows/s** |
+| 1.049B-row fixture, corrected 93/5/2 mixed shapes | on | 8 GiB / 24 | **4.153M rows/s**, 4,464 requests/s |
+
+The large-fixture result shows that total cardinality is not itself a throughput cliff. Physical
+page geometry and access locality matter: sequential workers reuse prefetched windows, while far
+pivots and delimiter probes pay more seek/decode work.
+
+### Heap and reader-pool knees
+
+At fixed eight cores, pool 8, 16 continuation walks, and a 60-second measurement:
+
+| Heap / windows | Sustained rows/s | RSS before forced GC | Post-force-GC used heap |
+| --- | ---: | ---: | ---: |
+| 2 GiB / 16 | 4.661M | 2.35 GiB | 432 MiB |
+| 3 GiB / 24 | 4.852M | 3.35 GiB | 431 MiB |
+| 4 GiB / 24 | **5.468M** | 4.31 GiB | 557 MiB |
+| 8 GiB / 24 | 5.517M (30-second point) | 6.47 GiB after prior mixed load | 626 MiB |
+
+Four GiB was the practical knee. Two and three GiB retained little live data after forced GC but
+lost throughput to allocation/collection pressure. Forcing two-MiB G1 regions at a two-GiB heap
+reduced throughput further, so automatic G1 region sizing remains the recommendation.
+
+At fixed four-GiB heap and 24 windows:
+
+| Reader pool | Sustained rows/s | Peak readers | Mean page-read latency |
+| ---: | ---: | ---: | ---: |
+| 8 | **5.468M** | 8 | 12.18 ms |
+| 12 | 5.509M | 12 | 12.06 ms |
+| 16 | 5.072M | 16 | 14.29 ms |
+
+Pool 12's 0.75% edge was within single-run noise and required 50% more open readers and decoded
+footers. Pool 16 was 7.2% slower and increased GC pressure. This drove the sorted default from two
+readers per visible CPU to one, bounded to 8–32.
+
+### Correctness and limits
+
+The optimized and untouched implementations produced byte-identical complete responses over all
+9,920 pages and 9,919,142 objects of the smaller fixture, including owner fields: 2,886,109,739
+response bytes with SHA-256
+`20078b857c86ff394ec9794da39e231507658004bb678058f05443ef75993c1e` on both sides. The full build,
+replay integration tests, HAR conformance, sorted-vs-DuckDB differentials, and adversarial XML tests
+also passed.
+
+The saturation client used for this investigation was diagnostic and is not a supported release
+command: its distributed anchors were fixture-derived and its mixed ratio was synthetic. The
+built-in `bench` command remains the reproducible correctness/warm single-walk tool; it does not
+saturate an eight-core server. Do not use these figures to infer cold-storage performance, remote
+network capacity, or an exact production request distribution.

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -143,6 +143,53 @@ uses only the range pool; an engaged skip-scan holds one row-group reader while 
 borrow a range reader to materialize a bare object. The first engagement for each file is visible
 through `delimiter.reader_pool.open.latency`.
 
+### Resource sizing for sorted serving
+
+Fixture cardinality does not become a heap-sized object index. At startup, sorted mode retains
+file/footer state and one routing entry per Parquet row group. Object rows are decoded on demand
+into bounded reader and prefetch windows; fixture bytes remain on storage and may occupy the OS
+page cache outside the JVM heap. Consequently, row-group count, file count, active readers, page
+geometry, and cached windows are more useful sizing inputs than the fixture's total object count.
+
+For an eight-CPU replay allocation driving up to 16 independent continuation walks, start with:
+
+```bash
+export JAVA_TOOL_OPTIONS='-Xms4g -Xmx4g -Dswath.replay.prefetch.max-windows=24'
+
+swath-replay serve \
+  --fixture <sorted-fixture> --bucket <bucket> \
+  --host 127.0.0.1 --port 19090 --serving-mode sorted \
+  --parquet-connections 0 --max-concurrent-requests 512 \
+  --metrics-port 19192
+```
+
+This is a capacity-test starting point, not a minimum. Leave G1 region sizing automatic and leave
+headroom above `-Xmx` for JVM native state and the OS page cache. The default 96-window cache is the
+safer starting point for wider or unknown fan-out; 24 windows was the measured knee for 16 active
+walks. A window retains decoded rows, so `max-windows` and heap must be tuned together.
+
+Tune one resource at a time after warming the JVM and storage cache:
+
+1. Keep prefetch enabled for continuation-heavy worker traffic. Disable it only to isolate random
+   seek/decode cost; that is a different workload, not a generally faster configuration.
+2. Compare `parquet.queries.peak` with the reader count. If the pool is full, CPU has headroom, and
+   `page.read.latency` is stable, try a small increase. If page latency or GC rises, reduce it.
+   Reader count is decode parallelism, not HTTP concurrency.
+3. Size `max-windows` near the number of independently advancing worker streams, with some headroom.
+   Use the prefetch hit/miss and live-window meters rather than retaining windows speculatively.
+4. Set `--max-concurrent-requests` at or above client fan-out, then verify that the client—not only
+   the server—has spare CPU. An undersized client can make a server change look neutral.
+5. Measure `worker_page`, `pivot_probe`, and `structure_probe` separately. Full pages benefit most
+   from prefetch; one-key pivots and delimiter skip-scans exercise different Parquet paths.
+
+On 2026-08-24, warm loopback saturation tests on eight isolated physical Xeon 8581C cores measured
+about **4.15–5.52 million object rows/s** over a 1.049-billion-row, 32-file fixture, depending on
+request mixture. A smaller warm random-page fixture reached **6.13 million rows/s**. Treat these as
+an order-of-magnitude capacity corridor, not a portable guarantee: CPU generation, Parquet page
+geometry, filesystem cache state, response fields, request locality, and client cost all move it.
+The setup, shape mix, resource sweep, and limitations are retained in the
+[dated field investigation](ops/dev/field-investigations.md#2026-08-24--sorted-replay-server-capacity).
+
 ## Reading a running server's meters (`--metrics-port`)
 
 `serve` keeps every meter in the table under "Metrics And Tuning" below, but a

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -132,14 +132,16 @@ Jetty's implicit 200-thread default. It defaults to 512 and is reported as
 connector queueing is not mistaken for backend latency.
 
 `--parquet-connections 0` uses the selected store's own reader default:
-`max(8, min(32, 2 × cores))` for sorted serving and `min(4, cores)` for DuckDB.
+`max(8, min(32, cores))` for sorted serving and `min(4, cores)` for DuckDB.
 Size this for concurrent decode work, not total requests: readers are returned before
 injected sleep. Each sorted slot holds an open reader and decoded footer per file, so
-very large pools can waste file descriptors and heap. Sorted mode opens both a row-group
-and range-reader pool per file: approximately `2 × connections × files` open readers. Those
-pools are independent. An ordinary range fill uses only the range pool; a native `delimiter=/`
-skip-scan holds one row-group reader while it may briefly borrow a range reader to materialize
-a bare object.
+very large pools can waste file descriptors and heap. Sorted mode eagerly opens the range-reader
+pool per file (`connections × files` readers). Its independent row-group pool opens lazily, one
+file at a time, only when a native `delimiter=/` skip-scan cannot answer from routing-index bounds;
+the conservative fully engaged bound remains `2 × connections × files`. An ordinary range fill
+uses only the range pool; an engaged skip-scan holds one row-group reader while it may briefly
+borrow a range reader to materialize a bare object. The first engagement for each file is visible
+through `delimiter.reader_pool.open.latency`.
 
 ## Reading a running server's meters (`--metrics-port`)
 
@@ -315,9 +317,9 @@ Replay meters use the `swath.replay.*` namespace. Important groups are:
 | `sortfixture.build.latency`, `sortfixture.output.bytes`, `sort.steal_reason{outcome,reason}` | Legacy-fixture sort work and engagement. |
 | `index.load.latency{source=derived}`, `index.entries` | Sorted routing-index construction. |
 | `serving.path{mode}`, `serving.fallback{reason}`, `serving.refused{reason}` | Selected path, startup decline, or request-time safety refusal. |
-| `delimiter.path{path}`, `delimiter.skipscan.row_group_opens`, `delimiter.skipscan.whole_group_shortcuts` | Rollup vs walk, skip-scan I/O, and routing-index-only whole-group engagements. |
+| `delimiter.path{path}`, `delimiter.skipscan.row_group_opens`, `delimiter.skipscan.whole_group_shortcuts`, `delimiter.reader_pool.open.latency` | Rollup vs walk, skip-scan I/O, routing-index-only whole-group engagements, and lazy per-file delimiter-pool first touch (timer count = files opened). |
 | `page.read.latency`, `fixture.list.latency` | Post-borrow range-decode service time (pool wait excluded) and complete pager operation. Cache hits add no page-read sample. |
-| `parquet.queries.in_flight`, `parquet.queries.peak` | Current and run-peak acquired backing readers. DuckDB is bounded by `connections`; sorted serving has independent row-group and range pools and a conservative aggregate bound of `2 × connections × files`. |
+| `parquet.queries.in_flight`, `parquet.queries.peak` | Current and run-peak acquired backing readers. DuckDB is bounded by `connections`; sorted serving eagerly holds `connections × files` range readers and has the conservative fully engaged bound `2 × connections × files` after every lazy row-group pool opens. |
 | `request.latency{shape}` | Server request cost, including reader-pool wait but excluding injected delay, separated into `worker_page`, `pivot_probe`, and `structure_probe`. |
 | `inject.overrun{shape}`, `inject.overrun.ms{shape}` | Requests exceeding the injected profile and their excess latency. Absent when injection is off; zero overruns is the healthy state. |
 | `prefetch.window.fill`, `prefetch.window.hit`, `prefetch.window.miss{reason}`, `prefetch.fill.rows` | Window-cache cost, effectiveness, and ramp behavior. |

--- a/swath-core/src/main/java/io/varve/swath/sort/SortedRangeReader.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortedRangeReader.java
@@ -437,6 +437,7 @@ public final class SortedRangeReader implements AutoCloseable {
 
         private static PrimitiveConverter string(java.util.function.Consumer<String> sink) {
             return new PrimitiveConverter() {
+                private Dictionary dictionarySource;
                 private String[] dictionary;
 
                 @Override
@@ -446,15 +447,18 @@ public final class SortedRangeReader implements AutoCloseable {
 
                 @Override
                 public void setDictionary(Dictionary values) {
+                    dictionarySource = values;
                     dictionary = new String[values.getMaxId() + 1];
-                    for (int id = 0; id < dictionary.length; id++) {
-                        dictionary[id] = values.decodeToBinary(id).toStringUsingUTF8();
-                    }
                 }
 
                 @Override
                 public void addValueFromDictionary(int dictionaryId) {
-                    sink.accept(dictionary[dictionaryId]);
+                    String value = dictionary[dictionaryId];
+                    if (value == null) {
+                        value = dictionarySource.decodeToBinary(dictionaryId).toStringUsingUTF8();
+                        dictionary[dictionaryId] = value;
+                    }
+                    sink.accept(value);
                 }
 
                 @Override

--- a/swath-core/src/main/java/io/varve/swath/sort/SortedRangeReader.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortedRangeReader.java
@@ -19,9 +19,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
+import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.example.data.Group;
-import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -38,6 +37,10 @@ import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.RecordReader;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 
 /**
@@ -167,9 +170,18 @@ public final class SortedRangeReader implements AutoCloseable {
             readerAcquired.run();
             acquisitionRecorded = true;
             readStartedNanos = nanoClock.getAsLong();
-            reader.setRequestedSchema(schema);
             for (int block = Math.max(0, startRowGroup); block < blocks.size() && out.size() < limit; block++) {
+                // ParquetFileReader caches a block's ColumnIndexStore the first time it is asked
+                // for it, but builds that store only for the reader's currently requested paths.
+                // A pooled reader can alternate between the owner and no-owner projections. If a
+                // no-owner request creates the cache first, a later owner request asks
+                // readFilteredRowGroup for owner offset indexes that are absent from the cached
+                // store; parquet-java then dereferences null inside filterOffsetIndex. Prime each
+                // block's cache under the maximal projection before selecting the response's real
+                // projection. This reads no data pages and preserves the no-owner decode saving.
+                reader.setRequestedSchema(schemaWithOwner);
                 ColumnIndexStore indexStore = reader.getColumnIndexStore(block);
+                reader.setRequestedSchema(schema);
                 RowRanges ranges = ColumnIndexFilter.calculateRowRanges(
                         filter, indexStore, FILTERED_COLUMNS, blocks.get(block).getRowCount());
                 if (ranges.rowCount() == 0) {
@@ -208,20 +220,20 @@ public final class SortedRangeReader implements AutoCloseable {
             throws IOException {
         try (PageReadStore pages = reader.readFilteredRowGroup(block, ranges)) {
             long rowCount = pages.getRowCount();
-            RecordReader<Group> rowReader =
-                    columnIo.getRecordReader(pages, new GroupRecordConverter(schema));
+            RecordReader<ObjectRow> rowReader =
+                    columnIo.getRecordReader(pages, new ObjectRowMaterializer(schema, includeOwner));
             for (long i = 0; i < rowCount && out.size() < limit; i++) {
-                Group g = rowReader.read();
-                if (!isObject(g)) {
+                ObjectRow row = rowReader.read();
+                if (row == null) {
                     // Eligibility should have excluded a fixture carrying anything else, but a
                     // reader that assumes it would serve a rolled-up prefix as an object.
                     continue;
                 }
-                byte[] key = g.getBinary(KEY_FIELD, 0).getBytes();
+                byte[] key = row.keyUnsafe();
                 if (!inRange(key, from, fromInclusive, toExclusive)) {
                     continue;   // the index prunes pages, never rows
                 }
-                out.add(SortedRowGroupReader.toObjectRow(g, key, includeOwner));
+                out.add(row);
             }
         }
     }
@@ -295,12 +307,6 @@ public final class SortedRangeReader implements AutoCloseable {
         }
     }
 
-    private static boolean isObject(Group g) {
-        return g.getFieldRepetitionCount(SortedRowGroupReader.ROW_TYPE_FIELD) > 0
-                && SortedRowGroupReader.OBJECT_ROW_TYPE.equals(
-                        g.getString(SortedRowGroupReader.ROW_TYPE_FIELD, 0));
-    }
-
     private static boolean inRange(byte[] key, byte[] from, boolean fromInclusive, byte[] toExclusive) {
         if (from != null) {
             int c = KeyBytes.compareUnsigned(key, from);
@@ -328,6 +334,144 @@ public final class SortedRangeReader implements AutoCloseable {
             return upper;
         }
         return upper == null ? lower : FilterApi.and(lower, upper);
+    }
+
+    /** Typed row materialization for the replay hot path; avoids building a generic Group per row. */
+    private static final class ObjectRowMaterializer extends RecordMaterializer<ObjectRow> {
+
+        private final ObjectRowConverter root;
+
+        ObjectRowMaterializer(MessageType schema, boolean includeOwner) {
+            root = new ObjectRowConverter(schema, includeOwner);
+        }
+
+        @Override
+        public ObjectRow getCurrentRecord() {
+            return root.current;
+        }
+
+        @Override
+        public GroupConverter getRootConverter() {
+            return root;
+        }
+    }
+
+    private static final class ObjectRowConverter extends GroupConverter {
+
+        private final Converter[] fields;
+        private final boolean includeOwner;
+        private byte[] key;
+        private long size;
+        private long lastModified;
+        private String etag;
+        private String storageClass;
+        private String ownerId;
+        private String ownerDisplayName;
+        private String checksumAlgorithm;
+        private String checksumType;
+        private String rowType;
+        private ObjectRow current;
+
+        ObjectRowConverter(MessageType schema, boolean includeOwner) {
+            this.includeOwner = includeOwner;
+            this.fields = new Converter[schema.getFieldCount()];
+            for (int i = 0; i < fields.length; i++) {
+                fields[i] = converter(schema.getFieldName(i));
+            }
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex) {
+            return fields[fieldIndex];
+        }
+
+        @Override
+        public void start() {
+            key = null;
+            size = 0L;
+            lastModified = 0L;
+            etag = null;
+            storageClass = null;
+            ownerId = null;
+            ownerDisplayName = null;
+            checksumAlgorithm = null;
+            checksumType = null;
+            rowType = null;
+        }
+
+        @Override
+        public void end() {
+            current = SortedRowGroupReader.OBJECT_ROW_TYPE.equals(rowType)
+                    ? new ObjectRow(key, size, lastModified, etag, storageClass,
+                            includeOwner ? ownerId : null, includeOwner ? ownerDisplayName : null,
+                            checksumAlgorithm, checksumType)
+                    : null;
+        }
+
+        private Converter converter(String name) {
+            return switch (name) {
+                // ObjectRow's public-seam constructor takes the one owning defensive copy. Copying
+                // Binary here as well would allocate and copy every key twice.
+                case KEY_FIELD -> binary(value -> key = value.getBytesUnsafe());
+                case "size" -> longValue(value -> size = value);
+                case "last_modified" -> longValue(value -> lastModified = value);
+                case "etag" -> string(value -> etag = value);
+                case "storage_class" -> string(value -> storageClass = value);
+                case "owner_id" -> string(value -> ownerId = value);
+                case "owner_display_name" -> string(value -> ownerDisplayName = value);
+                case "checksum_algorithm" -> string(value -> checksumAlgorithm = value);
+                case "checksum_type" -> string(value -> checksumType = value);
+                case SortedRowGroupReader.ROW_TYPE_FIELD -> string(value -> rowType = value);
+                default -> throw new IllegalArgumentException("unsupported object projection field: " + name);
+            };
+        }
+
+        private static PrimitiveConverter binary(java.util.function.Consumer<Binary> sink) {
+            return new PrimitiveConverter() {
+                @Override
+                public void addBinary(Binary value) {
+                    sink.accept(value);
+                }
+            };
+        }
+
+        private static PrimitiveConverter string(java.util.function.Consumer<String> sink) {
+            return new PrimitiveConverter() {
+                private String[] dictionary;
+
+                @Override
+                public boolean hasDictionarySupport() {
+                    return true;
+                }
+
+                @Override
+                public void setDictionary(Dictionary values) {
+                    dictionary = new String[values.getMaxId() + 1];
+                    for (int id = 0; id < dictionary.length; id++) {
+                        dictionary[id] = values.decodeToBinary(id).toStringUsingUTF8();
+                    }
+                }
+
+                @Override
+                public void addValueFromDictionary(int dictionaryId) {
+                    sink.accept(dictionary[dictionaryId]);
+                }
+
+                @Override
+                public void addBinary(Binary value) {
+                    sink.accept(value.toStringUsingUTF8());
+                }
+            };
+        }
+
+        private static PrimitiveConverter longValue(java.util.function.LongConsumer sink) {
+            return new PrimitiveConverter() {
+                @Override
+                public void addLong(long value) {
+                    sink.accept(value);
+                }
+            };
+        }
     }
 
     @Override

--- a/swath-core/src/main/java/io/varve/swath/sort/SortedRowGroupReader.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortedRowGroupReader.java
@@ -117,6 +117,14 @@ public final class SortedRowGroupReader implements AutoCloseable {
         public byte[] key() {
             return key.clone();
         }
+
+        /**
+         * Internal zero-copy view for the replay serving pipeline. Callers must never mutate it;
+         * public {@link #key()} remains the defensive API for general consumers.
+         */
+        public byte[] keyUnsafe() {
+            return key;
+        }
     }
 
     private static final ColumnPath KEY_COLUMN_PATH = ColumnPath.get(KEY_FIELD);

--- a/swath-core/src/test/java/io/varve/swath/sort/SortedRangeReaderTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortedRangeReaderTest.java
@@ -23,6 +23,30 @@ import org.junit.jupiter.api.io.TempDir;
 class SortedRangeReaderTest {
 
     @Test
+    void pooledReaderCanSwitchFromNoOwnerToOwnerProjection(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("part-00001.parquet");
+        try (SortedFileWriter writer = new SortedParquetWriter(file, SortConfigs.base(), SortMode.OBJECTS, 1)) {
+            for (int i = 0; i < 5_000; i++) {
+                writer.write(object(String.format("key-%05d", i)));
+            }
+        }
+
+        try (SortedRangeReader reader = new SortedRangeReader(file, 1)) {
+            byte[] lower = KeyBytes.ofUtf8("key-02000").raw();
+            assertThat(reader.range(0, lower, true, null, 10, false))
+                    .hasSize(10)
+                    .allSatisfy(row -> assertThat(row.ownerId()).isNull());
+
+            assertThat(reader.range(0, lower, true, null, 10, true))
+                    .hasSize(10)
+                    .allSatisfy(row -> {
+                        assertThat(row.ownerId()).isEqualTo("owner-id");
+                        assertThat(row.ownerDisplayName()).isEqualTo("owner-display");
+                    });
+        }
+    }
+
+    @Test
     void poolContentionIsExcludedFromTheReaderLeaseDuration(@TempDir Path dir) throws Exception {
         Path file = dir.resolve("part-00001.parquet");
         try (SortedFileWriter writer = new SortedParquetWriter(file, SortConfigs.base(), SortMode.OBJECTS, 1)) {

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
@@ -5,47 +5,59 @@
  */
 package io.varve.swath.replay.protocol;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 
 /** Renders {@link S3ListResult} and {@link S3Error} as byte-faithful S3 ListObjectsV2 XML. */
 public final class S3Xml {
 
-    private static final DateTimeFormatter S3_LAST_MODIFIED =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+    private static final int RESPONSE_BASE_CAPACITY = 512;
+    private static final int ESTIMATED_BYTES_PER_ENTRY = 320;
+
+    private static final DateTimeFormatter S3_LAST_MODIFIED_PREFIX =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.").withZone(ZoneOffset.UTC);
 
     private S3Xml() {
     }
 
-    public static String listBucket(S3ListResult result) {
+    /**
+     * Renders directly into the bytes Jetty writes. The replay hot path must not first construct a
+     * response-sized UTF-16 {@link String} and immediately encode the whole response back to UTF-8.
+     */
+    public static ByteBuffer listBucketBuffer(S3ListResult result) {
         S3ListRequest request = result.request();
-        StringBuilder xml = new StringBuilder(4096);
-        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-        xml.append("<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">");
+        Utf8XmlBuilder xml = new Utf8XmlBuilder(Math.max(4096,
+                RESPONSE_BASE_CAPACITY + result.entries().size() * ESTIMATED_BYTES_PER_ENTRY));
+        xml.appendAscii("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.appendAscii("<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">");
         element(xml, "Name", request.bucket());
-        element(xml, "Prefix", text(request.prefix(), request.encodingTypeUrl()));
+        byteElement(xml, "Prefix", request.prefix(), request.encodingTypeUrl());
         if (request.continuationToken() != null) {
             element(xml, "ContinuationToken", request.continuationToken());
         }
         if (request.startAfter() != null) {
-            element(xml, "StartAfter", text(request.startAfter(), request.encodingTypeUrl()));
+            byteElement(xml, "StartAfter", request.startAfter(), request.encodingTypeUrl());
         }
         if (result.nextContinuationToken() != null) {
             element(xml, "NextContinuationToken", result.nextContinuationToken());
         }
-        element(xml, "KeyCount", Integer.toString(result.keyCount()));
-        element(xml, "MaxKeys", Integer.toString(request.maxKeys()));
+        numericElement(xml, "KeyCount", result.keyCount());
+        numericElement(xml, "MaxKeys", request.maxKeys());
         if (request.delimiter() != null && request.delimiter().length > 0) {
-            element(xml, "Delimiter", text(request.delimiter(), request.encodingTypeUrl()));
+            byteElement(xml, "Delimiter", request.delimiter(), request.encodingTypeUrl());
         }
         if (request.encodingTypeUrl()) {
             element(xml, "EncodingType", "url");
         }
-        element(xml, "IsTruncated", Boolean.toString(result.truncated()));
+        fixedElement(xml, "IsTruncated", result.truncated() ? "true" : "false");
+        TimestampPrefixCache timestamps = new TimestampPrefixCache();
         for (S3ResultEntry entry : result.entries()) {
             if (entry instanceof S3ResultEntry.ObjectResult object) {
-                contents(xml, object.object(), request.encodingTypeUrl(), request.fetchOwner());
+                contents(xml, object.object(), request.encodingTypeUrl(), request.fetchOwner(), timestamps);
             }
         }
         for (S3ResultEntry entry : result.entries()) {
@@ -53,30 +65,48 @@ public final class S3Xml {
                 commonPrefix(xml, prefix.key(), request.encodingTypeUrl());
             }
         }
-        xml.append("</ListBucketResult>");
-        return xml.toString();
+        xml.appendAscii("</ListBucketResult>");
+        return xml.toByteBuffer();
+    }
+
+    /** Exact-sized compatibility form for callers that specifically need an owning byte array. */
+    public static byte[] listBucketBytes(S3ListResult result) {
+        ByteBuffer rendered = listBucketBuffer(result);
+        byte[] exact = new byte[rendered.remaining()];
+        rendered.get(exact);
+        return exact;
+    }
+
+    /** Compatibility form for callers and tests that consume XML as text. */
+    public static String listBucket(S3ListResult result) {
+        return new String(listBucketBytes(result), StandardCharsets.UTF_8);
     }
 
     public static String error(String code, String message, String resource) {
         StringBuilder xml = new StringBuilder(512);
         xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         xml.append("<Error>");
-        element(xml, "Code", code);
-        element(xml, "Message", message);
+        stringElement(xml, "Code", code);
+        stringElement(xml, "Message", message);
         if (resource != null) {
-            element(xml, "Resource", resource);
+            stringElement(xml, "Resource", resource);
         }
-        element(xml, "RequestId", "S3LISTINGREPLAY");
+        stringElement(xml, "RequestId", "S3LISTINGREPLAY");
         xml.append("</Error>");
         return xml.toString();
     }
 
-    private static void contents(StringBuilder xml, ListedObject object, boolean encoded, boolean fetchOwner) {
-        xml.append("<Contents>");
-        element(xml, "Key", text(object.key(), encoded));
-        element(xml, "LastModified", S3_LAST_MODIFIED.format(instant(object.lastModifiedEpochMicros())));
+    private static void contents(Utf8XmlBuilder xml, ListedObject object, boolean encoded,
+                                 boolean fetchOwner, TimestampPrefixCache timestamps) {
+        xml.appendAscii("<Contents>");
+        byteElement(xml, "Key", object.key(), encoded);
+        xml.appendAscii("<LastModified>");
+        timestamps.append(xml, object.lastModifiedEpochMicros());
+        xml.appendAscii("</LastModified>");
         if (object.etag() != null) {
-            element(xml, "ETag", "\"" + object.etag() + "\"");
+            xml.appendAscii("<ETag>&quot;");
+            xml.appendEscaped(object.etag());
+            xml.appendAscii("&quot;</ETag>");
         }
         if (object.checksumAlgorithm() != null) {
             element(xml, "ChecksumAlgorithm", object.checksumAlgorithm());
@@ -84,59 +114,290 @@ public final class S3Xml {
         if (object.checksumType() != null) {
             element(xml, "ChecksumType", object.checksumType());
         }
-        element(xml, "Size", Long.toString(object.size()));
+        numericElement(xml, "Size", object.size());
         if (object.storageClass() != null) {
             element(xml, "StorageClass", object.storageClass());
         }
         if (fetchOwner && (object.ownerId() != null || object.ownerDisplayName() != null)) {
-            xml.append("<Owner>");
+            xml.appendAscii("<Owner>");
             if (object.ownerId() != null) {
                 element(xml, "ID", object.ownerId());
             }
             if (object.ownerDisplayName() != null) {
                 element(xml, "DisplayName", object.ownerDisplayName());
             }
-            xml.append("</Owner>");
+            xml.appendAscii("</Owner>");
         }
-        xml.append("</Contents>");
+        xml.appendAscii("</Contents>");
     }
 
-    private static void commonPrefix(StringBuilder xml, byte[] prefix, boolean encoded) {
-        xml.append("<CommonPrefixes>");
-        element(xml, "Prefix", text(prefix, encoded));
-        xml.append("</CommonPrefixes>");
+    private static void commonPrefix(Utf8XmlBuilder xml, byte[] prefix, boolean encoded) {
+        xml.appendAscii("<CommonPrefixes>");
+        byteElement(xml, "Prefix", prefix, encoded);
+        xml.appendAscii("</CommonPrefixes>");
     }
 
-    private static String text(byte[] raw, boolean encoded) {
-        if (raw == null) {
-            return "";
+    /**
+     * Last-modified values in captures commonly arrive in runs from the same second. Formatting the
+     * calendar prefix is far more expensive than appending its three millisecond digits, so cache
+     * the last second within one response. The cache is request-local and therefore needs no lock.
+     */
+    private static final class TimestampPrefixCache {
+        private long second = Long.MIN_VALUE;
+        private String prefix;
+
+        private void append(Utf8XmlBuilder xml, long epochMicros) {
+            long currentSecond = Math.floorDiv(epochMicros, 1_000_000L);
+            if (prefix == null || currentSecond != second) {
+                second = currentSecond;
+                prefix = S3_LAST_MODIFIED_PREFIX.format(Instant.ofEpochSecond(currentSecond));
+            }
+            int millis = (int) (Math.floorMod(epochMicros, 1_000_000L) / 1_000L);
+            xml.appendAscii(prefix);
+            xml.appendThreeDigits(millis);
+            xml.appendByte('Z');
         }
-        return encoded ? ByteKeys.percentEncode(raw) : ByteKeys.utf8(raw);
     }
 
-    private static Instant instant(long epochMicros) {
-        long seconds = Math.floorDiv(epochMicros, 1_000_000L);
-        long micros = Math.floorMod(epochMicros, 1_000_000L);
-        return Instant.ofEpochSecond(seconds, micros * 1000L);
+    private static void element(Utf8XmlBuilder xml, String name, String value) {
+        xml.appendByte('<');
+        xml.appendAscii(name);
+        xml.appendByte('>');
+        xml.appendEscaped(value);
+        xml.appendAscii("</");
+        xml.appendAscii(name);
+        xml.appendByte('>');
     }
 
-    private static void element(StringBuilder xml, String name, String value) {
+    private static void fixedElement(Utf8XmlBuilder xml, String name, String asciiValue) {
+        xml.appendByte('<');
+        xml.appendAscii(name);
+        xml.appendByte('>');
+        xml.appendAscii(asciiValue);
+        xml.appendAscii("</");
+        xml.appendAscii(name);
+        xml.appendByte('>');
+    }
+
+    private static void numericElement(Utf8XmlBuilder xml, String name, long value) {
+        xml.appendByte('<');
+        xml.appendAscii(name);
+        xml.appendByte('>');
+        xml.appendLong(value);
+        xml.appendAscii("</");
+        xml.appendAscii(name);
+        xml.appendByte('>');
+    }
+
+    private static void byteElement(Utf8XmlBuilder xml, String name, byte[] value, boolean encoded) {
+        xml.appendByte('<');
+        xml.appendAscii(name);
+        xml.appendByte('>');
+        if (value != null) {
+            if (encoded) {
+                xml.appendPercentEncoded(value);
+            } else {
+                // Preserve the previous decoder semantics for malformed UTF-8 before XML escaping.
+                xml.appendEscaped(new String(value, StandardCharsets.UTF_8));
+            }
+        }
+        xml.appendAscii("</");
+        xml.appendAscii(name);
+        xml.appendByte('>');
+    }
+
+    private static void stringElement(StringBuilder xml, String name, String value) {
         xml.append('<').append(name).append('>');
-        escape(xml, value);
+        appendEscaped(xml, value);
         xml.append("</").append(name).append('>');
     }
 
-    private static void escape(StringBuilder xml, String value) {
+    private static void appendEscaped(StringBuilder xml, String value) {
         for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch (c) {
+            switch (value.charAt(i)) {
                 case '&' -> xml.append("&amp;");
                 case '<' -> xml.append("&lt;");
                 case '>' -> xml.append("&gt;");
                 case '"' -> xml.append("&quot;");
                 case '\'' -> xml.append("&apos;");
-                default -> xml.append(c);
+                default -> xml.append(value.charAt(i));
             }
+        }
+    }
+
+    /** Minimal growable UTF-8 sink specialized for the replay response grammar. */
+    private static final class Utf8XmlBuilder {
+        private static final byte[] HEX = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+        private static final boolean[] URL_SAFE = urlSafeTable();
+
+        private byte[] bytes;
+        private int length;
+
+        private Utf8XmlBuilder(int capacity) {
+            bytes = new byte[capacity];
+        }
+
+        private void appendByte(int value) {
+            ensure(1);
+            bytes[length++] = (byte) value;
+        }
+
+        @SuppressWarnings("deprecation")
+        private void appendAscii(String value) {
+            ensure(value.length());
+            // This overload copies the low byte of each UTF-16 code unit straight into the target
+            // array. Every caller is intentionally ASCII (tags, fixed values, or the proven-safe
+            // fast path in appendEscaped), so truncation is exactly the desired encoding and avoids
+            // both a temporary byte[] and a Java-level character-copy loop.
+            value.getBytes(0, value.length(), bytes, length);
+            length += value.length();
+        }
+
+        private void appendPercentEncoded(byte[] value) {
+            ensure(value.length * 3);
+            for (byte b : value) {
+                int v = b & 0xff;
+                if (URL_SAFE[v]) {
+                    bytes[length++] = b;
+                } else {
+                    bytes[length++] = '%';
+                    bytes[length++] = HEX[v >>> 4];
+                    bytes[length++] = HEX[v & 0x0f];
+                }
+            }
+        }
+
+        private void appendEscaped(String value) {
+            int safeLength = 0;
+            while (safeLength < value.length()) {
+                char c = value.charAt(safeLength);
+                if (c > 0x7f || c == '&' || c == '<' || c == '>' || c == '"' || c == '\'') {
+                    break;
+                }
+                safeLength++;
+            }
+            if (safeLength == value.length()) {
+                appendAscii(value);
+                return;
+            }
+            // One byte per code unit is enough for the overwhelmingly common ASCII case. Safe ASCII
+            // is copied directly below; only metacharacters and non-ASCII take the general encoder.
+            ensure(value.length());
+            for (int offset = 0; offset < value.length();) {
+                char c = value.charAt(offset);
+                switch (c) {
+                    case '&' -> appendAscii("&amp;");
+                    case '<' -> appendAscii("&lt;");
+                    case '>' -> appendAscii("&gt;");
+                    case '"' -> appendAscii("&quot;");
+                    case '\'' -> appendAscii("&apos;");
+                    default -> {
+                        if (c <= 0x7f) {
+                            bytes[length++] = (byte) c;
+                            offset++;
+                            continue;
+                        }
+                        int codePoint;
+                        if (Character.isHighSurrogate(c) && offset + 1 < value.length()
+                                && Character.isLowSurrogate(value.charAt(offset + 1))) {
+                            codePoint = Character.toCodePoint(c, value.charAt(offset + 1));
+                            offset++;
+                        } else if (Character.isSurrogate(c)) {
+                            // String.getBytes(UTF_8), used by the old renderer, replaces malformed
+                            // UTF-16 with the encoder's one-byte default replacement, '?'.
+                            codePoint = '?';
+                        } else {
+                            codePoint = c;
+                        }
+                        appendCodePoint(codePoint);
+                    }
+                }
+                offset++;
+            }
+        }
+
+        private void appendLong(long value) {
+            if (value == Long.MIN_VALUE) {
+                appendAscii("-9223372036854775808");
+                return;
+            }
+            boolean negative = value < 0;
+            long magnitude = negative ? -value : value;
+            int digits = 1;
+            for (long remaining = magnitude; remaining >= 10; remaining /= 10) {
+                digits++;
+            }
+            int width = digits + (negative ? 1 : 0);
+            ensure(width);
+            int end = length + width;
+            int cursor = end;
+            do {
+                bytes[--cursor] = (byte) ('0' + magnitude % 10);
+                magnitude /= 10;
+            } while (magnitude != 0);
+            if (negative) {
+                bytes[length] = '-';
+            }
+            length = end;
+        }
+
+        private void appendThreeDigits(int value) {
+            ensure(3);
+            bytes[length++] = (byte) ('0' + value / 100);
+            bytes[length++] = (byte) ('0' + value / 10 % 10);
+            bytes[length++] = (byte) ('0' + value % 10);
+        }
+
+        private void appendCodePoint(int codePoint) {
+            if (codePoint <= 0x7f) {
+                appendByte(codePoint);
+            } else if (codePoint <= 0x7ff) {
+                ensure(2);
+                bytes[length++] = (byte) (0xc0 | codePoint >>> 6);
+                bytes[length++] = (byte) (0x80 | codePoint & 0x3f);
+            } else if (codePoint <= 0xffff) {
+                ensure(3);
+                bytes[length++] = (byte) (0xe0 | codePoint >>> 12);
+                bytes[length++] = (byte) (0x80 | codePoint >>> 6 & 0x3f);
+                bytes[length++] = (byte) (0x80 | codePoint & 0x3f);
+            } else {
+                ensure(4);
+                bytes[length++] = (byte) (0xf0 | codePoint >>> 18);
+                bytes[length++] = (byte) (0x80 | codePoint >>> 12 & 0x3f);
+                bytes[length++] = (byte) (0x80 | codePoint >>> 6 & 0x3f);
+                bytes[length++] = (byte) (0x80 | codePoint & 0x3f);
+            }
+        }
+
+        private void ensure(int additional) {
+            int needed = length + additional;
+            if (needed > bytes.length) {
+                bytes = Arrays.copyOf(bytes, Math.max(needed, bytes.length + (bytes.length >>> 1)));
+            }
+        }
+
+        private ByteBuffer toByteBuffer() {
+            // Jetty accepts a bounded ByteBuffer, so the hot server path can write the populated
+            // prefix directly instead of copying every ~300-KiB page into an exact-sized byte[].
+            return ByteBuffer.wrap(bytes, 0, length);
+        }
+
+        private static boolean[] urlSafeTable() {
+            boolean[] safe = new boolean[256];
+            for (int value = 'A'; value <= 'Z'; value++) {
+                safe[value] = true;
+            }
+            for (int value = 'a'; value <= 'z'; value++) {
+                safe[value] = true;
+            }
+            for (int value = '0'; value <= '9'; value++) {
+                safe[value] = true;
+            }
+            safe['-'] = true;
+            safe['_'] = true;
+            safe['.'] = true;
+            safe['/'] = true;
+            return safe;
         }
     }
 }

--- a/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayHandler.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayHandler.java
@@ -114,7 +114,7 @@ final class ReplayHandler extends Handler.Abstract {
         } catch (RuntimeException e) {
             log.error("replay failed to serve request", e);
             status = HttpStatus.INTERNAL_SERVER_ERROR_500;
-            body = errorBuffer("InternalError", e.getMessage(), request.getHttpURI().getPath());
+            body = errorBuffer("InternalError", "internal replay error", request.getHttpURI().getPath());
         }
         metrics.recordHttpRequest(sample, status);
         write(response, status, body, callback);

--- a/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayHandler.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayHandler.java
@@ -96,12 +96,12 @@ final class ReplayHandler extends Handler.Abstract {
     public boolean handle(Request request, Response response, Callback callback) {
         var sample = metrics.startTimer();
         int status = HttpStatus.OK_200;
-        String body;
+        ByteBuffer body;
         try {
             body = handle(request);
         } catch (S3Error e) {
             status = e.status();
-            body = S3Xml.error(e.code(), e.getMessage(), request.getHttpURI().getPath());
+            body = errorBuffer(e.code(), e.getMessage(), request.getHttpURI().getPath());
         } catch (RowGroupOrderException e) {
             // The fixture is internally disordered and no path can serve this request (see
             // docs/swath-replay.md, "--serving-mode"). The full report — including the
@@ -110,17 +110,18 @@ final class ReplayHandler extends Handler.Abstract {
             // server's filesystem layout and a sweep classifies from the reason, not from the text.
             log.error("replay refused a request over a disordered fixture: {}", e.getMessage(), e);
             status = HttpStatus.INTERNAL_SERVER_ERROR_500;
-            body = S3Xml.error("InternalError", e.redactedMessage(), request.getHttpURI().getPath());
+            body = errorBuffer("InternalError", e.redactedMessage(), request.getHttpURI().getPath());
         } catch (RuntimeException e) {
+            log.error("replay failed to serve request", e);
             status = HttpStatus.INTERNAL_SERVER_ERROR_500;
-            body = S3Xml.error("InternalError", e.getMessage(), request.getHttpURI().getPath());
+            body = errorBuffer("InternalError", e.getMessage(), request.getHttpURI().getPath());
         }
         metrics.recordHttpRequest(sample, status);
         write(response, status, body, callback);
         return true;
     }
 
-    private String handle(Request request) {
+    private ByteBuffer handle(Request request) {
         if (!"GET".equals(request.getMethod())) {
             throw new S3Error(405, "MethodNotAllowed", "method not allowed");
         }
@@ -131,7 +132,7 @@ final class ReplayHandler extends Handler.Abstract {
         }
         S3ListRequest listRequest = ListObjectsV2RequestParser.parse(bucket, request.getHttpURI().getQuery());
         ServedListing served = boundedList(listRequest);
-        String body = S3Xml.listBucket(served.result());
+        ByteBuffer body = S3Xml.listBucketBuffer(served.result());
         sleepToDeadline(served.latency(), System.nanoTime() - served.startedNanos(), served.shape());
         return body;
     }
@@ -246,14 +247,18 @@ final class ReplayHandler extends Handler.Abstract {
         }
     }
 
-    private static void write(Response response, int status, String body, Callback callback) {
-        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    private static ByteBuffer errorBuffer(String code, String message, String resource) {
+        String renderedMessage = message == null ? "internal replay error" : message;
+        return ByteBuffer.wrap(S3Xml.error(code, renderedMessage, resource).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void write(Response response, int status, ByteBuffer body, Callback callback) {
         response.setStatus(status);
         response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/xml");
-        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, Integer.toString(bytes.length));
+        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, Integer.toString(body.remaining()));
         response.getHeaders().put("x-amz-request-id", "S3LISTINGREPLAY");
         response.getHeaders().put("x-amz-id-2", "S3LISTINGREPLAY");
-        response.write(true, ByteBuffer.wrap(bytes), callback);
+        response.write(true, body, callback);
     }
 
     private static String parseBucket(String path) {

--- a/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayMetrics.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/server/ReplayMetrics.java
@@ -64,6 +64,11 @@ public final class ReplayMetrics {
     private final Counter prefetchWindowEvictions;
     private final Counter delimiterSkipScanRowGroupOpens;
     private final Counter delimiterSkipScanWholeGroupShortcuts;
+    private final Timer delimiterReaderPoolOpenLatency;
+    // Micrometer gauges weakly reference their state object. Retain these method-reference objects
+    // for the metrics lifetime or a sustained run's next GC turns both live-cache values into NaN.
+    private IntSupplier prefetchWindowsGaugeSource;
+    private IntSupplier prefetchAnchorsGaugeSource;
     private final AtomicLong parquetQueriesInFlight = new AtomicLong();
     private final AtomicLong parquetQueriesPeak = new AtomicLong();
     private final long startedNanos = System.nanoTime();
@@ -122,6 +127,8 @@ public final class ReplayMetrics {
                 .register(registry);
         delimiterSkipScanWholeGroupShortcuts = Counter.builder(
                 "swath.replay.delimiter.skipscan.whole_group_shortcuts").register(registry);
+        delimiterReaderPoolOpenLatency = Timer.builder("swath.replay.delimiter.reader_pool.open.latency")
+                .publishPercentiles(0.5, 0.99).register(registry);
         Gauge
                 .builder("swath.replay.parquet.queries.in_flight", parquetQueriesInFlight, AtomicLong::get)
                 .register(registry);
@@ -218,9 +225,13 @@ public final class ReplayMetrics {
 
     /** Registers live bounded-cache cardinalities after the prefetch store is constructed. */
     public void registerPrefetchCacheGauges(IntSupplier windows, IntSupplier anchors) {
-        Gauge.builder("swath.replay.prefetch.windows.live", windows, IntSupplier::getAsInt)
+        prefetchWindowsGaugeSource = windows;
+        prefetchAnchorsGaugeSource = anchors;
+        Gauge.builder("swath.replay.prefetch.windows.live", prefetchWindowsGaugeSource,
+                        IntSupplier::getAsInt)
                 .register(registry);
-        Gauge.builder("swath.replay.prefetch.anchors.live", anchors, IntSupplier::getAsInt)
+        Gauge.builder("swath.replay.prefetch.anchors.live", prefetchAnchorsGaugeSource,
+                        IntSupplier::getAsInt)
                 .register(registry);
     }
 
@@ -316,6 +327,11 @@ public final class ReplayMetrics {
     /** Records a row group proven to contain one common prefix from routing-index bounds alone. */
     public void recordDelimiterSkipScanWholeGroupShortcut() {
         delimiterSkipScanWholeGroupShortcuts.increment();
+    }
+
+    /** Records one file's lazy delimiter-reader fleet opening on its first Parquet-backed rollup. */
+    public void recordDelimiterReaderPoolOpen(Timer.Sample sample) {
+        sample.stop(delimiterReaderPoolOpenLatency);
     }
 
     /** Records how many rows one window fill asked the delegate for (proves the ramp engages). */

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
@@ -25,8 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * A {@link ListingStore} over a stamped, globally sorted swath Parquet fixture, answered by
@@ -86,9 +84,7 @@ public final class SortedParquetStore implements ListingStore {
     private final List<IndexEntry> index;
     private final ReplayMetrics metrics;
     private final Map<Path, SortedRangeReader> rangeReaders;
-    private final Map<Path, BlockingQueue<SortedRowGroupReader>> groupReaders;
-    /** Every group reader this store made, borrowed or not — {@link #close()} closes the list, not the pool. */
-    private final List<SortedRowGroupReader> ownedGroupReaders;
+    private final Map<Path, LazyGroupReaderPool> groupReaders;
 
     public SortedParquetStore(List<Path> files, List<IndexEntry> index, ReplayMetrics metrics) {
         this(files, index, metrics, defaultConnectionCount());
@@ -119,15 +115,8 @@ public final class SortedParquetStore implements ListingStore {
                         metrics.parquetReaderReleased();
                     }
                 });
-        try {
-            this.groupReaders = openGroupReaders(files, connectionCount);
-            this.rangeReaders = openedRangeReaders;
-            this.ownedGroupReaders = groupReaders.values().stream()
-                    .flatMap(java.util.Collection::stream).toList();
-        } catch (RuntimeException e) {
-            openedRangeReaders.values().forEach(SortedParquetStore::closeQuietly);
-            throw e;
-        }
+        this.groupReaders = groupReaderPools(files, connectionCount, metrics);
+        this.rangeReaders = openedRangeReaders;
     }
 
     /**
@@ -137,12 +126,14 @@ public final class SortedParquetStore implements ListingStore {
      * {@code min(4, cores)}. That was right when a pooled slot was a DuckDB connection, which owns a
      * thread pool; it is wrong now that a slot is a Parquet file handle plus its decoded footer.
      * Decoding is still CPU work, so many multiples of the core count buy nothing — but a request
-     * stalled on an uncached page should not hold the only slot on a small machine. Hence a small
-     * multiple of the cores, floored so a 2-core box has headroom and capped so a large one does not
-     * hold hundreds of open footers per file for no throughput.
+     * stalled on an uncached page should not hold the only slot on a small machine. One slot per
+     * visible core saturated the decode path in local large-fixture sweeps; doubling it increased
+     * page latency and GC while reducing throughput. Keep the small-machine floor for I/O headroom,
+     * and cap large machines so a multi-file fixture does not hold hundreds of open footers per file
+     * for no throughput.
      */
     public static int defaultConnectionCount() {
-        return Math.max(8, Math.min(32, 2 * Runtime.getRuntime().availableProcessors()));
+        return Math.max(8, Math.min(32, Runtime.getRuntime().availableProcessors()));
     }
 
     @Override
@@ -212,20 +203,11 @@ public final class SortedParquetStore implements ListingStore {
      * (its requested schema, its open page store), so it is pooled rather than shared, exactly as the
      * range readers are.
      */
-    private static Map<Path, BlockingQueue<SortedRowGroupReader>> openGroupReaders(List<Path> files,
-                                                                                   int poolSize) {
-        Map<Path, BlockingQueue<SortedRowGroupReader>> readers = new LinkedHashMap<>();
-        try {
-            for (Path file : files) {
-                BlockingQueue<SortedRowGroupReader> pool = new ArrayBlockingQueue<>(Math.max(1, poolSize));
-                readers.put(file.toAbsolutePath(), pool);
-                for (int i = 0; i < Math.max(1, poolSize); i++) {
-                    pool.add(new SortedRowGroupReader(file));
-                }
-            }
-        } catch (IOException | RuntimeException e) {
-            readers.values().forEach(pool -> pool.forEach(SortedParquetStore::closeQuietly));
-            throw new IllegalStateException("failed to open a sorted Parquet row-group reader", e);
+    private static Map<Path, LazyGroupReaderPool> groupReaderPools(List<Path> files, int poolSize,
+                                                                   ReplayMetrics metrics) {
+        Map<Path, LazyGroupReaderPool> readers = new LinkedHashMap<>();
+        for (Path file : files) {
+            readers.put(file.toAbsolutePath(), new LazyGroupReaderPool(file, poolSize, metrics));
         }
         return Map.copyOf(readers);
     }
@@ -244,8 +226,8 @@ public final class SortedParquetStore implements ListingStore {
         return reader;
     }
 
-    private BlockingQueue<SortedRowGroupReader> pool(Path file) {
-        BlockingQueue<SortedRowGroupReader> readers = groupReaders.get(file.toAbsolutePath());
+    private LazyGroupReaderPool pool(Path file) {
+        LazyGroupReaderPool readers = groupReaders.get(file.toAbsolutePath());
         if (readers == null) {
             throw new IllegalStateException("no sorted Parquet row-group reader for fixture file " + file);
         }
@@ -253,12 +235,7 @@ public final class SortedParquetStore implements ListingStore {
     }
 
     private SortedRowGroupReader borrowGroupReader(Path file) {
-        try {
-            return pool(file).take();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("interrupted waiting for a sorted Parquet row-group reader", e);
-        }
+        return pool(file).borrow();
     }
 
     private static Map<Path, SortedRangeReader> openRangeReaders(
@@ -314,17 +291,17 @@ public final class SortedParquetStore implements ListingStore {
     }
 
     /**
-     * Closes every reader this store opened — the row-group readers and the range readers alike,
-     * whether or not they are currently in their pool.
+     * Closes every reader this store opened — the row-group readers and the range readers alike.
      *
-     * <p>Both halves are load-bearing. Iterating the <em>pools</em> would skip anything a request
-     * still holds, and the range readers were being missed entirely: they are the sole serving path
-     * now, and each owns one open {@code ParquetFileReader} per pooled slot per file.
+     * <p>Both halves are load-bearing. A row-group reader still held by a request is closed when that
+     * request returns it; an idle one is closed here. The range readers were once missed entirely:
+     * they are the sole ordinary-page serving path, and each owns one open {@code ParquetFileReader}
+     * per pooled slot per file.
      */
     @Override
     public void close() {
-        for (SortedRowGroupReader reader : ownedGroupReaders) {
-            closeQuietly(reader);
+        for (LazyGroupReaderPool pool : groupReaders.values()) {
+            pool.close();
         }
         for (SortedRangeReader reader : rangeReaders.values()) {
             closeQuietly(reader);
@@ -336,6 +313,88 @@ public final class SortedParquetStore implements ListingStore {
             reader.close();
         } catch (Exception e) {
             // Best effort: a fixture reader holds no state a failed close could corrupt.
+        }
+    }
+
+    /**
+     * Delimiter readers are a second footer-bearing reader fleet per fixture file. Most replay
+     * traffic is ordinary range pages, and a worker-only run must not pay that fleet's startup and
+     * resident-memory cost merely because the endpoint also supports delimiter probes. Initialize a
+     * file's pool on its first delimiter request; publication occurs only after the whole pool opens,
+     * so concurrent first probes either see the complete pool or wait for it.
+     */
+    static final class LazyGroupReaderPool {
+
+        private final Path file;
+        private final int size;
+        private final ReplayMetrics metrics;
+        private ArrayDeque<SortedRowGroupReader> available;
+        private boolean closed;
+
+        LazyGroupReaderPool(Path file, int size, ReplayMetrics metrics) {
+            this.file = file;
+            this.size = Math.max(1, size);
+            this.metrics = metrics;
+        }
+
+        synchronized SortedRowGroupReader borrow() {
+            initialize();
+            while (available.isEmpty() && !closed) {
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(
+                            "interrupted waiting for a sorted Parquet row-group reader", e);
+                }
+            }
+            if (closed) {
+                throw new IllegalStateException("sorted Parquet row-group reader pool is closed for " + file);
+            }
+            return available.removeFirst();
+        }
+
+        synchronized void release(SortedRowGroupReader reader) {
+            if (closed) {
+                closeQuietly(reader);
+            } else {
+                available.addLast(reader);
+                notifyAll();
+            }
+        }
+
+        private synchronized void initialize() {
+            if (closed) {
+                throw new IllegalStateException("sorted Parquet row-group reader pool is closed for " + file);
+            }
+            if (available != null) {
+                return;
+            }
+            ArrayDeque<SortedRowGroupReader> creating = new ArrayDeque<>(size);
+            var sample = metrics.startTimer();
+            try {
+                for (int i = 0; i < size; i++) {
+                    creating.addLast(new SortedRowGroupReader(file));
+                }
+            } catch (IOException | RuntimeException e) {
+                creating.forEach(SortedParquetStore::closeQuietly);
+                throw new IllegalStateException(
+                        "failed to open a sorted Parquet row-group reader for " + file, e);
+            }
+            available = creating;
+            metrics.recordDelimiterReaderPoolOpen(sample);
+        }
+
+        synchronized void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            if (available != null) {
+                available.forEach(SortedParquetStore::closeQuietly);
+                available.clear();
+            }
+            notifyAll();
         }
     }
 
@@ -519,7 +578,7 @@ public final class SortedParquetStore implements ListingStore {
         try {
             metrics.parquetReaderReleased();
         } finally {
-            pool(file).add(reader);
+            pool(file).release(reader);
         }
     }
 
@@ -539,13 +598,13 @@ public final class SortedParquetStore implements ListingStore {
     private SortedRowGroupReader.ObjectRow objectAt(Deque<SortedRowGroupReader.ObjectRow> lookahead,
                                                     IndexEntry entry, byte[] key, byte[] upper, int want,
                                                     boolean includeOwner) throws IOException {
-        if (lookahead.isEmpty() || !Arrays.equals(lookahead.peek().key(), key)) {
+        if (lookahead.isEmpty() || !Arrays.equals(lookahead.peek().keyUnsafe(), key)) {
             lookahead.clear();
             lookahead.addAll(rangeReader(entry.file())
                     .range(entry.rowGroup(), key, true, upper, Math.max(1, want), includeOwner));
         }
         SortedRowGroupReader.ObjectRow row = lookahead.poll();
-        if (row != null && Arrays.equals(row.key(), key)) {
+        if (row != null && Arrays.equals(row.keyUnsafe(), key)) {
             return row;
         }
         // Only reachable if the key vanished between the cursor reading it and this read, which the
@@ -572,7 +631,7 @@ public final class SortedParquetStore implements ListingStore {
     }
 
     private static ListedObject toListedObject(SortedRowGroupReader.ObjectRow row) {
-        return new ListedObject(row.key(), row.size(), row.lastModifiedEpochMicros(),
+        return new ListedObject(row.keyUnsafe(), row.size(), row.lastModifiedEpochMicros(),
                 row.etag(), row.storageClass(), row.ownerId(), row.ownerDisplayName(),
                 row.checksumAlgorithm(), row.checksumType());
     }

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/WindowedListingStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/WindowedListingStore.java
@@ -53,9 +53,10 @@ import java.util.Objects;
  *
  * <p><b>Eviction.</b> Eager: when a serve consumes through a delegate-final window's last row the
  * window is dead and is dropped immediately. LRU (bounded {@code max-windows}) is the backstop. Memory
- * is bounded by {@code max-windows × window-rows × row footprint} — a few MB to tens of MB, a function
- * of config, never of the fixture size N (I11 spirit); v1 holds windows as materialised row lists (the
- * PageBlock-packed follow-up is a deliberate, separately-measured next rung, not built here).
+ * is bounded by {@code max-windows × window-rows × row footprint}, a function of config and never of
+ * fixture size N (I11 spirit). The default permits 1.2M materialised rows and can therefore retain
+ * hundreds of MiB, not merely a few tens: v1 holds full object graphs. A packed-window follow-up is a
+ * deliberate, separately measured next rung, not built here.
  */
 public final class WindowedListingStore implements ListingStore {
 

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
@@ -8,6 +8,7 @@ package io.varve.swath.replay.protocol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,7 @@ class S3XmlTest {
         assertThat(xml.indexOf("<Delimiter>")).isLessThan(xml.indexOf("<EncodingType>"));
         assertThat(xml).contains("<IsTruncated>true</IsTruncated>");
         assertThat(xml).contains("<Key>a/has%20space.txt</Key>");
+        assertThat(xml).contains("<LastModified>2026-01-01T00:00:00.123Z</LastModified>");
         assertThat(xml).contains("<ETag>&quot;abc&amp;def&quot;</ETag>");
         assertThat(xml).contains("<ChecksumAlgorithm>CRC32</ChecksumAlgorithm>");
         assertThat(xml).contains("<ChecksumType>FULL_OBJECT</ChecksumType>");
@@ -45,6 +47,70 @@ class S3XmlTest {
         assertThat(xml).contains("<Prefix>a/dir/</Prefix>");
         assertThat(xml).contains("<NextContinuationToken>v2:");
         assertThat(xml.indexOf("<Contents>")).isLessThan(xml.indexOf("<CommonPrefixes>"));
+    }
+
+    @Test
+    void rendersAdversarialUnencodedValuesAsExactUtf8Bytes() {
+        byte[] malformed = new byte[] {'a', '&', '<', '>', '"', '\'', (byte) 0xff};
+        S3ListRequest request = new S3ListRequest(
+                "b&<>\"'\ud800", malformed, null, null, null, Integer.MIN_VALUE, false, true);
+        ListedObject object = new ListedObject(bytes("k/😀&<>'\""), Long.MIN_VALUE, -1,
+                "e&<>\"'😀", "ST😀&", "id<", "display'", "CRC&", "TYPE>");
+        S3ListResult result = new S3ListResult(request,
+                List.of(new S3ResultEntry.ObjectResult(object)), false, null);
+
+        String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+                + "<Name>b&amp;&lt;&gt;&quot;&apos;?</Name>"
+                + "<Prefix>a&amp;&lt;&gt;&quot;&apos;�</Prefix>"
+                + "<KeyCount>1</KeyCount><MaxKeys>-2147483648</MaxKeys>"
+                + "<IsTruncated>false</IsTruncated><Contents>"
+                + "<Key>k/😀&amp;&lt;&gt;&apos;&quot;</Key>"
+                + "<LastModified>1969-12-31T23:59:59.999Z</LastModified>"
+                + "<ETag>&quot;e&amp;&lt;&gt;&quot;&apos;😀&quot;</ETag>"
+                + "<ChecksumAlgorithm>CRC&amp;</ChecksumAlgorithm><ChecksumType>TYPE&gt;</ChecksumType>"
+                + "<Size>-9223372036854775808</Size><StorageClass>ST😀&amp;</StorageClass>"
+                + "<Owner><ID>id&lt;</ID><DisplayName>display&apos;</DisplayName></Owner>"
+                + "</Contents></ListBucketResult>";
+
+        assertThat(S3Xml.listBucketBytes(result)).isEqualTo(expected.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void percentEncodesEveryUnsafeByteWithoutUtf8Decoding() {
+        byte[] raw = new byte[] {'/', ' ', (byte) 0xff, '&', '<', '>'};
+        S3ListRequest request = new S3ListRequest("bucket", raw, bytes("/"), raw, null,
+                1, true, false);
+        S3ListResult result = new S3ListResult(request, List.of(new S3ResultEntry.CommonPrefixResult(raw)),
+                false, null);
+
+        String xml = S3Xml.listBucket(result);
+        assertThat(xml).contains("<Prefix>/%20%FF%26%3C%3E</Prefix>")
+                .contains("<StartAfter>/%20%FF%26%3C%3E</StartAfter>")
+                .contains("<Delimiter>/</Delimiter>")
+                .contains("<CommonPrefixes><Prefix>/%20%FF%26%3C%3E</Prefix></CommonPrefixes>");
+    }
+
+    @Test
+    void boundedBufferGrowthPreservesEveryResponseByte() {
+        List<S3ResultEntry> entries = new ArrayList<>();
+        String longKey = "x".repeat(1_024);
+        for (int i = 0; i < 20; i++) {
+            entries.add(new S3ResultEntry.ObjectResult(new ListedObject(
+                    bytes(longKey + i), i, 0, null, "STANDARD", null, null, null, null)));
+        }
+        S3ListRequest request = new S3ListRequest("bucket", null, null, null, null, 20, true, false);
+        S3ListResult result = new S3ListResult(request, entries, false, null);
+
+        byte[] exact = S3Xml.listBucketBytes(result);
+        var buffer = S3Xml.listBucketBuffer(result);
+        byte[] bounded = new byte[buffer.remaining()];
+        buffer.get(bounded);
+
+        assertThat(bounded).isEqualTo(exact);
+        assertThat(new String(exact, StandardCharsets.UTF_8))
+                .contains("<Key>" + longKey + "19</Key>")
+                .endsWith("</ListBucketResult>");
     }
 
     private static byte[] bytes(String value) {

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayMetricsGaugeStrongReferenceTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayMetricsGaugeStrongReferenceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.replay.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/** Regression for Micrometer weakly referencing the method-reference object behind a gauge. */
+final class ReplayMetricsGaugeStrongReferenceTest {
+
+    private static final int MAX_GC_ATTEMPTS = 50;
+
+    @Test
+    void liveCacheGaugesSurviveGarbageCollection() throws InterruptedException {
+        ReplayMetrics metrics = new ReplayMetrics();
+        registerAndDropGaugeSources(metrics);
+
+        // Do not merely hope System.gc() ran: wait until an unrelated weak canary proves it did.
+        WeakReference<Object> canary = new WeakReference<>(new Object());
+        for (int i = 0; i < MAX_GC_ATTEMPTS && canary.get() != null; i++) {
+            System.gc();
+            Thread.sleep(10L);
+        }
+        assertThat(canary.get())
+                .as("a GC that clears weak references must run within %d attempts", MAX_GC_ATTEMPTS)
+                .isNull();
+
+        assertThat(metrics.registry().find("swath.replay.prefetch.windows.live").gauge().value())
+                .isEqualTo(3.0);
+        assertThat(metrics.registry().find("swath.replay.prefetch.anchors.live").gauge().value())
+                .isEqualTo(7.0);
+    }
+
+    /** Leave the bound method references reachable only through {@link ReplayMetrics}. */
+    private static void registerAndDropGaugeSources(ReplayMetrics metrics) {
+        AtomicInteger windows = new AtomicInteger(3);
+        AtomicInteger anchors = new AtomicInteger(7);
+        metrics.registerPrefetchCacheGauges(windows::get, anchors::get);
+    }
+}

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayServerTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayServerTest.java
@@ -104,6 +104,26 @@ class ReplayServerTest {
     }
 
     @Test
+    void anUnexpectedFixtureFailureReturnsNoInternalDetail() throws Exception {
+        String sensitiveDetail = "/srv/captures/private/part-00001.parquet at key secret/customer";
+        try (ReplayServer server = new ReplayServer("127.0.0.1", 0, "bucket", request -> {
+            throw new IllegalStateException(sensitiveDetail);
+        })) {
+            server.start();
+
+            HttpResponse<String> response = HttpProbe.response(server, "/bucket?list-type=2");
+
+            assertThat(response.statusCode()).isEqualTo(500);
+            assertThat(response.body())
+                    .contains("<Code>InternalError</Code>")
+                    .contains("<Message>internal replay error</Message>")
+                    .doesNotContain(sensitiveDetail)
+                    .doesNotContain("/srv/captures")
+                    .doesNotContain("secret/customer");
+        }
+    }
+
+    @Test
     void echoesRequestedMaxKeysButClampsInternalPageSize() throws Exception {
         AtomicReference<S3ListRequest> seen = new AtomicReference<>();
         try (ReplayServer server = new ReplayServer(

--- a/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
@@ -6,6 +6,7 @@
 package io.varve.swath.replay.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -30,6 +31,7 @@ import io.varve.swath.sort.SortConfigs;
 import io.varve.swath.sort.SortMode;
 import io.varve.swath.sort.SortedFileWriter;
 import io.varve.swath.sort.SortedParquetWriter;
+import io.varve.swath.sort.SortedRowGroupReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -39,6 +41,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -572,7 +577,7 @@ class SortedParquetStoreTest {
     }
 
     @Test
-    void lazyDelimiterPoolClosesABorrowedReaderWhenItReturns(@TempDir Path dir) throws IOException {
+    void closingLazyDelimiterPoolClosesABorrowedReaderWhenItReturns(@TempDir Path dir) throws IOException {
         Fixture fixture = writeSorted(dir, manySmallGroups(), keys(120));
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ReplayMetrics metrics = new ReplayMetrics(registry, ReplayMetrics.SERVING_MODE_SORTED);
@@ -580,6 +585,11 @@ class SortedParquetStoreTest {
                 fixture.files.getFirst(), 1, metrics);
 
         var borrowed = pool.borrow();
+        assertThatCode(() -> {
+            try (var cursor = borrowed.openKeyCursor(0)) {
+                // Opening the cursor is the observable reader operation; no row walk is needed.
+            }
+        }).as("the borrowed reader is usable before the pool closes").doesNotThrowAnyException();
         pool.close();
         pool.release(borrowed);
 
@@ -589,6 +599,51 @@ class SortedParquetStoreTest {
         assertThatThrownBy(pool::borrow)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("pool is closed");
+        assertThatThrownBy(() -> borrowed.openKeyCursor(0))
+                .as("release after pool close must close the returned reader")
+                .isInstanceOfAny(IOException.class, RuntimeException.class);
+    }
+
+    @Test
+    void releasingLazyDelimiterReaderWakesOneBlockedBorrower(@TempDir Path dir) throws Exception {
+        Fixture fixture = writeSorted(dir, manySmallGroups(), keys(120));
+        var pool = new SortedParquetStore.LazyGroupReaderPool(
+                fixture.files.getFirst(), 1,
+                new ReplayMetrics(new SimpleMeterRegistry(), ReplayMetrics.SERVING_MODE_SORTED));
+        var held = pool.borrow();
+        CountDownLatch enteredBorrow = new CountDownLatch(1);
+        CountDownLatch returned = new CountDownLatch(1);
+        AtomicReference<SortedRowGroupReader> received = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread waiter = Thread.ofVirtual().start(() -> {
+            enteredBorrow.countDown();
+            try {
+                received.set(pool.borrow());
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                returned.countDown();
+            }
+        });
+
+        try {
+            assertThat(enteredBorrow.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(returned.await(100, TimeUnit.MILLISECONDS))
+                    .as("the second borrow stays blocked while the only reader is held")
+                    .isFalse();
+
+            pool.release(held);
+
+            assertThat(returned.await(5, TimeUnit.SECONDS))
+                    .as("release must wake the blocked borrower")
+                    .isTrue();
+            assertThat(failure.get()).isNull();
+            assertThat(received.get()).isSameAs(held);
+        } finally {
+            pool.close();
+            waiter.join(5000);
+            pool.release(received.get() != null ? received.get() : held);
+        }
     }
 
     @Test

--- a/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
@@ -572,6 +572,26 @@ class SortedParquetStoreTest {
     }
 
     @Test
+    void lazyDelimiterPoolClosesABorrowedReaderWhenItReturns(@TempDir Path dir) throws IOException {
+        Fixture fixture = writeSorted(dir, manySmallGroups(), keys(120));
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ReplayMetrics metrics = new ReplayMetrics(registry, ReplayMetrics.SERVING_MODE_SORTED);
+        var pool = new SortedParquetStore.LazyGroupReaderPool(
+                fixture.files.getFirst(), 1, metrics);
+
+        var borrowed = pool.borrow();
+        pool.close();
+        pool.release(borrowed);
+
+        assertThat(registry.find("swath.replay.delimiter.reader_pool.open.latency").timer().count())
+                .as("the lazy fleet opens and is timed exactly once")
+                .isEqualTo(1L);
+        assertThatThrownBy(pool::borrow)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pool is closed");
+    }
+
+    @Test
     void rangeReadFailureReturnsTheReaderAndBalancesInFlightMetrics(@TempDir Path dir) throws IOException {
         Fixture fixture = writeSorted(dir, manySmallGroups(), keys(120));
         ReplayMetrics metrics = new ReplayMetrics(new SimpleMeterRegistry(), ReplayMetrics.SERVING_MODE_SORTED);


### PR DESCRIPTION
## Summary

- render ListObjectsV2 XML directly into bounded UTF-8 buffers, with byte-exact escaping, URL encoding, numeric output, and timestamp-prefix reuse
- replace generic Parquet Group materialization with a typed, dictionary-aware reader and fix pooled narrow-to-wide projection correctness
- lazily open delimiter reader fleets, repair their shutdown lifecycle, retain live-cache gauge sources, and expose lazy-open latency
- move the sorted reader default to one slot per visible CPU after the large-fixture pool sweep

## Local evidence

On eight physical cores with isolated client cores:

- SOREL warm random-page, prefetch off: 2.680M rows/s on untouched main to 6.126M rows/s here (+128.6%)
- full 1.049B-row Sentinel sequential walk: 5.517M rows/s
- corrected 93/5/2 worker/pivot/structure mix: 4.153M object rows/s, zero errors
- Sentinel heap knee: 4 GiB / 24 windows / pool 8 sustained 5.468M rows/s, within 1% of the 8 GiB point
- pool 8 / 12 / 16: 5.468M / 5.509M / 5.072M rows/s; pool 8 is the footprint-balanced default

The full SOREL differential matched untouched main byte-for-byte across 9,920 responses, 9,919,142 objects, and 2,886,109,739 bytes (SHA-256 `20078b857c86ff394ec9794da39e231507658004bb678058f05443ef75993c1e`).

## Verification

- `./gradlew build`
- adversarial exact-byte XML cases including malformed bytes, Unicode, escaping, numeric extremes, negative timestamps, and buffer growth
- sorted-vs-DuckDB HAR conformance and full real-fixture differential
- pooled projection-switch, lazy-pool shutdown, and post-GC gauge regressions

## Follow-ups

The coarse-vs-resorted fixture matrix, page-cache-cold storage run, packed prefetch-window representation, and supported trace-driven load command remain separate measurement/design work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sorted data retrieval and projection switching for more reliable reads.
  * Adjusted default reader usage to better match available CPU resources.
  * Improved S3 listing response generation, including large UTF-8 responses.

* **Reliability**
  * Reader pools now open on demand and clean up safely during shutdown or failures.
  * Improved XML escaping, malformed-text handling, and generic server error responses.
  * Added monitoring for reader-pool opening latency and strengthened cache metrics.

* **Documentation**
  * Updated guidance for reader pools, resource limits, latency metrics, and cache memory expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->