### PR TITLE
Improve newcomer documentation clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ or [see the visual field guide](https://swath.varve.io/field-guide/).*
 
 ## Try it
 
-This is the exact listing shown in the demo. It scans the entire public NOAA bucket—
-39.6 million objects in the recorded run—and saves a resumable Parquet dataset:
+This is the exact listing shown in the demo. It scans the entire public NOAA bucket and
+saves a resumable Parquet dataset. The recorded run listed 39.6 million objects, made
+41,582 S3 API calls, wrote 790.8 MB of Parquet, and peaked at about 1.7 GB of resident
+memory (RSS). Review the [request-cost guidance](docs/operating.md#request-cost) before
+running it. This is a full-scale demonstration, not a lightweight smoke test:
 
 ```bash
 mkdir -p out
@@ -58,17 +61,15 @@ compaction step:
 duckdb -c "SELECT count(*) FROM read_parquet('out/noaa-gestofs-pds/data/*.parquet')"
 ```
 
-If the listing is interrupted, the output directory is the run handle:
+If the listing is interrupted, resume it by passing the same output directory:
 
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
   ghcr.io/varveio/swath:latest resume /out/noaa-gestofs-pds
 ```
 
-The recorded run made 41,582 S3 API calls, wrote 790.8 MB of Parquet, and peaked around
-1.7 GB RSS. Read the [request-cost guidance](docs/operating.md#request-cost) before
-reproducing it. `--concurrency` is an adaptive ceiling rather than a fixed request count;
-see [Choosing concurrency](docs/configuration.md#choosing-concurrency) before raising it.
+`--concurrency` is an adaptive ceiling rather than a fixed request count; see
+[Choosing concurrency](docs/configuration.md#choosing-concurrency) before raising it.
 
 For a private bucket, remove `--no-sign-request`, use the bucket's region, and pass
 credentials into the container. Docker does not automatically inherit a host AWS profile;

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@ internals to use swath.
 
 ## Start
 
-1. [Getting started](getting-started.md) — try a public listing with Docker, save a
-   managed Parquet dataset, query it, and learn how resume works.
+1. [Getting started](getting-started.md) — check the Docker image, optionally reproduce
+   the full public demo, query its managed Parquet dataset, and learn how to resume a run.
 2. [Installation](install.md) — choose Docker, the self-contained jar, a release archive,
    or a source build.
 3. [Common workflows](usage.md) — choose an output, filter rows, sort Parquet, resume a
@@ -42,8 +42,8 @@ For the repository-level technical model, continue with
 [the internals overview](internals/overview.md), then go only as deep as you need:
 
 - [Architecture](internals/architecture.md) — components and the flow of a run.
-- [Listing algorithms](internals/algorithms.md) — seeding, pivots, stealing, AIMD,
-  sorting, and the correctness argument.
+- [Listing algorithms](internals/algorithms.md) — seeding, pivots, stealing, adaptive
+  concurrency, sorting, and the correctness argument.
 - [Contracts and data model](internals/contracts.md) — invariants I1–I12, types,
   persistence schemas, output schemas, and delivery guarantees.
 - [Worked bucket shapes](internals/walkthroughs.md) — step-by-step traces through

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,9 +25,9 @@ The resolution rules are deliberately independent:
 | Input | Resolution |
 | --- | --- |
 | No `-o`, or `-o -` | stdout; `auto` is table on a terminal and TSV when redirected |
-| `--format discard` | diagnostic stdout-shaped sink with no bytes written; rejects a real `-o` destination and gzip/Zstandard compression |
+| `--format discard` | diagnostic sink that counts rows without writing them; rejects a real `-o PATH` destination and gzip or Zstandard compression |
 | `-o` ending in `.tsv` or `.jsonl` | atomically published single file; the suffix supplies the format when `--format` is omitted |
-| `-o` ending in `.parquet` | FILE-kind, one-writer Parquet dataset directory containing one part; it is not one physical Parquet file |
+| `-o` ending in `.parquet` | by default, a one-part, non-resumable Parquet dataset directory; `--output-type dir` overrides that destination-kind inference |
 | A `.gz` or `.zst` outer suffix | stripped before format inference and implies gzip or Zstandard for text; for example, `rows.jsonl.gz` is a gzip JSONL file |
 | Any other real `-o` path | directory dataset; `--format` is required because the path supplies none |
 | `--output-type file` or `--output-type dir` | overrides only destination kind, never a path's implied format |
@@ -38,9 +38,8 @@ compression is internal. Table, TSV, and JSONL support optional compression as s
 or single-file streams. Only TSV and JSONL support bounded directory datasets; those
 datasets are non-resumable and require `--checkpoint none` in this release.
 
-Discard is also non-resumable. It uses the normal engine, checkpoint protocol, bounded listing
-channel, row tally, and metrics, but bypasses every material output component. Use `--report PATH`
-to retain its summary because the sink itself intentionally creates no destination.
+Discard is non-resumable. It runs the normal listing engine but writes no listing rows.
+Use `--report PATH` to retain its summary.
 
 Text directory datasets use `--text-writers` (default `3`, range `2..64`) and
 `--text-part-size` (default `256mb`). At startup, unless stdout or `-q` suppresses it,
@@ -51,25 +50,19 @@ effective choice is visible before listing begins.
 
 ## Choosing `--concurrency`
 
-`--concurrency` is the maximum listing width (`Tmax`), not a fixed request count and not
-a throughput target. The live AIMD target starts at 4, grows while the endpoint is healthy,
-and reduces on explicit store backpressure (503/5xx) or a sustained, progress-starved worker
-timeout storm. Successful-request latency inflation damps further growth but does not reduce
-an already-high target.
+`--concurrency` sets the maximum width of concurrent listing work; it is a ceiling, not a
+target. swath starts with a smaller live limit, raises it while the endpoint is healthy,
+and lowers it when the store pushes back or workers repeatedly time out without progress.
 
-That distinction matters on low-latency or replay endpoints: a very high ceiling can create
-queueing and consume more CPU, heap, connections, and server resources without increasing
-keys per second. Start with the default 64 (or a measured 128 for a known large workload), then
-increase in repeated matched runs. Compare `listing_duration_ms` and the report trajectory's
-`worker_keys_fetched_per_sec`, `worker_pages_per_sec`, `worker_latency_mean_ms`, `in_flight`,
-and `aimd_target_*` fields. Choose the smallest ceiling on the throughput plateau; do not use
-one short prefix or one replay latency as a universal S3 setting. Real S3's higher latency may
-need a larger ceiling than a local replay, and AIMD will still adapt downward when S3 emits an
-actual stress signal.
+Start with the default of 64. Increase it only in repeated, otherwise identical runs, and
+choose the smallest value at which throughput stops improving. A higher ceiling can consume
+more CPU, memory, and connections without making the listing faster. Results from a short
+prefix or local replay server do not establish the right value for real S3.
 
-Output can be the bottleneck independently of listing width. Use `--format discard` only for
-diagnostic listing-engine measurements; validate the chosen ceiling again with the production
-output format and destination.
+The output destination can be a separate bottleneck. `--format discard` can isolate listing
+cost for diagnosis, but validate the final setting again with the output format and storage
+you will use in production. The [performance guide](performance.md#find-the-limiting-stage)
+explains which report fields to compare.
 
 ## Precedence
 
@@ -110,7 +103,7 @@ and similar environments.
 | `JAVA_TOOL_OPTIONS` | unset | JVM flags read by Java itself; works with the jar, launcher, and Docker image |
 | `NO_COLOR` | unset | Disables automatic color when set to any value |
 | `TERM=dumb` | environment | Disables automatic color and terminal redraws |
-| `CLICOLOR_FORCE` | unset | Forces automatic color on outside a terminal |
+| `CLICOLOR_FORCE` | unset | Forces color even when stderr is not connected to a terminal |
 
 An explicit `--color=always` or `--color=never` wins over terminal environment signals.
 
@@ -131,7 +124,7 @@ The following table is machine-checked against the code registry.
 | --- | --- | --- | --- | --- | --- | --- |
 | `engine.readahead` | `on or off` | `off` | experimental | free | fresh list | Speculatively fetch ahead on sustained dense tails; can trade API calls and memory for lower wall time. |
 | `seed.mode` | `shallow, none, or hints` | `shallow` | stable (`hints` reserved) | identity | fresh list | Choose initial keyspace discovery. `hints` is reserved but not implemented. |
-| `parquet.writers` | `integer 2..64 (heap-admitted above 4)` | `3` | stable | free | fresh list | Set the bounded direct (unsorted) Parquet writer pool. Counts 2–4 retain the measured release envelope; 5–64 require the JVM maximum heap to cover the conservative writer-memory plan. Higher counts are an expert experiment: they shrink each lane's share of the fixed queue budget and can multiply time-rotated parts and final-manifest metadata. FILE-kind Parquet still resolves to one writer. Sorted staging/finalization does not construct this pool, so this setting is inert under `--sort`. |
+| `parquet.writers` | `integer 2..64 (heap-admitted above 4)` | `3` | stable | free | fresh list | Set the writer count for unsorted Parquet output. For counts above four, swath checks that the configured heap is large enough. Counts 2–4 are the tested range. Higher counts can use more memory and create more small parts; benchmark before adopting them. Unless `--output-type dir` overrides the default inference, a path ending in `.parquet` uses one writer. `--sort` does not use this writer pool, so the setting has no effect under `--sort`. |
 | `summary.interval` | `positive duration` | `--progress-interval`, otherwise `30s` | stable | free | fresh list | Set `_swath_summary.json` heartbeat cadence; accepts values such as `2s`, `500ms`, or `PT2S`. |
 | `sort.ignore-disk-check` | `on or off` | `off` | diagnostic | free | fresh list and resume | Bypass sorted-output free-space checks. Size the staging volume independently first. |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,8 +41,10 @@ If the output is a managed Parquet dataset, resume by its output directory:
 swath resume out/
 ```
 
-Stdout and FILE-kind outputs are one-shot and cannot resume. Exit codes 74, 75, 124,
-130, and 143 only imply resumable state when a managed output directory exists. See
+Stdout, text files, and TSV or JSONL directory datasets are one-shot outputs and cannot
+resume. A Parquet path ending in `.parquet` is also one-shot unless `--output-type dir`
+overrode the default destination-kind inference. Exit codes 74, 75, 124, 130, and 143
+only imply resumable state when a managed output directory exists. See
 [Checkpoint and resume](usage.md#checkpoint-and-resume).
 
 ## The output directory is refused

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,10 @@
 # Getting started
 
 This guide uses Docker to run the same public listing as the README video, query its
-managed Parquet dataset, and resume it after an interruption. This is a real large-bucket
-run: the recording listed 39,585,029 objects.
+managed Parquet dataset, and resume it after an interruption. This is a full-scale
+demonstration, not a lightweight smoke test: the recording listed 39,585,029 objects,
+made 41,582 S3 API calls, wrote 790.8 MB of Parquet, and peaked at about 1.7 GB of resident
+memory (RSS). Review the [request-cost guidance](operating.md#request-cost) before running it.
 
 **Shell note:** the commands use a Bash-compatible shell on Linux or macOS. On Windows
 PowerShell, create the directory with `New-Item -ItemType Directory -Force out`, replace
@@ -25,8 +27,9 @@ This should print the swath version and exit without contacting S3.
 
 ## 2. Run the public demo
 
-Create a host directory and run the exact listing command shown in the demo. Running the
-container as your current user avoids root-owned output on Linux:
+If you want to reproduce the full demo, create a host directory first.
+Then run the exact listing command shown in the demo. Running the container as your
+current user avoids root-owned output on Linux:
 
 ```bash
 mkdir -p out
@@ -38,13 +41,14 @@ docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \
   --format parquet -o /out/noaa-gestofs-pds
 ```
 
+Sections 3 and 4 use the resulting dataset. If you skip the full demo, continue to
+[List your bucket](#5-list-your-bucket).
+
 The command is anonymous and needs no AWS credentials. If the exact command fails, use
 the [troubleshooting guide](faq.md) for the reported access, network, or Docker error
 instead of adding credentials to this public example.
 
-swath reads listing metadata; it never downloads object contents. The recorded run made
-41,582 S3 API calls, wrote 790.8 MB of Parquet, and peaked around 1.7 GB RSS. Read the
-[request-cost guidance](operating.md#request-cost) before reproducing it.
+swath reads listing metadata; it never downloads object contents.
 
 ## 3. Query the Parquet dataset
 
@@ -83,9 +87,8 @@ Sorted output uses temporary disk space; read
 
 ## 4. Resume an interrupted run
 
-The output directory is also the run handle. While a listing is active, swath keeps its
-checkpoint under `<output>/.swath/`. After Ctrl+C, a crash, or a stopped container, resume
-the same directory:
+While a listing is active, swath keeps its checkpoint under `<output>/.swath/`. After
+Ctrl+C, a crash, or a stopped container, pass the same output directory to `resume`:
 
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD/out:/out" \

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -17,74 +17,28 @@ Logs always go to stderr; listing data can therefore stream safely on stdout. Us
 `-vv`, or `-vvv` for INFO, DEBUG, or TRACE logs. `-q` selects ERROR and `-qq` disables
 logging; quiet wins if both quiet and verbose flags are present.
 
-For most investigations, start with the JSON report. It combines configuration, outcome,
-cost, timing, and the final meter snapshot without requiring a telemetry backend.
+## 1. Start with progress and the JSON report
 
-## 1. Micrometer meters
+Keep the default progress display for an ordinary run. If the run fails or appears slow,
+open `_swath_summary.json` for managed output, or request the same report elsewhere with
+`--report PATH`. Start with `complete`, `error_class`, `cost`, `output`, `duration_ms`,
+`session_duration_ms`, and `listing_duration_ms` before moving into engine details.
 
-Configure OTLP with `--metrics-endpoint` or `SWATH_OTLP_ENDPOINT`; change its default `5s`
-step with `SWATH_OTLP_INTERVAL`. `--no-metrics` disables export. Bucket names are not used
-as default tags, avoiding an unbounded-cardinality series.
+This table provides a first diagnostic pass:
 
-This is the public instrument index. Counters are cumulative; timers include count, total,
-maximum, and configured percentiles; gauges are snapshots. The
-[instrumentation reference](internals/metrics-internals.md) owns exact engagement-reason
-values and implementation details.
-
-| Area | Meters | What they answer |
+| Evidence | Likely bottleneck | Check next |
 | --- | --- | --- |
-| Store requests | `swath.api.calls`, `swath.api.latency`, `swath.fetch.latency.phase` | How many LIST attempts ran, how long they took, and where client-visible latency accumulated. |
-| Useful work | `swath.entries.emitted`, `swath.bytes.estimated`, `swath.progress.units` | How much output was accepted and whether any phase is still advancing. |
-| Scheduling | `swath.workers.active`, `swath.in_flight.avg`, `swath.tail_occupancy.avg_in_flight`, `swath.tail_occupancy.wall_share`, `swath.open_frontier.keys_emitted` | Whether workers stayed supplied and whether an open-ended tail dominated the run. |
-| Split and steal | `swath.steals`, `swath.errors`, `swath.steal_reason`, `swath.probe.fetches`, `swath.probe.structure_fetches`, `swath.probe.empty_upper_bisections`, `swath.split.unsplittable_victims`, `swath.split.guard_aborts` | Which work-discovery paths engaged, failed, or proved unproductive. |
-| Page shape | `swath.page.raw_count`, `swath.page.raw_keys`, `swath.page.short_truncated` | Whether returned pages were full, sparse, or unexpectedly short. |
-| Throttling | `swath.throttle.events`, `swath.aimd.target_reductions`, `swath.aimd.freeze_gate_checks`, `swath.owner_split.demand_gated_t`, `swath.owner_split.demand_gated_t_min` | Whether the store pushed back and how the adaptive target responded. |
-| Waits | `swath.queue.wait`, `swath.rate_limit.wait`, `swath.rate_limit.api_wait` | Whether output admission, the concurrency gate, or a configured request-rate cap held work up. |
-| Process | `swath.process.memory.rss.bytes`, `swath.process.memory.heap.bytes`, `swath.process.cpu.time` | Live process resource use when the platform exposes it. |
-| Idle workers | `swath.idle_backoff.level`, `swath.idle_backoff.resets`, `swath.idle_backoff.slot_denied`, `swath.idle_backoff.park_time` | Whether idle workers repeatedly searched, backed off, or lacked probe slots. |
-| Checkpoint | `swath.checkpoint.commit.latency`, `swath.checkpoint.commit_batch_size`, `swath.checkpoint.queue.wait`, `swath.checkpoint.commit.wait`, `swath.checkpoint.queue.depth` | Whether SQLite durability is the limiting stage. |
-| Parquet | `swath.parquet.rotation`, `swath.parquet.parts`, `swath.parquet.finalize.latency`, `swath.parquet.write.latency` | How the managed Parquet sink rotated and finalized parts. |
-| Sorted output | `swath.sort.entries`, `swath.sort.segments.written`, `swath.sort.segment.bytes`, `swath.sort.merge.passes`, `swath.sort.merge.latency`, `swath.sort.merge.range.latency`, `swath.sort.merge.boundaries.latency`, `swath.sort.merge.boundaries.embedded.entries`, `swath.sort.merge.boundaries.embedded.bytes`, `swath.sort.merge.boundaries.scan.bytes`, `swath.sort.finalize.close.latency`, `swath.sort.manifest.md5.bytes`, `swath.sort.manifest.md5.latency`, `swath.sort.manifest.bounds.rows`, `swath.sort.manifest.bounds.bytes`, `swath.sort.manifest.bounds.latency`, `swath.sort.publication.latency`, `swath.sort.finalize.latency`, `swath.sort.finalize.parallelism`, `swath.sort.backpressure.wait`, `swath.sort.page_runs_per_buffer`, `swath.sort.staging.bytes.peak`, `swath.sort.handoff.queue.depth.peak`, `swath.sort.off_thread.buffers.peak` | How much staging and merge work sorting required, and what constrained it. |
-| Local resources | `swath.disk.free_bytes`, `swath.s3.pool.leased`, `swath.s3.pool.idle_available`, `swath.s3.pool.pending_acquisition`, `swath.s3.pool.max`, `swath.s3.pool.connection_aborted`, `swath.s3.pool.handshakes`, `swath.s3.socket_closure_recovered` | Whether disk, the connection pool, or connection churn constrained the client. |
-| Phase and output | `swath.phase`, `swath.output.files`, `swath.output.bytes`, `swath.output.broken_pipe`, `swath.emit.latency` | What phase is active and how the selected sink behaves. |
-| Run result | `swath.run.duration`, `swath.run.throughput` | Final wall time and lifetime-average throughput. These are end-of-run, not live, values. |
+| High API latency and many requests in flight | Object store or network | `fetch.latency.phase`, throttling, connection-pool waits, recovered errors |
+| Low API rate and few requests in flight while listing | Not enough useful ranges, or one long tail | splits, probes, tail occupancy, open-frontier share |
+| High `queue.wait` or `emit.latency` | Output formatting or storage | `dataset_writer`, format write/finalize time, output filesystem |
+| High checkpoint queue or commit waits | Checkpoint storage | checkpoint latency and `checkpoint.queue.depth` |
+| High sort backpressure or many merge passes | Sort memory, disk, or open-file limits | the `sort` block, staging peak, effective fan-in |
+| `progress.units` unchanged for more than five minutes | Potential stall | phase, thread dump, last error, disk, and connection-pool state |
 
-The discard profiling sink retains `swath.entries.emitted`, `swath.bytes.estimated`, progress, and
-`swath.emit.latency`, but intentionally creates no `swath.output.files` or
-`swath.output.bytes` series because it materializes no output. Its engagement is visible as
-`swath.steal_reason{outcome="OUTPUT",reason="discard"}` and the run report records zero output
-files/bytes.
-
-`swath.fetch.latency.phase` has bounded `call_class` values (`worker_page`,
-`pivot_probe`, `structure_probe`) and `phase` values (`connect_acquire`, `ttfb`,
-`sdk_unmarshal`, `total`, `response_parse`). Treat the phases as independent signals,
-not additive slices: SDK boundaries can overlap, and `sdk_unmarshal` includes draining the
-response body as well as SDK parsing. SDK-derived phases are best effort; absent samples
-are omitted, not recorded as zero. `total` includes failures, while `response_parse` exists
-only after a response was returned. The report's `probe_latency` block is the easiest way
-to read their percentiles.
-
-`swath.progress.units` is the phase-independent stuck signal. It advances for emitted rows
-and during sorted merge passes. Allow at least five minutes before declaring a stall: a
-final Parquet flush can legitimately leave it unchanged for a short window.
-
-Process and SDK-pool gauges may be unavailable or may hold the last reported value. In
-particular, pool gauges update on completed API attempts and freeze during a merge. Read
-them with the API-call rate. A live `swath.s3.pool.pending_acquisition > 0` indicates pool
-acquisition pressure; low in-flight work by itself does not.
-
-### 1.1 Proactive rate cap vs. reactive AIMD backoff
-
-Two independent mechanisms can delay a request:
-
-- `--request-rate` is a proactive, run-wide cap. Its wait time is
-  `swath.rate_limit.api_wait`; without a configured cap this stays zero.
-- AIMD reacts to service throttling by lowering the live concurrency target. Throttle
-  events and target reductions appear in `swath.throttle.events` and
-  `swath.aimd.target_reductions`. `swath.rate_limit.wait` measures waits at the shared
-  concurrency gate, so it can also be nonzero from ordinary slot contention.
-
-Read all four signals together before attributing a slowdown to the store.
+The sections below explain the report and logs in detail. Use the
+[Micrometer meter reference](#5-metric-export-and-micrometer-reference) when you need
+telemetry export or implementation-level diagnosis. For controlled
+performance comparisons, continue to the [performance guide](performance.md).
 
 <a id="2-list_run_summary-one-line-at-run-end"></a>
 
@@ -164,23 +118,24 @@ metrics identify the compatibility path that reopened a carried part.
 The report can contain the target URI, arguments, filter values, slow-range bounds, and
 key samples. Treat it as operational data and redact it before sharing.
 
-`dataset_writer` is present for direct Parquet and parallel directory TSV/JSONL output; its
-`format` is `parquet`, `tsv`, or `jsonl`. It is absent for stdout, single-file text, discard, and
-sorted output, which do not construct the shared pool. Its aggregate resource fields report the
-configured writer count, total lane-queue capacity, JVM maximum heap, and—for Parquet—the pinned
-row-group target, its conservative allowance multiplier, and the heap-admission plan. It also reports
-the part-rotation configuration, streamed full-part digest work, and terminal complete-manifest
-write count/time. During listing the manifest count remains zero while periodic JSON summaries read
-the live part/byte counters directly; after successful publication it is normally one. The
-Parquet-only fields are null for text. Its aggregate
-`submit_blocked_*` fields measure full sticky-lane admission waits;
-`head_of_line_blocked_*` is the subset where another lane thread was waiting for work on an empty
-queue when that wait began. The bounded `lanes[]` array reports lane id, queue
-current/capacity/sampled peak, waiting state, rows, finalized bytes, batches, active elapsed time,
-blocked/HOL time, and part/finalize activity. Lane identifiers live
-only in this structured block, not in Micrometer tags. Every duration in the block is elapsed time,
-not CPU time; use the retained-JFR procedure in the [performance guide](performance.md#retain-a-jfr-cpu-profile)
-for actual CPU attribution.
+### Writer-pool details (advanced)
+
+`dataset_writer` is present for unsorted Parquet and parallel directory TSV/JSONL output.
+It is absent for stdout, text files, discard, and sorted output, which do not use this
+writer pool.
+
+| Fields | Meaning |
+| --- | --- |
+| `format`, `writer_count`, `total_queue_capacity` | Selected format, writer count, and aggregate queued-batch capacity. |
+| `jvm_max_heap_bytes`, `row_group_target_bytes_per_writer`, `row_group_allowance_multiplier`, `planned_heap_bytes`, `heap_admission_applied` | Parquet memory inputs and the result of its safety check. These fields are null for text. |
+| `part_rotation_interval_ms`, `part_rotation_max_rows`, `part_digest_*`, `manifest_write_*` | Part creation, checksum work, and the final manifest write. The manifest count is normally zero during listing and one after successful publication. |
+| `submit_blocked_*` | Time spent waiting because the selected writer's queue was full. |
+| `head_of_line_blocked_*` | The subset of waits that began while another writer had an empty queue and was waiting for work. |
+| `lanes[]` | Per-writer queue use, rows, bytes, batches, active time, waits, parts, and finalization activity. |
+
+Lane identifiers appear only in this structured block, not in Micrometer tags. Durations
+are elapsed time, not CPU time. For CPU attribution, use the
+[advanced JFR procedure](performance.md#retain-a-jfr-cpu-profile).
 
 ## 4. Progress and logs
 
@@ -198,20 +153,72 @@ Useful markers include startup configuration, first request, first page, phase c
 and the final result. DEBUG and TRACE logs add engine evidence; they are intended for
 short investigations rather than routine high-volume runs.
 
-## 5. Diagnosing a slow run
+## 5. Metric export and Micrometer reference
 
-| Evidence | Likely limiting stage | Check next |
+Configure OTLP with `--metrics-endpoint` or `SWATH_OTLP_ENDPOINT`; change its default `5s`
+step with `SWATH_OTLP_INTERVAL`. `--no-metrics` disables export. Bucket names are not used
+as default tags, avoiding an unbounded-cardinality series.
+
+This is the public instrument index. Counters are cumulative; timers include count, total,
+maximum, and configured percentiles; gauges are snapshots. The
+[instrumentation reference](internals/metrics-internals.md) owns exact engagement-reason
+values and implementation details.
+
+| Area | Meters | What they answer |
 | --- | --- | --- |
-| High API latency, high in-flight work | Store or network service time | `fetch.latency.phase`, throttles, pool pending, recovered errors |
-| Low API rate and low in-flight work while listing | Work supply or a long tail | steal reasons, probes, tail occupancy, open-frontier share |
-| High `queue.wait` or `emit.latency` | Output admission or sink | `dataset_writer` blocked/HOL time, lane balance, format write/finalize latency, output filesystem |
-| High checkpoint queue or commit waits | SQLite durability | checkpoint volume latency and queue depth |
-| High sort backpressure or many merge passes | Sort memory/disk/FD limits | `sort` report block, staging peak, effective fan-in |
-| `progress.units` flat for more than five minutes | Potential stall | phase, thread dump, last error, disk and pool state |
+| Store requests | `swath.api.calls`, `swath.api.latency`, `swath.fetch.latency.phase` | How many LIST attempts ran, how long they took, and where client-visible latency accumulated. |
+| Useful work | `swath.entries.emitted`, `swath.bytes.estimated`, `swath.progress.units` | How much output was accepted and whether any phase is still advancing. |
+| Scheduling | `swath.workers.active`, `swath.in_flight.avg`, `swath.tail_occupancy.avg_in_flight`, `swath.tail_occupancy.wall_share`, `swath.open_frontier.keys_emitted` | Whether workers stayed supplied and whether an open-ended tail dominated the run. |
+| Split and steal | `swath.steals`, `swath.errors`, `swath.steal_reason`, `swath.probe.fetches`, `swath.probe.structure_fetches`, `swath.probe.empty_upper_bisections`, `swath.split.unsplittable_victims`, `swath.split.guard_aborts` | Which work-discovery paths engaged, failed, or proved unproductive. |
+| Page shape | `swath.page.raw_count`, `swath.page.raw_keys`, `swath.page.short_truncated` | Whether returned pages were full, sparse, or unexpectedly short. |
+| Throttling | `swath.throttle.events`, `swath.aimd.target_reductions`, `swath.aimd.freeze_gate_checks`, `swath.owner_split.demand_gated_t`, `swath.owner_split.demand_gated_t_min` | Whether the store pushed back and how the adaptive target responded. |
+| Waits | `swath.queue.wait`, `swath.rate_limit.wait`, `swath.rate_limit.api_wait` | Whether output admission, the concurrency gate, or a configured request-rate cap held work up. |
+| Process | `swath.process.memory.rss.bytes`, `swath.process.memory.heap.bytes`, `swath.process.cpu.time` | Live process resource use when the platform exposes it. |
+| Idle workers | `swath.idle_backoff.level`, `swath.idle_backoff.resets`, `swath.idle_backoff.slot_denied`, `swath.idle_backoff.park_time` | Whether idle workers repeatedly searched, backed off, or lacked probe slots. |
+| Checkpoint | `swath.checkpoint.commit.latency`, `swath.checkpoint.commit_batch_size`, `swath.checkpoint.queue.wait`, `swath.checkpoint.commit.wait`, `swath.checkpoint.queue.depth` | Whether SQLite durability is the limiting stage. |
+| Parquet | `swath.parquet.rotation`, `swath.parquet.parts`, `swath.parquet.finalize.latency`, `swath.parquet.write.latency` | How the managed Parquet sink rotated and finalized parts. |
+| Sorted output | `swath.sort.entries`, `swath.sort.segments.written`, `swath.sort.segment.bytes`, `swath.sort.merge.passes`, `swath.sort.merge.latency`, `swath.sort.merge.range.latency`, `swath.sort.merge.boundaries.latency`, `swath.sort.merge.boundaries.embedded.entries`, `swath.sort.merge.boundaries.embedded.bytes`, `swath.sort.merge.boundaries.scan.bytes`, `swath.sort.finalize.close.latency`, `swath.sort.manifest.md5.bytes`, `swath.sort.manifest.md5.latency`, `swath.sort.manifest.bounds.rows`, `swath.sort.manifest.bounds.bytes`, `swath.sort.manifest.bounds.latency`, `swath.sort.publication.latency`, `swath.sort.finalize.latency`, `swath.sort.finalize.parallelism`, `swath.sort.backpressure.wait`, `swath.sort.page_runs_per_buffer`, `swath.sort.staging.bytes.peak`, `swath.sort.handoff.queue.depth.peak`, `swath.sort.off_thread.buffers.peak` | How much staging and merge work sorting required, and what constrained it. |
+| Local resources | `swath.disk.free_bytes`, `swath.s3.pool.leased`, `swath.s3.pool.idle_available`, `swath.s3.pool.pending_acquisition`, `swath.s3.pool.max`, `swath.s3.pool.connection_aborted`, `swath.s3.pool.handshakes`, `swath.s3.socket_closure_recovered` | Whether disk, the connection pool, or connection churn constrained the client. |
+| Phase and output | `swath.phase`, `swath.output.files`, `swath.output.bytes`, `swath.output.broken_pipe`, `swath.emit.latency` | What phase is active and how the selected sink behaves. |
+| Run result | `swath.run.duration`, `swath.run.throughput` | Final wall time and lifetime-average throughput. These are end-of-run, not live, values. |
 
-For repeatable performance experiments, use the
-[performance guide](performance.md). For implementation-level interpretation, use the
-[metrics internals](internals/metrics-internals.md).
+The discard profiling sink retains `swath.entries.emitted`, `swath.bytes.estimated`, progress,
+and `swath.emit.latency`, but creates no `swath.output.files` or `swath.output.bytes` series
+because it writes no output. Its engagement is visible as
+`swath.steal_reason{outcome="OUTPUT",reason="discard"}`, and the report records zero output
+files and bytes.
+
+`swath.fetch.latency.phase` has bounded `call_class` values (`worker_page`,
+`pivot_probe`, `structure_probe`) and `phase` values (`connect_acquire`, `ttfb`,
+`sdk_unmarshal`, `total`, `response_parse`). Treat the phases as independent signals,
+not additive slices: SDK boundaries can overlap, and `sdk_unmarshal` includes draining the
+response body as well as SDK parsing. SDK-derived phases are best effort; absent samples
+are omitted, not recorded as zero. `total` includes failures, while `response_parse` exists
+only after a response was returned. The report's `probe_latency` block is the easiest way
+to read their percentiles.
+
+`swath.progress.units` is the phase-independent stuck signal. It advances for emitted rows
+and during sorted merge passes. Allow at least five minutes before declaring a stall: a
+final Parquet flush can legitimately leave it unchanged for a short window.
+
+Process and SDK-pool gauges may be unavailable or may hold the last reported value. In
+particular, pool gauges update on completed API attempts and freeze during a merge. Read
+them with the API-call rate. A live `swath.s3.pool.pending_acquisition > 0` indicates pool
+acquisition pressure; low in-flight work by itself does not.
+
+### 5.1 Proactive rate cap vs. reactive adaptive backoff
+
+Two independent mechanisms can delay a request:
+
+- `--request-rate` is a proactive, run-wide cap. Its wait time is
+  `swath.rate_limit.api_wait`; without a configured cap this stays zero.
+- The additive-increase/multiplicative-decrease (AIMD) controller reacts to service
+  throttling by lowering the live concurrency target. Throttle events and target reductions
+  appear in `swath.throttle.events` and `swath.aimd.target_reductions`.
+  `swath.rate_limit.wait` measures waits at the shared concurrency gate, so it can also be
+  nonzero from ordinary slot contention.
+
+Read all four signals together before attributing a slowdown to the store.
 
 ## 6. Exit codes
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -21,70 +21,6 @@ Bucket shape, client location, output disk, filters, CPU architecture, and servi
 all affect the result. Absolute numbers from another bucket are rarely useful; the
 relationships among your own report fields are.
 
-To measure the listing engine without row serialization or listing-sink I/O, run the same fixture
-and configuration through the diagnostic discard sink:
-
-```bash
-swath list s3://bucket/prefix/ --format discard --checkpoint none --report discard.json
-```
-
-This is not a parser-free HTTP benchmark. It retains response parsing and model construction,
-filters, checkpoint/engine coordination, the bounded listing channel, row tally, internal metrics,
-and the small diagnostic write requested by `--report`. Compare it with an otherwise identical
-TSV/Parquet arm to quantify the removable listing-output cost. If discard drives the replay service
-to its own CPU or latency ceiling, the result is a server limit rather than Swath's client ceiling;
-retain the server metrics beside the client report.
-
-### Retain a JFR CPU profile
-
-Elapsed timers cannot attribute CPU: a Parquet lane's active stretch can contain encoding,
-filesystem writes, fsync, checkpoint work, and time waiting to serialize a manifest update.
-For CPU attribution on Linux/JDK 25, derive a profile that explicitly enables the CPU-time
-sampler. The stock `profile.jfc` enables execution sampling but leaves `jdk.CPUTimeSample`
-disabled, so `cpu-time-hot-methods` would otherwise have no events:
-
-```bash
-jfr configure --input "$JAVA_HOME/lib/jfr/profile.jfc" --output swath-cpu-profile.jfc \
-  jdk.CPUTimeSample#enabled=true
-JAVA_OPTS="-XX:StartFlightRecording=filename=$PWD/swath.jfr,settings=$PWD/swath-cpu-profile.jfc,disk=true,dumponexit=true,maxsize=2g" \
-  swath list s3://bucket/prefix/ --format parquet -o out/ --report run.json
-```
-
-The Gradle/application launcher honors `JAVA_OPTS`. For the runnable jar or container use the
-same option on `java` directly or through `JAVA_TOOL_OPTIONS`. `dumponexit=true` retains the
-recording on a normal exit, a handled signal, or an uncaught Java failure. `SIGKILL`, host loss,
-and swath's deliberate `Runtime.halt()` safety paths (the terminal liveness-watchdog escalation and
-sort disk guard) cannot run the exit dump. For a suspected hard wedge, use an external `jcmd
-<pid> JFR.dump filename=...` before the halt deadline. Give each arm a different filename and keep
-its JFR beside its JSON report.
-
-JDK 25's `jfr` tool provides useful first passes:
-
-```bash
-jfr summary swath.jfr
-jfr view cpu-time-hot-methods swath.jfr
-jfr view thread-cpu-load swath.jfr
-jfr view gc-cpu-time swath.jfr
-jfr view file-writes-by-path swath.jfr
-jfr view jdk.CPUTimeSamplesLost swath.jfr
-```
-
-`cpu-time-hot-methods` uses `jdk.CPUTimeSample` for CPU-time attribution. On a platform where that
-event is unavailable, retain the stock `profile` configuration and use `jfr view hot-methods` for
-execution samples instead; do not describe those elapsed execution samples as measured CPU time.
-Check `jdk.CPUTimeSamplesLost` before comparing attribution between arms. If losses are material,
-adjust `jdk.CPUTimeSample#throttle` in the generated configuration and rerun both arms identically;
-more frequent sampling can increase profiler overhead.
-
-Attribute execution samples by both thread and stack. Direct Parquet lanes are named
-`parquet-writer-*`; the checkpoint writer is `swath-checkpoint-writer`. Listing workers are
-virtual threads, so group their samples by `io.varve.swath.engine`, `io.varve.swath.store`, and
-AWS SDK frames rather than expecting a stable platform-thread name. Sorted staging/merge work is
-recognizable from `io.varve.swath.sort` frames and `*-encoder-*` platform threads. The
-[JDK 25 troubleshooting guide](https://docs.oracle.com/en/java/javase/25/troubleshoot/troubleshooting-guide.pdf)
-reports less than 2% overhead for most profiling recordings, but overhead is application-specific:
-measure it on the fixture, and use the same JFR settings and recording size limit in every arm.
-
 ### In-flight utilisation
 
 `--concurrency N` is a ceiling. The achieved request concurrency is
@@ -95,8 +31,8 @@ utilisation = engine.avg_in_flight / configured concurrency
 ```
 
 Use the configured ceiling, not `peak_in_flight`. High utilisation means the ceiling may
-be binding. Low utilisation means useful ranges, CPU, or another stage could not keep it
-full; raising the ceiling usually adds overhead.
+be the bottleneck. Low utilisation means useful ranges, CPU, or another stage could not
+keep it full; raising the ceiling usually adds overhead.
 
 For a sorted run, the report's whole-run average includes the post-listing merge, where
 API in-flight is zero. Rescale it to the listing phase with:
@@ -120,54 +56,65 @@ listing throughput ≈ average in-flight * page size / request latency
 Across a concurrency sweep:
 
 - Rising latency with rising in-flight suggests remote, network, client CPU, or queue
-  saturation. Check `fetch.latency.phase`, throttle/AIMD counters, pool pending, and CPU.
-- Flat latency while in-flight and splits plateau suggests work-supply starvation. Check
+  saturation. Check `fetch.latency.phase`, throttling and adaptive-concurrency counters,
+  connection-pool waits, and CPU.
+- Flat request latency together with plateaus in in-flight requests and split count
+  suggests work-supply starvation. Check
   `engine.splits`, steals, probe reasons, tail occupancy, and the shape block.
-- High `queue.wait`, Parquet latency, or checkpoint waits identifies a local downstream
-  stage rather than the object store.
-- Falling utilisation, falling throughput, and rising CPU per key is the signature of an
-  overshot ceiling, regardless of which resource ran out first.
+- High `queue.wait`, Parquet latency, or checkpoint waits identify a local downstream stage
+  rather than the object store.
+- The combination of falling utilisation, falling throughput, and rising CPU per key is a
+  sign of an overshot ceiling, regardless of which resource ran out first.
 
 Treat `shape.divergence_depth_histogram`, `mass_skew_gini`, and `delimiter_fanout` as clues,
 not diagnoses. Direct engagement and wait counters show what actually constrained the run.
 
-For direct Parquet or a parallel TSV/JSONL directory dataset, read the report's
-format-labelled `dataset_writer` block with `client_cost`:
+To isolate output cost, repeat the same run with the diagnostic discard sink:
 
-- `submit_blocked_ms` is the consumer's time waiting for sticky lane admission; it is contained
-  in `client_cost[].emit`, not additional time to add to it.
-- `head_of_line_blocked_ms` is the subset that began while another lane was waiting for work with
-  an empty queue. Material time confirms that sticky routing stranded an idle writer; zero means
-  that stronger condition was not observed at the start of a blocked admission, not that every
-  possible transient imbalance is ruled out.
+```bash
+swath list s3://bucket/prefix/ --format discard --checkpoint none --report discard.json
+```
+
+Discard still performs S3 response parsing, filtering, checkpoint coordination, and row
+counting; it only removes formatting and output I/O. Compare it with an otherwise identical
+TSV or Parquet run. When using a replay server, retain its metrics too so a server bottleneck
+is not mistaken for a client limit.
+
+For unsorted Parquet or a parallel TSV/JSONL directory dataset, each batch is assigned
+to one background writer, called a lane. Read the report's `dataset_writer` block with
+`client_cost`:
+
+- `submit_blocked_ms` is time spent waiting because the selected writer's queue was full.
+  It is already included in `client_cost[].emit`; do not add it again.
+- `head_of_line_blocked_ms` is the blocked time for waits that began while another writer
+  had an empty queue and was waiting for work. A material value shows that assigning each
+  batch to a fixed writer left capacity unused. Zero means that condition was not observed
+  when a wait began.
 - Per-lane rows, finalized bytes, batches, active elapsed time, queue peak, and finalize activity
   show load imbalance. `active_elapsed_ms` is elapsed service time and can overlap across lanes.
-- Rising lane-submit blocking followed by rising `client_cost[].writer_backpressure` confirms the
-  full causal chain into listing workers. A full queue peak without blocked time is not a
+- If `submit_blocked_ms` rises and `client_cost[].writer_backpressure` follows, output is slowing
+  the listing workers. A queue reaching capacity without measurable blocked time is not a
   bottleneck by itself.
 
 Do not infer writer capacity from an I/O-bound run whose lanes are mostly idle. Validate a writer
-count against the fastest expected listing regime: sustained submit blocking means the sink is
-binding; material head-of-line blocking with idle lanes means dispatch coupling is binding. If
-neither appears, raising the writer count would only add memory and file-part overhead for that
-workload.
+count against the fastest expected listing regime. Sustained submit blocking means output is
+the bottleneck. Material head-of-line blocking means writer assignment is leaving capacity
+unused. If neither appears, raising the writer count would only add memory and file-part
+overhead for that workload.
 
-Direct Parquet uses `--tune parquet.writers=N`; counts 2–4 are the measured release envelope and
-5–64 must pass the JVM heap-admission plan described in the contracts. Directory TSV/JSONL uses
-`--text-writers N` over the independent 2–64 text range. Both retain the same 256-batch aggregate
-whole-pool submission ceiling as concurrency rises. Confirm the resolved `writer_count`,
-`total_queue_capacity`, rotation settings, and Parquet memory-plan fields in `dataset_writer` before
-comparing runs.
+Unsorted managed Parquet directory output uses `--tune parquet.writers=N`; 2–4 is the
+tested range. Counts 5–64 require enough JVM heap to pass the safety check described in
+the contracts. Directory TSV/JSONL uses `--text-writers N`, also in the range 2–64. Both
+limit the total queued work to 256 batches. Confirm `writer_count`,
+`total_queue_capacity`, rotation settings, and the Parquet memory-plan fields in
+`dataset_writer` before comparing runs.
 
-Higher counts are not monotonic throughput scaling. Dividing the fixed budget gives each lane fewer
-queue slots, which can expose sticky-dispatch head-of-line blocking sooner. The default time/row
-rotation is also per lane: more active lanes can create more sub-target parts, each of which maintains
-a streamed full-part digest and incurs its own close/checkpoint work. The complete manifest is written
-once after all lanes join. For text, first bracket the default with matched 2/3/4-writer arms; keep
-direct Parquet comparisons inside its measured 2–4 release envelope. Compare `part_digest_ms`,
-finalize/checkpoint time, terminal `manifest_write_ms`, part count, `submit_blocked_ms`, and
-`head_of_line_blocked_ms` before adopting an expert count. If small-file overhead or HOL blocking
-rises faster than throughput, more writers are making the sink worse.
+More writers do not guarantee more throughput. Because the total queue budget is fixed,
+each writer gets fewer queue slots. More writers can also create more small parts, and every
+part adds close, checkpoint, and digest work. For text, compare otherwise identical runs
+with 2, 3, and 4 writers first; keep unsorted Parquet within its tested 2–4 range. Adopt a
+higher count only when throughput improves without disproportionate growth in part count,
+finalization time, `submit_blocked_ms`, or `head_of_line_blocked_ms`.
 
 ### Size CPU and memory empirically
 
@@ -182,13 +129,63 @@ either the CPU budget or the request-latency/concurrency budget. Add headroom be
 coordination cost rises with core and concurrency count.
 
 Active page, queue, writer, and merge buffers are configuration-bounded, but the complete
-process is not strictly constant-memory: direct Parquet retains `O(parts)` metadata and
+process is not strictly constant-memory: unsorted Parquet retains `O(parts)` metadata and
 sorted output retains `O(segments)` metadata. Larger part/segment targets reduce those
 counts. The public PERF-2 gate covers 100,000 keys and requires peak heap below 1 GiB under
 its default Parquet fixture; it does not establish a billion-object memory envelope.
 
 For production sizing, sweep realistic concurrency under an explicit `-Xmx`, watch peak
 heap/RSS and disk, and keep the setting below the point where utilisation collapses.
+
+<a id="retain-a-jfr-cpu-profile"></a>
+
+### Advanced: retain a JFR CPU profile
+
+Elapsed timers show how long work took, but not how much CPU it consumed. For CPU
+attribution on Linux with JDK 25, create a Java Flight Recorder (JFR) configuration that
+enables CPU-time sampling. The stock `profile.jfc` enables execution sampling but leaves
+`jdk.CPUTimeSample` disabled:
+
+```bash
+jfr configure --input "$JAVA_HOME/lib/jfr/profile.jfc" --output swath-cpu-profile.jfc \
+  jdk.CPUTimeSample#enabled=true
+JAVA_OPTS="-XX:StartFlightRecording=filename=$PWD/swath.jfr,settings=$PWD/swath-cpu-profile.jfc,disk=true,dumponexit=true,maxsize=2g" \
+  swath list s3://bucket/prefix/ --format parquet -o out/ --report run.json
+```
+
+The application launcher honors `JAVA_OPTS`. For the runnable jar or container, pass the
+same option through `JAVA_TOOL_OPTIONS` or directly to `java`. `dumponexit=true` retains
+the recording after a normal exit, handled signal, or uncaught Java failure. It cannot run
+after `SIGKILL`, host loss, or a deliberate `Runtime.halt()`. When investigating a process
+that may be forcibly halted, dump the recording first with
+`jcmd <pid> JFR.dump filename=...`. Give each comparison run a different filename and keep
+its JFR recording beside its JSON report.
+
+Useful first commands are:
+
+```bash
+jfr summary swath.jfr
+jfr view cpu-time-hot-methods swath.jfr
+jfr view thread-cpu-load swath.jfr
+jfr view gc-cpu-time swath.jfr
+jfr view file-writes-by-path swath.jfr
+jfr view jdk.CPUTimeSamplesLost swath.jfr
+```
+
+`cpu-time-hot-methods` uses `jdk.CPUTimeSample`. If that event is unavailable, use the
+stock `profile` configuration and `jfr view hot-methods` instead, and describe the result
+as execution samples rather than measured CPU time. Check `jdk.CPUTimeSamplesLost` before
+comparing runs. If losses are material, adjust `jdk.CPUTimeSample#throttle` and rerun each
+configuration with identical profiler settings; more frequent sampling can add overhead.
+
+Attribute samples by both thread and stack. Unsorted Parquet writers are named
+`parquet-writer-*`, and the checkpoint writer is `swath-checkpoint-writer`. Listing workers
+are virtual threads, so group them by `io.varve.swath.engine`, `io.varve.swath.store`, and
+AWS SDK frames. Sorted work appears under `io.varve.swath.sort` frames and `*-encoder-*`
+platform threads. Oracle's
+[JDK 25 troubleshooting guide](https://docs.oracle.com/en/java/javase/25/troubleshoot/troubleshooting-guide.pdf)
+reports less than 2% overhead for most profiling recordings, but measure the overhead on
+your workload and use the same settings for every comparison.
 
 ## Current field observations
 
@@ -234,25 +231,27 @@ cores, observed roughly 118,000–136,000 keys/s per busy core for objects-mode 
 CPU cost rose about 7–8% from one/two cores to eight. Derive an equivalent value on your
 hardware rather than importing this ARM-specific constant.
 
-The 32-concurrency arm stayed below 1 GiB heap at 96 million objects, while smaller runs at
-higher concurrency used more. That supports the buffer-sizing design, but it is one host,
-one bucket, one run per point, and unsorted output only.
+The 32-concurrency run stayed below 1 GiB heap. Every run used the same 96-million-object
+input, but the higher-concurrency runs used more heap. That supports the buffer-sizing
+design, but it is one host, one bucket, one run per point, and unsorted output only.
 
 ### Local replay tuning takeaways
 
 Controlled replay runs reinforce the sizing procedure above: keep the default concurrency ceiling
 for an unknown endpoint, and raise it only when repeated matched runs show that more in-flight work
 still buys throughput. Higher ceilings can add queueing, latency, CPU, memory, and connections after
-keys/s has plateaued; AIMD reacts to explicit store stress but does not search an already-high target
-back down to the throughput knee. Higher-latency endpoints may still need a larger ceiling, so no
-single replay result is a universal S3 setting.
+keys/s has plateaued. The adaptive-concurrency controller reacts to explicit store stress, but it
+does not automatically lower a healthy but unnecessarily high limit to find the most efficient
+setting. Higher-latency endpoints may still need a larger ceiling, so no single replay
+result is a universal S3 setting.
 
-For TSV/JSONL directory output, bracket the default with 2/3/4 writers before trying expert counts.
-If output is limiting, compare otherwise identical discard, tmpfs, and destination-volume arms to
-separate listing, encoding, and filesystem/finalization cost. Part size is also storage-specific:
-compare 64/128/256 MiB while watching finalize/force time, part count, submit blocking, and
-head-of-line blocking rather than assuming that larger parts are faster. Keep the 256 MiB default
-unless the destination's own measurements justify an override.
+For TSV/JSONL directory output, compare the default with otherwise identical runs using
+2 and 4 writers before trying expert counts. If output is the suspected bottleneck,
+compare discard, a memory-backed filesystem, and the production destination to separate
+listing, encoding, and storage costs. Part size is also storage-specific: compare 64,
+128, and 256 MiB while watching file-finalization time, part count, submit blocking, and
+head-of-line blocking. Keep the 256 MiB default unless measurements on the destination
+justify an override.
 
 ## The sorted merge
 
@@ -283,7 +282,7 @@ The tested SHA was `2bd24c2f33df35341a497a91e24e7633a224b941`. The focused
 serial A, zero descending physical-key transitions, eight effective ranges, and no clamp,
 cascade, or failure reason. Peak heap was 3.598 GiB of `-Xmx12g`.
 
-GEFS and MRMS corroborate scale only. MRMS mutated across arms and its physical order was
+GEFS and MRMS corroborate scale only. MRMS mutated between runs and its physical order was
 not independently checked. Merge-object rate is not listing throughput; do not combine the
 campaign's phase rates with the unsorted sweep.
 
@@ -303,19 +302,20 @@ pages, or resume overhead.
   concurrency ceiling under-filled.
 - Aggressive concurrency can increase scheduling, allocation, and connection churn while
   producing no more work.
-- Direct Parquet with very small part targets grows retained part metadata and makes the one
+- Unsorted Parquet with very small part targets grows retained part metadata and makes the one
   terminal `O(parts)` manifest larger; per-part finalization/checkpoint/digest overhead can still
   dominate even though the manifest is no longer rewritten per part.
 - Sorted output depends on staging disk, heap, and descriptor headroom. Small or constrained
   runs fall back to serial merge.
-- Remote throttling reduces the AIMD target and may dominate a run even when the engine can
-  supply work.
+- Remote throttling reduces the adaptive concurrency target and may dominate a run even
+  when the engine can supply work.
 
 ## Methodology and missing evidence
 
 Current observations are mostly n=1, from one ARM host and one cross-cloud vantage. Live
-buckets can mutate between arms. Runs were serial and read from their JSON reports; the
-merge comparison bracketed the default arm with two serial arms on the same idle filesystem.
+buckets can mutate between comparison runs. Runs were serial and read from their JSON reports;
+the merge comparison bracketed the default configuration with two serial runs on the same
+idle filesystem.
 
 Raise this evidence to release-candidate quality with repeated runs and reported variance,
 an in-region client, an x86 comparison, a fixed-shape object-count sweep, and a documented

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -194,9 +194,9 @@ The setup, shape mix, resource sweep, and limitations are retained in the
 
 ## Reading a running server's meters (`--metrics-port`)
 
-`serve` keeps every meter in the table under "Metrics And Tuning" below, but a
-long-running server has no `bench` report to print them into. `--metrics-port`
-exposes them over HTTP for as long as the server runs:
+`serve` keeps every meter in the "Metrics and tuning" table below, but a long-running
+server does not produce a `bench` report. `--metrics-port` exposes the meters over HTTP
+for as long as the server runs:
 
 ```bash
 swath-replay serve ... --metrics-port 19192
@@ -204,13 +204,12 @@ swath-replay serve ... --metrics-port 19192
 curl -s http://127.0.0.1:19192/metrics | jq .
 ```
 
-Three paths and nothing else: `GET /metrics` returns the whole registry as JSON,
-`GET /runtime-attestation` returns the resource limits visible inside this
-server process, and `GET /healthz` returns `ok` once the server is listening —
-which is also the readiness signal to poll before starting a client, since a
-large fixture's index derive is not instant. A negative port (the default)
-disables the endpoint; `0` binds a free port and reports it in the startup line,
-which carries `metrics_endpoint=` whenever the endpoint is on.
+The endpoint exposes only three paths. `GET /metrics` returns the whole registry as JSON;
+`GET /runtime-attestation` returns the resource limits visible to the server process; and
+`GET /healthz` returns `ok` once the server is listening. Poll the health endpoint before
+starting a client because building the index for a large fixture can take time. A negative
+port (the default) disables the endpoint; `0` binds a free port and reports it in the
+startup line, which carries `metrics_endpoint=` whenever the endpoint is on.
 
 The attestation uses `schema_version: runtime-attestation-v1`. Its `cgroup_v2`
 object names the resolved directory and records `cpuset.cpus.effective`,
@@ -236,14 +235,11 @@ Read server headroom from `swath.replay.request.latency{shape}` per request shap
 against the injected profile for that same shape. A pooled average would hide the
 important case because clients issue different mixtures of differently priced requests.
 
-**It is a second port on purpose.** A metrics or runtime-attestation scrape never
-enters the serving path: it takes no read permit, receives no injected latency,
-and increments no listing request counter, so polling cannot perturb what it
-measures — and it still answers while every serving thread is parked in an
-injected sleep, which is exactly when an answer is most wanted. Its thread pool
-is deliberately tiny (4), because taxing
-the box to answer a diagnostic would tax the measurement the diagnostic exists
-to validate.
+**It is a second port on purpose.** A metrics or runtime-attestation request does not
+enter the serving path, take a read permit, receive injected latency, or increment a
+listing counter. It therefore remains available while serving threads are delayed and
+does not directly alter the request measurements. Its thread pool is limited to four
+threads so diagnostics do not consume significant capacity from the workload being measured.
 
 **Poll it; do not wait for shutdown.** There is no dump-on-exit, by design: a
 server run as a sidecar is typically *killed* when the process it serves exits,
@@ -289,8 +285,8 @@ Injected latency is the request's total target time. After serving the page, the
 waits only for the remainder, so the client observes `max(server_cost, profile)`, not
 `server_cost + profile`. Requests that exceed their profile increment
 `swath.replay.inject.overrun{shape}` and record the excess in
-`swath.replay.inject.overrun.ms{shape}`; a run with material overruns measured the replay
-server rather than the intended profile.
+`swath.replay.inject.overrun.ms{shape}`. If overruns are substantial, the benchmark is
+measuring replay-server overhead rather than the configured latency profile.
 
 ### Compressed time (`--latency-scale`)
 
@@ -379,7 +375,7 @@ Names above omit the common `swath.replay.` prefix for compactness. Fallback rea
 `mixed_row_types`, and `sanity_failed`.
 
 Tune on your fixture and machine. More conformance parallelism or DuckDB connections can
-reduce wall time until scans contend; after that it increases per-query latency. Warm the
+reduce wall time until scans contend; after that they increase per-query latency. Warm the
 JVM, connection pool, and filesystem cache before recording a benchmark.
 
 ## Fidelity limits
@@ -393,6 +389,6 @@ JVM, connection pool, and filesystem cache before recording a benchmark.
 - Differential tests and the conformance harness establish behavior; the repository does
   not yet publish a versioned, portable corridor benchmark bundle.
 
-Retain fixture provenance, source revision, machine, configuration, and report with any
-published result. Keep captures, HARs, checkpoints, and mismatch artifacts in `/tmp` or
-another ignored location; never commit real bucket data.
+Whenever you publish benchmark results, retain the fixture provenance, source revision,
+machine details, configuration, and report. Keep captures, HARs, checkpoints, and
+mismatch artifacts in `/tmp` or another ignored location; never commit real bucket data.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,41 +40,31 @@ history and delete-marker listing are not implemented yet.
 | Keep globally key-sorted Parquet | `swath list ... --format parquet --sort -o out/` | Yes |
 
 `--format auto` is the default. It chooses an aligned table when stdout is a terminal
-and TSV when stdout is redirected. Explicit formats are `table`, `tsv`, `jsonl`, `parquet`,
-and the diagnostic `discard` sink. Discard accepts no `-o` destination or compression: it drains
-and tallies the normal engine pipeline without formatting rows or constructing a writer, writer
-pool, compressor, or file. It still includes S3 response parsing, Swath model/filter work,
-checkpoint commits, bounded-channel handoff, and the normal emission metrics.
-`--compression none|gzip|zstd` compresses table, TSV, or JSONL output to a
-file or stdout, and TSV/JSONL parts in a directory dataset. For files it is also
-inferred from `.gz` or `.zst`; stdout needs the explicit option. Parquet uses its own
-compression and rejects this option.
+and TSV when stdout is redirected. Serialization formats are `table`, `tsv`, `jsonl`,
+and `parquet`; `discard` is the diagnostic format. `--compression none|gzip|zstd`
+compresses table, TSV, or JSONL output to a file or stdout, and TSV/JSONL parts in a
+directory dataset. For files, compression is also inferred from `.gz` or `.zst`; stdout
+needs the explicit option. Parquet uses its own compression and rejects this option.
 
-TSV and JSONL directory datasets use 2–64 bounded writer lanes (`--text-writers`,
-default `3`) and rotate independent parts at `--text-part-size` (default `256mb`).
-Each compressed part is a complete gzip or Zstandard frame. The dataset publishes a
-manifest and writes `_SUCCESS` last, but is non-resumable in this release and therefore
-requires `--checkpoint none`. A failed or timed-out text-dataset run has no `_SUCCESS`, although a
-manifest may already exist; its already-finalized part files are diagnostic leftovers, not a
-resumable dataset.
-Counts above four are an expert tuning surface: per-lane queue shares
-shrink and per-lane rotation can multiply small parts and final-manifest metadata, so benchmark the
-`dataset_writer` blocked-time, part, digest, and manifest fields before adopting them.
+Use a managed Parquet directory when you need checkpoint and resume. Text files are
+published atomically but are one-shot outputs. TSV and JSONL can also write a parallel
+directory dataset, but that dataset is not resumable in this release and requires
+`--checkpoint none`.
 
-Use a managed Parquet directory when checkpoint/resume matters. Text file destinations
-are published atomically but are not resumable; compressed files are published only
-after their gzip or Zstandard frame finishes. TSV/JSONL directories are bounded,
-parallel, one-shot datasets.
+For every directory dataset, `_SUCCESS` is the completion marker. Do not consume its
+parts until that file exists. An interrupted text run may leave diagnostic files that
+are not a usable dataset and cannot be resumed. An interrupted managed Parquet run
+retains finalized parts and can be resumed from its checkpoint.
 
-An interrupted or timed-out managed Parquet run has no complete consumer snapshot until `_SUCCESS`
-exists, although a manifest may already exist. Its finalized parts and live/terminal summary metrics
-may also exist, but SQLite remains the resume authority; do not treat those parts as a published
-dataset.
+The diagnostic `discard` format runs and measures the listing pipeline without writing
+listing rows. It rejects a real `-o PATH` destination and gzip or Zstandard compression,
+is not resumable, and should be used with `--report PATH` when you want to keep its results.
+Omitting `-o` or passing `-o -` both select stdout and are valid.
 
-Do not use `-o inventory.parquet` when you expect one physical Parquet file. In the
-current release that FILE-kind path creates a one-writer, non-resumable dataset directory
-and requires `--checkpoint none`. Write a normal managed dataset and combine it
-downstream when a consumer requires one file.
+Do not use `-o inventory.parquet` when you expect one physical Parquet file. Unless you
+override the default inference with `--output-type dir`, that path creates a one-part,
+non-resumable dataset directory and requires `--checkpoint none`. Write a normal managed
+dataset and combine it downstream when a consumer requires one file.
 
 ### Directory dataset layout
 
@@ -159,7 +149,7 @@ swath list s3://my-bucket/ --format parquet --sort -o sorted/
 
 Sorted output has three important constraints:
 
-1. It requires a directory-shaped Parquet destination and a durable checkpoint.
+1. It requires a managed Parquet directory and a durable checkpoint.
 2. It writes compressed page-run segments under `_staging/`, then merges them into the
    final Parquet parts. During the merge, staging and final output coexist.
 3. Disk usage therefore scales with captured data. Measure a representative prefix and
@@ -172,7 +162,7 @@ the volume has been sized independently.
 
 Large merges use several contiguous key ranges by default and reduce that parallelism
 when heap or file-descriptor limits cannot carry it. Small merges remain serial. For
-resource sizing, staging codecs, merge controls, and how to recognize the binding limit,
+resource sizing, staging codecs, merge controls, and how to identify the bottleneck,
 see [Performance](performance.md#the-sorted-merge) and
 [Advanced configuration](configuration.md#sorted-output-jvm-properties).
 
@@ -181,8 +171,9 @@ see [Performance](performance.md#the-sorted-merge) and
 
 ## Checkpoint and resume
 
-The output directory is the run handle. With the default `--checkpoint auto`, a managed
-Parquet dataset stores its live checkpoint at `<output>/.swath/checkpoint.sqlite`:
+The output directory identifies the resumable run. With the default `--checkpoint auto`,
+a managed Parquet dataset stores its live checkpoint at
+`<output>/.swath/checkpoint.sqlite`:
 
 ```bash
 swath list s3://my-bucket/ --format parquet -o out/
@@ -210,10 +201,10 @@ managed output directory, not an arbitrary SQLite path.
 | --- | --- |
 | Managed Parquet dataset | Finalized parts are durable and retained exactly once; an unfinished tail may be re-listed. |
 | stdout | One-shot and non-resumable. Commit-before-emit means an interrupted stream can omit a page already committed internally. |
-| Discard | Profiling-only and non-resumable; a clean completion means every committed page was drained and tallied, but no listing-output artifact exists. A requested JSON report is still written. |
-| FILE-kind text | One-shot and non-resumable; successful publication atomically replaces the destination. |
+| Discard | Diagnostic and non-resumable; it counts rows but creates no listing-output artifact. A requested JSON report is still written. |
+| Text file | One-shot and non-resumable; successful publication atomically replaces the destination. |
 | Directory-dataset TSV/JSONL | Non-resumable; bounded parallel parts are published with `_SUCCESS` last, and a failed run has no success marker. |
-| FILE-kind Parquet | One-writer, non-resumable dataset directory in the current release. |
+| Parquet path ending in `.parquet` | By default, a one-part, non-resumable dataset directory. `--output-type dir` overrides this inference. |
 
 The exact commit, split, and sink contracts are in
 [Contracts and data model](internals/contracts.md#5-resume-args_hash-and-per-sink-guarantees).
@@ -285,6 +276,12 @@ Everyday runs should use the defaults. `--tune`, diagnostic engine ablations, JV
 properties, environment precedence, and bearer-token behavior are documented in
 [Configuration](configuration.md). The engine-toggle surface is for controlled A/B work,
 not ordinary tuning.
+
+TSV and JSONL directory datasets use three background writers by default
+(`--text-writers 3`) and rotate parts at 256 MiB (`--text-part-size 256mb`). Higher writer
+counts can use more memory and produce more small files; change either setting only after
+a matched performance comparison. See
+[Performance](performance.md#find-the-limiting-stage) for the measurements to compare.
 
 <a id="tuning---tune"></a>
 <a id="diagnostic-tier-ablation---engine-toggle"></a>


### PR DESCRIPTION
## Summary

- clarify the README and getting-started flow, including the full-demo cost and resource expectations
- simplify output, resume, configuration, and troubleshooting guidance for newcomers
- reorganize metrics, performance, and replay documentation so basic workflows come before advanced diagnostics
- preserve command-resolution edge cases and machine-checked documentation contracts

## Validation

- `./gradlew build`
- documentation contract tests rerun with `--rerun-tasks`
- Markdown link and diff checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified demo instructions, resource metrics, request-cost guidance, and resume workflows.
  * Updated configuration guidance for adaptive concurrency, output formats, discard behavior, color settings, and Parquet writers.
  * Expanded troubleshooting guidance for interruptions, performance, metrics, diagnostics, memory usage, and writer backpressure.
  * Documented output compression, resumability, completion markers, path inference, sorted output, and text-dataset tuning.
  * Refined replay metrics, latency reporting, diagnostic isolation, tuning recommendations, and benchmark artifact retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->