### PR TITLE
Align the swath homepage with the 0.2.5 release docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,13 @@
   }
   .fit.inventory .k { color: var(--signal); }
   .fit p { margin: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+  .fit-note {
+    max-width: 42rem;
+    margin: 0.75rem 0 0;
+    color: var(--muted);
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
 
   figure { margin: 0; }
   .hero-media {
@@ -412,8 +419,10 @@
         <p class="tagline">List very large S3 buckets in parallel, even when you don't know how their keys are distributed.</p>
         <p class="lede">
           swath divides S3's ordered keyspace across workers and rebalances it as the
-          listing runs. Stream object metadata as a table, TSV, or JSONL, or write
-          checkpointed Parquet for direct querying. Object contents are never read.
+          listing runs. Stream object metadata as a table, TSV, or JSONL, or write a
+          crash-resumable Parquet dataset for direct querying. Object contents are never
+          read. A live listing is not a point-in-time snapshot of a bucket that changes
+          during the run.
         </p>
 
         <div class="cta">
@@ -424,17 +433,18 @@
         <div class="fit-grid" aria-label="When to use swath">
           <div class="fit">
             <span class="k">Use swath when</span>
-            <p>You need a current listing, Inventory is absent or stale, and a serial listing is too slow.</p>
+            <p>You need an on-demand listing of a very large bucket, no sufficiently current inventory is available, and serial pagination is too slow.</p>
           </div>
           <div class="fit inventory">
-            <span class="k">Use Inventory when</span>
-            <p>A fresh S3 Inventory already exists. Querying it is cheaper than running a live bucket scan.</p>
+            <span class="k">Use existing metadata when</span>
+            <p>A current S3 Inventory or S3 Metadata table already has the fields you need. Querying it is normally cheaper than a live scan.</p>
           </div>
         </div>
+        <p class="fit-note">For a small prefix or a one-off task, the AWS CLI or an SDK paginator is usually simpler.</p>
       </div>
 
       <figure class="hero-media">
-        <div class="media-top"><span>Recorded run · 36 seconds</span><span>39.7M objects / 128 workers</span></div>
+        <div class="media-top"><span>36-second replay</span><span>39.7M objects · 1m 09s run</span></div>
         <video controls muted playsinline preload="metadata" poster="assets/poster.png"
           src="assets/swath-noaa-gestofs.mp4" aria-label="Animated replay of a swath listing run">
           <a href="assets/swath-noaa-gestofs.mp4">Watch the recorded run</a>
@@ -501,7 +511,7 @@
       </div>
 
       <figure class="workflow-media">
-        <div class="media-top"><span>CLI demo · 36 seconds</span><span>list / resume / DuckDB</span></div>
+        <div class="media-top"><span>36-second CLI demo</span><span>list / resume / DuckDB</span></div>
         <video controls muted playsinline preload="metadata" poster="assets/swath-cli-demo-poster.png"
           src="assets/swath-cli-demo.mp4" aria-label="Terminal demo of listing, resuming, and querying with swath">
           <a href="assets/swath-cli-demo.mp4">Watch the command-line demo</a>
@@ -515,8 +525,9 @@
   <footer>
     <p>
       swath is pre-1.0: <span class="mono">list</span> and <span class="mono">resume</span> ship;
+      general-purpose S3 buckets are supported, and GCS through its XML API is experimental.
       <span class="mono">inspect</span>, <span class="mono">diff</span>, versioned listing, and
-      stores beyond S3 are roadmap. Flags and output schemas may still change.
+      native additional backends are roadmap. Flags and output schemas may still change.
     </p>
     <div class="colophon">
       <svg viewBox="0 0 64 64" aria-hidden="true">


### PR DESCRIPTION
## Summary

This keeps the existing swath.varve.io design and makes a focused release-copy pass on the homepage.

- describes Parquet output as a crash-resumable dataset rather than merely “checkpointed Parquet”
- adds the live-listing consistency caveat: a completed run is not a point-in-time snapshot of a bucket that changes during the scan
- makes the fit guidance precise across swath, an existing S3 Inventory/S3 Metadata table, and a small CLI/SDK listing
- disambiguates the 36-second replay from the measured 1m09s listing wall clock
- labels the command-line recording as a 36-second demo rather than leaving the unit ambiguous
- updates the footer to describe general-purpose S3 as supported and GCS XML interoperability as experimental

## Scope

This intentionally preserves the visual design and changes only `index.html` (19 additions, 8 deletions).

The field guide is a separate 135 KB editorial asset with several linked terminology and contract changes. Issue #143 tracks that pass, including stale `swath-replay-server` references, resume-identity wording, objects/files terminology, US English, cost wording, and repeated meta-claims. Keeping it separate makes both reviews materially safer.

The generated NOAA run report is unchanged; its 1m09s measurement remains the source for the clarified homepage label.

## Branch

This PR targets `gh-pages`, not `main`.

## Validation

- branch is one signed-off commit directly ahead of `gh-pages`
- GitHub compare reports only `index.html` changed
- existing responsive layout and media assets are untouched
