### PR TITLE
Use zero-based sorted part filenames

### DIFF
--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -486,10 +486,12 @@ needs. Writer settings are **pinned** (not defaults): `parquet.block.size`,
 - **Sorted output (`--sort`, §6) gets the same consumer `manifest.json` +
   `.swath-state.json` + `_SUCCESS` at publish time** — the
   final **`part-NNNNN.parquet`** files (uniform naming, no
-  `sorted-` prefix; `%05d` zero-padded, lexical name order == key order) live
+  `sorted-` prefix; `NNNNN` is a dense, zero-based sequence beginning at
+  `00000`, `%05d` zero-padded, and lexical name order == key order) live
   under `data/` like any part — a `--sort` dataset and a plain dataset share
   the same `part-` prefix (never a `sorted-` prefix on either) but differ by
   the `w`-infix: plain (unsorted) parts are `part-w{worker}-{seq}.parquet`,
+  where each writer's dense `seq` is independently zero-based,
   `--sort` finals are `part-{NNNNN}.parquet` with no `w`-infix — a consumer
   distinguishes them either way, but authoritatively via `manifest.json`'s
   `sorted` field; the manifest carries their
@@ -716,7 +718,8 @@ which owns the at-most-once-text durability questions it would reopen):
   file carries static footer key-value metadata — `swath.sort.order` (the
   comparator order), `swath.sort.mode` (`objects` | `versions`),
   `swath.sort.format_version`, and, for a multi-file rolled output,
-  `swath.sort.file_index`/`swath.sort.file_final` (1-based position and a
+  `swath.sort.file_index`/`swath.sort.file_final` (1-based position, independent
+  of the filename's zero-based ordinal, and a
   last-file marker proving the resolved file set is complete) — static values
   only, no routing data; the replay server derives its own in-memory
   first-key index at startup instead of trusting an embedded index.

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -86,7 +86,7 @@ swath-replay sort-fixture \
 
 The transform uses the same bounded sort library as swath, writes temporary files then
 renames them, and prints row/file/byte/segment/merge counts. Output files are named
-`part-00001.parquet` onward. Versioned rows or duplicate keys are rejected in the current
+`part-00000.parquet` onward. Versioned rows or duplicate keys are rejected in the current
 non-versioned format rather than silently collapsed.
 
 ## Start the server

--- a/swath-cli/src/test/java/io/varve/swath/cli/SortCliGuardTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SortCliGuardTest.java
@@ -116,14 +116,14 @@ final class SortCliGuardTest {
         DatasetLayout layout = DatasetLayout.of(outputDir);
         Path dataDir = Files.createDirectories(layout.dataDir());
         Files.createFile(stagingDir.resolve("seg-1-0.parquet"));
-        Files.createFile(dataDir.resolve("part-00001.parquet.tmp"));
+        Files.createFile(dataDir.resolve("part-00000.parquet.tmp"));
         Path manifest = Files.createFile(layout.manifest());
-        Path finalFile = Files.createFile(dataDir.resolve("part-00001.parquet"));
+        Path finalFile = Files.createFile(dataDir.resolve("part-00000.parquet"));
 
         ListCommand.cleanSortStagingAndStaleTmp(outputDir, stagingDir);
 
         assertThat(Files.exists(stagingDir)).as("staging dir removed").isFalse();
-        assertThat(Files.exists(dataDir.resolve("part-00001.parquet.tmp"))).as("stale tmp removed").isFalse();
+        assertThat(Files.exists(dataDir.resolve("part-00000.parquet.tmp"))).as("stale tmp removed").isFalse();
         assertThat(Files.exists(manifest)).as("published manifest kept").isTrue();
         assertThat(Files.exists(finalFile)).as("published final file kept").isTrue();
     }

--- a/swath-cli/src/test/java/io/varve/swath/cli/SortForeignManifestTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SortForeignManifestTest.java
@@ -133,7 +133,7 @@ final class SortForeignManifestTest {
         // never silently trusted — the identity mismatch is decisive before _SUCCESS is even consulted.
         Files.writeString(layout.success(), "");
         Path dataDir = Files.createDirectories(layout.dataDir());
-        Path staleFinal = dataDir.resolve("part-00001.parquet");
+        Path staleFinal = dataDir.resolve("part-00000.parquet");
         Files.writeString(staleFinal, "not a real parquet file — a foreign prior run's leftover");
         assertThat(Manifest.readIdentity(outputDir)).hasValueSatisfying(id -> {
             assertThat(id.argsHash()).isEqualTo(foreignArgsHash);

--- a/swath-cli/src/test/java/io/varve/swath/cli/SortPublishedReentryTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/SortPublishedReentryTest.java
@@ -84,7 +84,7 @@ final class SortPublishedReentryTest {
         Files.writeString(layout.success(), "");
         // Resume guard: a resumed run must NOT clear a finalized part — plant one and require it
         // to survive the PUBLISHED reentry (prepareDatasetForFreshRun runs ONLY on a non-resumed run).
-        Path finalizedPart = Files.createDirectories(layout.dataDir()).resolve("part-00001.parquet");
+        Path finalizedPart = Files.createDirectories(layout.dataDir()).resolve("part-00000.parquet");
         Files.writeString(finalizedPart, "this run's already-published finalized part");
         assertThat(CheckpointDbProbe.runStatus(db, runId)).isEqualTo("RUNNING");
 

--- a/swath-core/src/main/java/io/varve/swath/sort/ParallelRangeMerge.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/ParallelRangeMerge.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * {@code R} contiguous ordered ranges and merge each range independently on its own thread, each
  * producing its own ordered part file(s). The concatenation of the ranges' outputs, in range order,
  * is the global sort with no duplicate and no gap — given the input segments already had none — so
- * {@link SortTransform} renames them into a single ascending {@code part-00001.parquet}… sequence.
+ * {@link SortTransform} renames them into a single ascending {@code part-00000.parquet}… sequence.
  *
  * <p><b>Why this is correct.</b> Ranges split on the <b>key bytes</b> (the primary component of
  * {@link ListEntryComparator}); each row is assigned to exactly one range by an exact per-row key

--- a/swath-core/src/main/java/io/varve/swath/sort/SortTransform.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortTransform.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * {@link #cleanStaleFinals}, not here.
  *
  * <p>Multi-file output rolls the sorted stream into range-disjoint files named {@code
- * part-00001.parquet}, {@code part-00002.parquet}, … (lexical order == key order), starting a
+ * part-00000.parquet}, {@code part-00001.parquet}, … (lexical order == key order), starting a
  * fresh file each time the current one reaches {@code finalFileBytes} (default ~1&nbsp;GiB;
  * {@code docs/internals/contracts.md} §7).
  *
@@ -273,7 +273,7 @@ public final class SortTransform {
      * degenerate keyspace that cannot be split into more than one range, so the caller falls back to
      * the untouched serial merge. Otherwise it merges the ranges concurrently
      * ({@link ParallelRangeMerge}), then does the SAME serial publish as the serial path — rename the
-     * ordered range parts into one ascending {@code part-00001.parquet}… sequence (filename order ==
+     * ordered range parts into one ascending {@code part-00000.parquet}… sequence (filename order ==
      * key order == global sort), fire the publish listener, delete staging. Immediately before that
      * rename it writes the multi-file completeness stamp ({@code file_index} 1..N, one
      * {@code file_final} on N), which is the point at which the global part order is first known.
@@ -410,9 +410,9 @@ public final class SortTransform {
             writer.close();
             atomicRename(tf.get(0), finalFiles.get(0));
         } else {
-            int index = 1;
+            int filenameIndex = 0;
             for (Path tmp : tmpsInOrder) {
-                String name = String.format("%s%05d%s", FINAL_PREFIX, index++, FINAL_SUFFIX);
+                String name = finalPartName(filenameIndex++);
                 Path finalPath = outputDir.resolve(name);
                 atomicRename(tmp, finalPath);
                 finalFiles.add(finalPath);
@@ -455,18 +455,26 @@ public final class SortTransform {
     private SortedFileWriter openNextFile(Path outputDir, Path stagingDir, List<Path> finalFiles,
                                           List<Path> tmpFiles, List<SortedFileWriter> finalWriters,
                                           SortedFileWriterFactory outputSequence) throws IOException {
-        int index = finalFiles.size() + 1;
-        String name = String.format("%s%05d%s", FINAL_PREFIX, index, FINAL_SUFFIX);
+        int filenameIndex = finalFiles.size();
+        String name = finalPartName(filenameIndex);
         Path finalPath = outputDir.resolve(name);
         // Write the tmp OUTSIDE data/ — into the sibling staging dir on the same
         // filesystem — and atomically rename it INTO data/ (see transform()). data/ (outputDir) thus
         // only ever holds finalized *.parquet; a crash never strands a *.tmp inside the pure-parquet dir.
         Path tmpPath = stagingDir.resolve(name + TMP_SUFFIX);
-        SortedFileWriter writer = outputSequence.create(tmpPath, index);
+        // The public filename follows Spark/Hadoop's zero-based part ordinal. The footer's
+        // file_index remains a 1-based position so existing sorted fixtures retain their stamp
+        // semantics and replay's completeness check remains backward-compatible.
+        SortedFileWriter writer = outputSequence.create(tmpPath, filenameIndex + 1);
         finalFiles.add(finalPath);
         tmpFiles.add(tmpPath);
         finalWriters.add(writer);
         return writer;
+    }
+
+    /** Spark/Hadoop-style public part name with a dense, zero-based ordinal. */
+    private static String finalPartName(int filenameIndex) {
+        return String.format("%s%05d%s", FINAL_PREFIX, filenameIndex, FINAL_SUFFIX);
     }
 
     private static List<FinalPart> finalParts(List<Path> paths, List<SortedFileWriter> writers) {

--- a/swath-core/src/main/java/io/varve/swath/sort/SortTransformResult.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortTransformResult.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * The outcome of a {@link SortTransform} run: the published final sorted file(s), in key order, and
- * the total row count. Range-disjoint and named {@code part-00001.parquet}… when
+ * the total row count. Range-disjoint and named {@code part-00000.parquet}… when
  * {@code final-file-bytes} rolls the output; a single file otherwise.
  *
  * <p>{@code mergePasses}/{@code cascadedPasses}/{@code fastPathEmissions} surface the

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortCascadeContractTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortCascadeContractTest.java
@@ -99,7 +99,7 @@ final class SortCascadeContractTest {
                     store, run.id(), 4, seeds, cascadingSegments(), SortMode.OBJECTS,
                     EngineToggles.DEFAULT, TraceSink.NONE, false);
 
-            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
             assertThat(Files.exists(finalFile)).isTrue();
 
             // Byte-exact global order + completeness (no gap, no overlap) against the ground truth.

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortFreshRunStagingSweepTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortFreshRunStagingSweepTest.java
@@ -93,7 +93,7 @@ final class SortFreshRunStagingSweepTest {
             assertThat(Files.exists(staleSeg)).as("abandoned stale segment swept before listing began").isFalse();
             assertThat(Files.exists(staleMerge)).as("abandoned stale cascade intermediate swept too").isFalse();
 
-            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
             List<String> keys = ParquetReads.keys(finalFile);
             assertThat(keys).as("only this run's real keys — the stale content was never merged in")
                     .containsExactlyElementsOf(expectedSorted(keyspace));

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortMergeReentryContractTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortMergeReentryContractTest.java
@@ -147,7 +147,7 @@ final class SortMergeReentryContractTest {
                 (files, rows) -> writeManifest(outputDir,
                         files.stream().map(io.varve.swath.sort.FinalPart::path).toList()));
 
-        Path finalFile = outputDir.resolve("part-00001.parquet");
+        Path finalFile = outputDir.resolve("part-00000.parquet");
         assertThat(ParquetReads.keys(finalFile)).containsExactlyElementsOf(sortedStrings(keyspace));
         assertThat(SortStamp.read(finalFile)).isPresent();
         assertThat(result.totalRows()).isEqualTo(keyspace.size());
@@ -194,20 +194,20 @@ final class SortMergeReentryContractTest {
             // cascade intermediate the re-run must clean. Finals live under <root>/data/, so the
             // crashed prior attempt's orphans sit there too.
             Path dataDir = Files.createDirectories(DatasetLayout.of(outputDir).dataDir());
-            Files.writeString(dataDir.resolve("part-00001.parquet"), "orphaned pre-manifest content");
-            Files.writeString(dataDir.resolve("part-00001.parquet.tmp"), "stale tmp");
+            Files.writeString(dataDir.resolve("part-00000.parquet"), "orphaned pre-manifest content");
+            Files.writeString(dataDir.resolve("part-00000.parquet.tmp"), "stale tmp");
             Files.writeString(stagingDir.resolve("merge-0.parquet"), "stale cascade intermediate");
             assertThat(Files.exists(DatasetLayout.of(outputDir).manifest())).isFalse();
 
             new ListRunner().runSortMergeOnly(ctx, outputDir, stagingDir, store, run.id(),
                     singlePass(), SortMode.OBJECTS, spec(sidecar));
 
-            Path finalFile = dataDir.resolve("part-00001.parquet");
+            Path finalFile = dataDir.resolve("part-00000.parquet");
             assertThat(ParquetReads.keys(finalFile))
                     .as("orphaned final file overwritten with the correct merge output")
                     .containsExactlyElementsOf(sortedStrings(keyspace));
             assertThat(SortStamp.read(finalFile)).isPresent();
-            assertThat(Files.readString(DatasetLayout.of(outputDir).manifest())).contains("part-00001.parquet");
+            assertThat(Files.readString(DatasetLayout.of(outputDir).manifest())).contains("part-00000.parquet");
             assertThat(store.sortPhase(run.id())).isEqualTo(SortPhase.PUBLISHED);
             assertThat(Files.exists(stagingDir)).as("staging removed after republish").isFalse();
             assertThat(counter(ctx, "swath.steal_reason", "merge_redone"))
@@ -297,7 +297,7 @@ final class SortMergeReentryContractTest {
         SortTransformResult result = redo.transform(segments, outputDir, stagingDir,
                 (files, rows) -> writeManifest(outputDir,
                         files.stream().map(io.varve.swath.sort.FinalPart::path).toList()));
-        assertThat(ParquetReads.keys(outputDir.resolve("part-00001.parquet")))
+        assertThat(ParquetReads.keys(outputDir.resolve("part-00000.parquet")))
                 .containsExactlyElementsOf(sortedStrings(keyspace));
         assertThat(result.totalRows()).isEqualTo(keyspace.size());
     }

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortPipelineTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortPipelineTest.java
@@ -100,7 +100,7 @@ final class SortPipelineTest {
                     EngineToggles.DEFAULT, TraceSink.NONE, false);
 
             // One published, globally-sorted, stamped file (under <root>/data/).
-            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
             assertThat(Files.exists(finalFile)).isTrue();
             List<String> keys = ParquetReads.keys(finalFile);
             assertThat(keys).containsExactlyElementsOf(expectedSorted(keyspace));
@@ -110,7 +110,7 @@ final class SortPipelineTest {
 
             // Manifest published (LAST) referencing only the final file — never a staging segment.
             String manifest = Files.readString(DatasetLayout.of(outputDir).manifest());
-            assertThat(manifest).contains("part-00001.parquet");
+            assertThat(manifest).contains("part-00000.parquet");
             assertThat(manifest).doesNotContain("seg-");
             assertThat(manifest).doesNotContain("_staging");
 
@@ -173,10 +173,10 @@ final class SortPipelineTest {
             new ListRunner().runSortMergeOnly(ctx, outputDir, stagingDir, store, run.id(),
                     smallSegments(), SortMode.OBJECTS, spec());
 
-            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
             assertThat(ParquetReads.keys(finalFile)).containsExactlyElementsOf(expectedSorted(keyspace));
             assertThat(SortStamp.read(finalFile)).isPresent();
-            assertThat(Files.readString(DatasetLayout.of(outputDir).manifest())).contains("part-00001.parquet");
+            assertThat(Files.readString(DatasetLayout.of(outputDir).manifest())).contains("part-00000.parquet");
             assertThat(store.sortPhase(run.id())).isEqualTo(SortPhase.PUBLISHED);
             assertThat(counter(ctx, "swath.steal_reason", "SORT", "merge_redone")).isEqualTo(1.0);
             assertThat(Files.exists(stagingDir)).as("staging dir removed after republish").isFalse();

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortResumeCascadeScaleTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortResumeCascadeScaleTest.java
@@ -178,7 +178,7 @@ final class SortResumeCascadeScaleTest {
                     .as("SORT.merge_redone fired exactly once (zero new LIST fetches)").isEqualTo(1.0);
 
             // Every sealed segment reused; final output complete, globally sorted, duplicate-free.
-            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+            Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
             List<String> outKeys = ParquetReads.keys(finalFile);
             List<String> expected = sortedStrings(keyspace);
             assertThat(outKeys).as("no duplicate rows").doesNotHaveDuplicates();

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortResumeListingContractTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortResumeListingContractTest.java
@@ -234,7 +234,7 @@ final class SortResumeListingContractTest {
         }
 
         // ---- correctness: complete, globally sorted, no dup, no gap (byte-exact) ----
-        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
         List<String> outKeys = ParquetReads.keys(finalFile);
         List<String> expected = keyspace.stream().map(k -> new String(k, StandardCharsets.UTF_8))
                 .sorted().toList();
@@ -323,7 +323,7 @@ final class SortResumeListingContractTest {
         }
 
         // ---- correctness: complete, sorted, no dup, no gap ----
-        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
         List<String> outKeys = ParquetReads.keys(finalFile);
         List<String> expected = keyspace.stream().map(k -> new String(k, StandardCharsets.UTF_8))
                 .sorted().toList();
@@ -433,7 +433,7 @@ final class SortResumeListingContractTest {
         }
 
         // ---- correctness sanity: the published output is complete + globally sorted ----
-        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00001.parquet");
+        Path finalFile = DatasetLayout.of(outputDir).dataFile("part-00000.parquet");
         List<String> expected = keyspace.stream()
                 .map(k -> new String(k, StandardCharsets.UTF_8)).sorted().toList();
         assertThat(ParquetReads.keys(finalFile))

--- a/swath-core/src/test/java/io/varve/swath/runtime/SortedManifestMetadataHandoffTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortedManifestMetadataHandoffTest.java
@@ -32,7 +32,7 @@ class SortedManifestMetadataHandoffTest {
     void trustedFreshMetadataPublishesWithoutOpeningTheFinalPart(@TempDir Path root) throws Exception {
         DatasetLayout layout = DatasetLayout.of(root);
         Files.createDirectories(layout.dataDir());
-        Path absent = layout.dataDir().resolve("part-00001.parquet");
+        Path absent = layout.dataDir().resolve("part-00000.parquet");
         FinalPartMetadata metadata =
                 new FinalPartMetadata(2, 123, "0123456789abcdef0123456789abcdef",
                         "alpha", "omega", 23, 17, 10);
@@ -45,7 +45,7 @@ class SortedManifestMetadataHandoffTest {
                 new RunMetrics(registry));
 
         JsonNode file = MAPPER.readTree(layout.manifest().toFile()).path("files").get(0);
-        assertThat(file.path("key").asText()).isEqualTo("data/part-00001.parquet");
+        assertThat(file.path("key").asText()).isEqualTo("data/part-00000.parquet");
         assertThat(file.path("size").asLong()).isEqualTo(123);
         assertThat(file.path("MD5checksum").asText()).isEqualTo(metadata.md5());
         assertThat(file.path("rowCount").asLong()).isEqualTo(2);
@@ -60,7 +60,7 @@ class SortedManifestMetadataHandoffTest {
     void metadataLessCarriedPartIsStillReadAndRejectedWhenTruncated(@TempDir Path root) throws Exception {
         DatasetLayout layout = DatasetLayout.of(root);
         Files.createDirectories(layout.dataDir());
-        Path truncated = layout.dataDir().resolve("part-00001.parquet");
+        Path truncated = layout.dataDir().resolve("part-00000.parquet");
         Files.write(truncated, new byte[] {1, 2, 3, 4});
 
         SimpleMeterRegistry registry = new SimpleMeterRegistry();

--- a/swath-core/src/test/java/io/varve/swath/sort/CaptureSorterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/CaptureSorterTest.java
@@ -126,7 +126,7 @@ class CaptureSorterTest {
      * decorator that wraps the final writer (see {@code CaptureSorter.DuplicateKeyCheckingWriterFactory})
      * — its {@code previousKey} state must survive a FINAL-FILE ROLL, not just a single writer's
      * lifetime. Force a roll after every row ({@code finalFileBytes = 1}) so the OBJECT "a" is
-     * written to {@code part-00001} and its COMMON_PREFIX duplicate lands in {@code part-00002}
+     * written to {@code part-00000} and its COMMON_PREFIX duplicate lands in {@code part-00001}
      * — only cross-file state can catch
      * this. Also proves the duplicate-detected path still leaves ONLY {@code .tmp} files behind (no
      * renamed/published final), same as the merge-phase {@link DuplicateHook} discipline.
@@ -280,7 +280,7 @@ class CaptureSorterTest {
 
         // Simulate a crash: a stale FINAL .tmp in outputDir, and stale partial segments left in this
         // engine's own fixed staging dir from an interrupted prior attempt.
-        Path staleTmp = Files.createFile(outputDir.resolve("part-00001.parquet.tmp"));
+        Path staleTmp = Files.createFile(outputDir.resolve("part-00000.parquet.tmp"));
         Path stagingDir = Files.createDirectories(outputDir.resolve(CaptureSorter.STAGING_DIR_NAME));
         Path staleSegment = Files.createFile(stagingDir.resolve("fixture-0.parquet"));
 

--- a/swath-core/src/test/java/io/varve/swath/sort/ParallelRangeMergeRowGroupSkipPropTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/ParallelRangeMergeRowGroupSkipPropTest.java
@@ -538,7 +538,7 @@ class ParallelRangeMergeRowGroupSkipPropTest {
         List<String> names = files.stream().map(p -> p.getFileName().toString()).toList();
         assertThat(names).as("final files in ascending name order").isSorted();
         for (int i = 0; i < names.size(); i++) {
-            assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i + 1));
+            assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i));
         }
     }
 

--- a/swath-core/src/test/java/io/varve/swath/sort/SortRollPublishStampCharacterizationTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortRollPublishStampCharacterizationTest.java
@@ -50,8 +50,8 @@ class SortRollPublishStampCharacterizationTest {
 
     /**
      * Serial rolled publish: with a 1-byte roll gate every row lands in its own file, so the four rows
-     * produce {@code part-00001..part-00004}. The stamp's {@code file_index} is the GLOBAL 1..N in
-     * filename order and {@code file_final} is present on the LAST file only.
+     * produce {@code part-00000..part-00003}. The stamp's {@code file_index} remains the GLOBAL 1..N
+     * position in filename order and {@code file_final} is present on the LAST file only.
      */
     @Test
     void serialRollStampsGlobalFileIndexOneToNAndFinalOnLastOnly(@TempDir Path root) throws IOException {
@@ -68,7 +68,7 @@ class SortRollPublishStampCharacterizationTest {
         // Roll cadence: one row per file, four files, named in key order.
         assertThat(result.finalFiles()).hasSize(4);
         assertThat(names(result.finalFiles())).containsExactly(
-                "part-00001.parquet", "part-00002.parquet", "part-00003.parquet", "part-00004.parquet");
+                "part-00000.parquet", "part-00001.parquet", "part-00002.parquet", "part-00003.parquet");
         assertThat(keys(result.finalFiles())).containsExactly("a", "b", "c", "d");
         for (Path f : result.finalFiles()) {
             assertThat(keys(List.of(f))).hasSize(1);
@@ -92,10 +92,9 @@ class SortRollPublishStampCharacterizationTest {
 
     /**
      * Parallel rolled publish: three balanced ranges, each rolling every row into its own part, so the
-     * nine rows produce {@code part-00001..part-00009} — a correct global sort by filename order. But the
-     * stamp's {@code file_index} is RANGE-LOCAL: it restarts at 1 within each range, so the observed
-     * sequence in filename order is {@code 1,2,3,1,2,3,1,2,3}, NOT the global {@code 1..9}. And NO file
-     * carries the {@code file_final} key — asserted by its explicit absence, the tripwire.
+     * nine rows produce {@code part-00000..part-00008} — a correct global sort by filename order.
+     * The filename ordinal is zero-based while the footer's compatibility-preserving {@code
+     * file_index} is the global 1..N position.
      */
     @Test
     void parallelRollStampsTheSameGlobalFileIndexAndFinalAsSerial(@TempDir Path root) throws IOException {
@@ -115,6 +114,10 @@ class SortRollPublishStampCharacterizationTest {
                 .transform(staging, dirs.output, dirs.staging, PublishListener.NO_OP, progress::add);
 
         assertThat(result.finalFiles()).hasSize(9);
+        assertThat(names(result.finalFiles())).containsExactly(
+                "part-00000.parquet", "part-00001.parquet", "part-00002.parquet",
+                "part-00003.parquet", "part-00004.parquet", "part-00005.parquet",
+                "part-00006.parquet", "part-00007.parquet", "part-00008.parquet");
         assertThat(keys(result.finalFiles()))
                 .containsExactly("a", "b", "c", "d", "e", "f", "g", "h", "i");
 

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformFanInClampTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformFanInClampTest.java
@@ -125,7 +125,7 @@ class SortTransformFanInClampTest {
         assertThat(parts.size()).as("small final-file-bytes must roll into multiple parts").isGreaterThan(1);
         for (int i = 0; i < parts.size(); i++) {
             assertThat(parts.get(i).getFileName().toString())
-                    .isEqualTo(String.format("part-%05d.parquet", i + 1));
+                    .isEqualTo(String.format("part-%05d.parquet", i));
         }
         // Monotonic part boundaries: the last key of part i is strictly before the first key of part i+1.
         String prevMax = null;

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformPageRunParallelMergePropTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformPageRunParallelMergePropTest.java
@@ -194,7 +194,7 @@ class SortTransformPageRunParallelMergePropTest {
 
     /**
      * Rolled output: each range also splits into several parts. Stacks intra-range file boundaries on
-     * top of the inter-range ones — the whole {@code part-00001..N} sequence must still be the exact
+     * top of the inter-range ones — the whole {@code part-00000..part-(N-1)} sequence must still be the exact
      * global sort.
      */
     @Property(tries = 30)
@@ -829,7 +829,7 @@ class SortTransformPageRunParallelMergePropTest {
             List<String> names = parallel.finalFiles().stream()
                     .map(p -> p.getFileName().toString()).toList();
             for (int i = 0; i < names.size(); i++) {
-                assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i + 1));
+                assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i));
             }
         } finally {
             deleteRecursively(root);

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergePropTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergePropTest.java
@@ -112,7 +112,7 @@ class SortTransformParallelMergePropTest {
     /**
      * Same core property, but each range ALSO rolls into multiple parts (a decorator forces a roll
      * every ~5 rows). Stresses intra-range file boundaries stacked on top of the inter-range
-     * boundaries: filename order across the whole {@code part-00001..part-N} sequence must still be the
+     * boundaries: filename order across the whole {@code part-00000..part-(N-1)} sequence must still be the
      * exact global sort, byte-exact to a serial run rolled the same way.
      */
     @Property(tries = 30)
@@ -508,7 +508,7 @@ class SortTransformParallelMergePropTest {
         List<String> names = files.stream().map(p -> p.getFileName().toString()).toList();
         assertThat(names).as("final files enumerated in ascending name order").isSorted();
         for (int i = 0; i < names.size(); i++) {
-            assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i + 1));
+            assertThat(names.get(i)).isEqualTo(String.format("part-%05d.parquet", i));
         }
     }
 

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergeTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergeTest.java
@@ -62,7 +62,7 @@ class SortTransformParallelMergeTest {
         assertThat(keys(parallel.finalFiles())).containsExactlyElementsOf(expected);
         List<String> names = parallel.finalFiles().stream().map(p -> p.getFileName().toString()).toList();
         assertThat(names).isSorted();
-        assertThat(names.get(0)).isEqualTo("part-00001.parquet");
+        assertThat(names.get(0)).isEqualTo("part-00000.parquet");
         // Staging fully reclaimed and the dir removed (same publish contract as serial).
         assertThat(Files.exists(parDirs.staging)).isFalse();
         assertThat(listTmp(parDirs.output)).isEmpty();

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergeTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformParallelMergeTest.java
@@ -61,8 +61,8 @@ class SortTransformParallelMergeTest {
         // Filename order == key order == the global sort, no gap, no duplicate.
         assertThat(keys(parallel.finalFiles())).containsExactlyElementsOf(expected);
         List<String> names = parallel.finalFiles().stream().map(p -> p.getFileName().toString()).toList();
-        assertThat(names).isSorted();
-        assertThat(names.get(0)).isEqualTo("part-00000.parquet");
+        assertThat(names).containsExactly(
+                "part-00000.parquet", "part-00001.parquet", "part-00002.parquet");
         // Staging fully reclaimed and the dir removed (same publish contract as serial).
         assertThat(Files.exists(parDirs.staging)).isFalse();
         assertThat(listTmp(parDirs.output)).isEmpty();

--- a/swath-core/src/test/java/io/varve/swath/sort/SortTransformTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortTransformTest.java
@@ -47,7 +47,7 @@ class SortTransformTest {
         // contents — the sorter owns it exclusively.
         assertThat(Files.exists(dirs.staging)).isFalse();
         assertThat(listTmp(dirs.output)).isEmpty();                    // no stale .tmp
-        assertThat(result.finalFiles().get(0).getFileName().toString()).isEqualTo("part-00001.parquet");
+        assertThat(result.finalFiles().get(0).getFileName().toString()).isEqualTo("part-00000.parquet");
     }
 
     @Test
@@ -109,8 +109,8 @@ class SortTransformTest {
         assertThat(result.finalFiles()).hasSize(6);
         List<String> names = result.finalFiles().stream().map(p -> p.getFileName().toString()).toList();
         assertThat(names).containsExactly(
-                "part-00001.parquet", "part-00002.parquet", "part-00003.parquet",
-                "part-00004.parquet", "part-00005.parquet", "part-00006.parquet");
+                "part-00000.parquet", "part-00001.parquet", "part-00002.parquet",
+                "part-00003.parquet", "part-00004.parquet", "part-00005.parquet");
         // Lexical file order == key order, and files are range-disjoint (one key each, ascending).
         assertThat(keys(result.finalFiles())).containsExactly("a", "b", "c", "d", "e", "f");
         for (Path f : result.finalFiles()) {
@@ -187,7 +187,7 @@ class SortTransformTest {
     void staleTmpFromACrashedPublishIsCleanedBeforeReRun(@TempDir Path root) throws IOException {
         Dirs dirs = dirs(root);
         // A previous run crashed mid-publish, leaving a partial .tmp behind.
-        Path stale = Files.createFile(dirs.output.resolve("part-00001.parquet.tmp"));
+        Path stale = Files.createFile(dirs.output.resolve("part-00000.parquet.tmp"));
         List<Path> staging = List.of(writeSegment(dirs.staging, "seg-0.parquet", objects("a", "b")));
 
         SortTransformResult result = transform(SortConfig.fromSystemProperties())
@@ -245,14 +245,14 @@ class SortTransformTest {
 
         assertThat(Files.exists(staleFinal)).as("stale final swept before republish").isFalse();
         assertThat(keys(result.finalFiles())).containsExactly("a", "b");
-        assertThat(result.finalFiles()).containsExactly(dirs.output.resolve("part-00001.parquet"));
+        assertThat(result.finalFiles()).containsExactly(dirs.output.resolve("part-00000.parquet"));
         // The manifest callback saw exactly the files this run produced — no stale survivor mixed in.
         assertThat(published).containsExactlyElementsOf(result.finalFiles());
         // Only the produced final remains on disk under the output dir root.
         try (var s = Files.newDirectoryStream(dirs.output, "part-*.parquet")) {
             List<Path> onDisk = new ArrayList<>();
             s.forEach(onDisk::add);
-            assertThat(onDisk).containsExactly(dirs.output.resolve("part-00001.parquet"));
+            assertThat(onDisk).containsExactly(dirs.output.resolve("part-00000.parquet"));
         }
     }
 

--- a/swath-replay/src/test/java/io/varve/swath/replay/fixture/ResIdxCrashFallbackTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/fixture/ResIdxCrashFallbackTest.java
@@ -78,7 +78,7 @@ class ResIdxCrashFallbackTest {
         // abandoned part-*.parquet.tmp. No completed stamped file exists.
         Path crashDir = Files.createDirectories(dir.resolve("crash"));
         writeUnsortedPart(crashDir.resolve("part-0.parquet"), "delta", "alpha", "charlie", "bravo");
-        Files.writeString(crashDir.resolve("part-00001.parquet.tmp"), "partial-crash-bytes");
+        Files.writeString(crashDir.resolve("part-00000.parquet.tmp"), "partial-crash-bytes");
 
         // Sorted mode refuses it by name rather than quietly serving it a different way.
         assertThatThrownBy(() -> ReplayServingFactory.open(crashDir, ServingMode.SORTED, 2))

--- a/swath-replay/src/test/java/io/varve/swath/replay/fixture/SortFixtureCommandTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/fixture/SortFixtureCommandTest.java
@@ -52,7 +52,7 @@ class SortFixtureCommandTest {
         }
 
         assertThat(exit).isEqualTo(0);
-        Path output = outputDir.resolve("part-00001.parquet");
+        Path output = outputDir.resolve("part-00000.parquet");
         assertThat(Files.exists(output)).isTrue();
         assertThat(SortStamp.read(output)).isPresent();
 
@@ -122,7 +122,7 @@ class SortFixtureCommandTest {
         Path capture = Files.createDirectories(dir.resolve("capture"));
         writeUnsortedPart(capture.resolve("part-0.parquet"), "a", "b");
         Path outputDir = Files.createDirectories(dir.resolve("out"));
-        Path staleTmp = Files.createFile(outputDir.resolve("part-00001.parquet.tmp"));
+        Path staleTmp = Files.createFile(outputDir.resolve("part-00000.parquet.tmp"));
         Files.createDirectories(outputDir.resolve(CaptureSorter.STAGING_DIR_NAME));
         Files.createFile(outputDir.resolve(CaptureSorter.STAGING_DIR_NAME).resolve("fixture-0.parquet"));
 
@@ -132,7 +132,7 @@ class SortFixtureCommandTest {
         assertThat(exit).isEqualTo(0);
         assertThat(Files.exists(staleTmp)).isFalse();
         assertThat(Files.exists(outputDir.resolve(CaptureSorter.STAGING_DIR_NAME))).isFalse();
-        assertThat(SortStamp.read(outputDir.resolve("part-00001.parquet"))).isPresent();
+        assertThat(SortStamp.read(outputDir.resolve("part-00000.parquet"))).isPresent();
     }
 
     // --- helpers ---

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayServingFactoryTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/ReplayServingFactoryTest.java
@@ -91,17 +91,17 @@ class ReplayServingFactoryTest {
         // A genuine 2-file rolled publish (file 1 honestly stamped file_index=1, file 2 file_index=2
         // + file_final=true) so the completeness check passes — but the two files' NAMES are
         // then swapped, so resolveFiles' lexical order disagrees with each file's own key content
-        // (the file named "00001" actually holds the higher keys) — only the ascending-first-key
+        // (the file named "00000" actually holds the higher keys) — only the ascending-first-key
         // sanity check catches this, and it must still fire even though completeness is satisfied.
         Path fixtureDir = Files.createDirectories(dir.resolve("fixture"));
-        rollToNFiles(dir, fixtureDir, List.of("a", "d"));   // part-00001=a (idx 1), part-00002=d (idx 2, final)
-        Path first = fixtureDir.resolve("part-00001.parquet");
-        Path second = fixtureDir.resolve("part-00002.parquet");
+        rollToNFiles(dir, fixtureDir, List.of("a", "d"));   // part-00000=a (idx 1), part-00001=d (idx 2, final)
+        Path first = fixtureDir.resolve("part-00000.parquet");
+        Path second = fixtureDir.resolve("part-00001.parquet");
         Path tmp = fixtureDir.resolve("swap.tmp");
         Files.move(first, tmp);
         Files.move(second, first);
         Files.move(tmp, second);
-        // Now "part-00001.parquet" holds "d" (file_index=2, final) and "part-00002.parquet" holds
+        // Now "part-00000.parquet" holds "d" (file_index=2, final) and "part-00001.parquet" holds
         // "a" (file_index=1) — completeness still holds (indices {1,2} present, final on max), but the
         // flattened first-key sequence in lexical order is d, a — not ascending.
 


### PR DESCRIPTION
Closes #28

## Summary
- start sorted Parquet filenames at `part-00000.parquet`
- preserve the existing 1-based `swath.sort.file_index` footer for compatibility
- document that sorted and unsorted filename ordinals are zero-based
- update serial, parallel, resume, replay, and manifest coverage

Unsorted output was already zero-based per writer lane (`part-w<lane>-00000.parquet`).

## Investigation
The reported recovery-allocation hypothesis is not present in the current implementation. Sorted naming was deterministically 1-based in both publication paths: serial publication derived the name from the existing final-file count plus one, and parallel publication began its final rename index at one. Recovery paths therefore did not leak a discarded public filename ordinal. This change standardizes new sorted output on the conventional zero-based public filename sequence while retaining the established one-based footer index for compatibility.

## Testing
- `./gradlew build`
- `./gradlew :swath-core:test --tests 'io.varve.swath.sort.SortTransformParallelMergeTest'`\n- `git diff --check`