### PR TITLE
Honor S3 continuation-token precedence in replay

### DIFF
--- a/docs/internals/s3-implementation-compatibility.md
+++ b/docs/internals/s3-implementation-compatibility.md
@@ -4,17 +4,6 @@ Deviations between real AWS S3 and S3-compatible implementations (LocalStack, Mi
 similar) that swath has had to design around, because they are not visible from the S3 API
 contract alone — only from running against the real thing.
 
-## `continuation-token` together with `start-after`
-
-Real S3 accepts a `ListObjectsV2` request that supplies both parameters and uses the
-`continuation-token` as the resume boundary, ignoring the conflicting `start-after`. The replay
-server previously rejected this request shape with `400 InvalidArgument`, which stopped clients
-that retain their initial `start-after` while walking subsequent pages. `ListObjectsV2Pager` now
-matches S3: a present continuation token takes precedence, while `start-after` remains the boundary
-when no token is supplied, and the response omits the ignored `StartAfter` value. A malformed
-continuation token is still rejected even if the request also supplies a valid `start-after`;
-precedence does not turn token validation into fallback.
-
 ## `%` in an echoed `start-after`/`prefix`/`marker`
 
 **The deviation.** When a `ListObjectsV2` request is made with `encoding-type=url`, S3 percent-

--- a/docs/internals/s3-implementation-compatibility.md
+++ b/docs/internals/s3-implementation-compatibility.md
@@ -4,6 +4,17 @@ Deviations between real AWS S3 and S3-compatible implementations (LocalStack, Mi
 similar) that swath has had to design around, because they are not visible from the S3 API
 contract alone — only from running against the real thing.
 
+## `continuation-token` together with `start-after`
+
+Real S3 accepts a `ListObjectsV2` request that supplies both parameters and uses the
+`continuation-token` as the resume boundary, ignoring the conflicting `start-after`. The replay
+server previously rejected this request shape with `400 InvalidArgument`, which stopped clients
+that retain their initial `start-after` while walking subsequent pages. `ListObjectsV2Pager` now
+matches S3: a present continuation token takes precedence, while `start-after` remains the boundary
+when no token is supplied, and the response omits the ignored `StartAfter` value. A malformed
+continuation token is still rejected even if the request also supplies a valid `start-after`;
+precedence does not turn token validation into fallback.
+
 ## `%` in an echoed `start-after`/`prefix`/`marker`
 
 **The deviation.** When a `ListObjectsV2` request is made with `encoding-type=url`, S3 percent-

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -316,6 +316,12 @@ Supported parameters are `list-type=2`, `prefix`, `delimiter`, `start-after`,
 `continuation-token`, `max-keys`, `encoding-type=url`, and `fetch-owner`. Replay tokens and
 real S3 continuation tokens are intentionally not interchangeable.
 
+A request may carry both `continuation-token` and `start-after`, which some clients do because
+they keep their opening `start-after` in the request template and add the token as they page.
+Replay resumes at the token and ignores the `start-after`, as real S3 does, and omits the ignored
+value from the response. A malformed token is still rejected, `start-after` present or not:
+precedence chooses which boundary applies, it does not make one a fallback for the other.
+
 ## Run real-S3 conformance
 
 The harness can capture S3 traffic through Dockerized mitmproxy, create a fixture, replay

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
@@ -19,9 +19,10 @@ import org.slf4j.LoggerFactory;
  * Owns every S3 ListObjectsV2 protocol rule once, driving a range-only {@link ListingStore}:
  * max-keys accounting (objects and common prefixes counted together, emit-then-check;
  * {@code max-keys=0} ⇒ empty, non-truncated), truncation, delimiter rollup, common-prefix resume,
- * prefix/start-after interplay, and continuation-token encode/decode. Because both the DuckDB and
- * the sorted-Parquet stores are driven through this one pager, a differential test attributes any
- * disagreement to a store by construction.
+ * prefix/start-after interplay, continuation-token precedence over start-after, and
+ * continuation-token encode/decode. Because both the DuckDB and the sorted-Parquet stores are
+ * driven through this one pager, a differential test attributes any disagreement to a store by
+ * construction.
  *
  * <p>The pager translates S3 semantics into byte ranges: the prefix window is
  * {@code [prefix, prefixUpper(prefix))} ({@link ByteKeys#prefixUpper}), a resume boundary is the
@@ -261,9 +262,6 @@ public final class ListObjectsV2Pager implements ListingFixture {
     }
 
     private Boundary resolveBoundary(S3ListRequest request) {
-        if (request.continuationToken() != null && request.startAfter() != null) {
-            throw new S3Error(400, "InvalidArgument", "continuation-token and start-after are mutually exclusive");
-        }
         if (request.continuationToken() != null) {
             ContinuationToken token = ContinuationToken.decode(request.continuationToken());
             return token == null ? null : new Boundary(token.boundary(), token.inclusive());

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/ListObjectsV2Pager.java
@@ -261,10 +261,17 @@ public final class ListObjectsV2Pager implements ListingFixture {
         return filtered;
     }
 
+    /**
+     * Resolves the resume boundary S3 would use. A continuation token wins over a conflicting
+     * {@code start-after} — real S3 accepts both and resumes at the token — but only a token that
+     * decodes to a real resume point does; a blank one is absent, not an empty boundary that would
+     * silently restart a walk the client asked to resume. A malformed token still throws: precedence
+     * does not turn token validation into a fallback.
+     */
     private Boundary resolveBoundary(S3ListRequest request) {
-        if (request.continuationToken() != null) {
+        if (request.hasContinuationToken()) {
             ContinuationToken token = ContinuationToken.decode(request.continuationToken());
-            return token == null ? null : new Boundary(token.boundary(), token.inclusive());
+            return new Boundary(token.boundary(), token.inclusive());
         }
         if (request.startAfter() != null) {
             return new Boundary(request.startAfter(), false);

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3ListRequest.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3ListRequest.java
@@ -23,4 +23,14 @@ public record S3ListRequest(
         this(bucket, prefix, delimiter, startAfter, continuationToken, maxKeys,
                 Math.min(Math.max(maxKeys, 0), S3_MAX_KEYS), encodingTypeUrl, fetchOwner);
     }
+
+    /**
+     * Whether the request carries a continuation token that actually resumes something. A blank
+     * {@code continuation-token=} query value is not a resume point — {@link ContinuationToken#decode}
+     * reads it as absent — so it must not suppress {@code start-after} either, in the boundary the
+     * pager resolves or in the response the renderer echoes. Both ask here so the two cannot drift.
+     */
+    public boolean hasContinuationToken() {
+        return continuationToken != null && !continuationToken.isBlank();
+    }
 }

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
@@ -36,10 +36,11 @@ public final class S3Xml {
         xml.appendAscii("<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">");
         element(xml, "Name", request.bucket());
         byteElement(xml, "Prefix", request.prefix(), request.encodingTypeUrl());
-        if (request.continuationToken() != null) {
+        // A token and a start-after can both arrive; the pager resumes at the token, so the response
+        // echoes the token and omits the start-after S3 ignored.
+        if (request.hasContinuationToken()) {
             element(xml, "ContinuationToken", request.continuationToken());
-        }
-        if (request.continuationToken() == null && request.startAfter() != null) {
+        } else if (request.startAfter() != null) {
             byteElement(xml, "StartAfter", request.startAfter(), request.encodingTypeUrl());
         }
         if (result.nextContinuationToken() != null) {

--- a/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/protocol/S3Xml.java
@@ -39,7 +39,7 @@ public final class S3Xml {
         if (request.continuationToken() != null) {
             element(xml, "ContinuationToken", request.continuationToken());
         }
-        if (request.startAfter() != null) {
+        if (request.continuationToken() == null && request.startAfter() != null) {
             byteElement(xml, "StartAfter", request.startAfter(), request.encodingTypeUrl());
         }
         if (result.nextContinuationToken() != null) {

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/ContinuationTokenPropertyTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/ContinuationTokenPropertyTest.java
@@ -28,6 +28,9 @@ import net.jqwik.api.statistics.Statistics;
  * mutated body is either rejected with the S3 400 or decodes to an observably DIFFERENT (boundary,
  * inclusive) pair — never a silent wrong-equal decode of a corrupted token; only a base64-aliasing
  * no-op (same decoded payload bytes) is exempt.
+ *
+ * <p>The last property covers the other end of the contract: which strings count as a token at all,
+ * which is what decides whether a request resumes at its token or at its {@code start-after}.
  */
 class ContinuationTokenPropertyTest {
 
@@ -163,5 +166,36 @@ class ContinuationTokenPropertyTest {
         } catch (IllegalArgumentException e) {
             return false;   // one side is not valid base64 at all — not a no-op
         }
+    }
+
+    @Provide
+    Arbitrary<String> tokenStrings() {
+        return Arbitraries.oneOf(
+                Arbitraries.strings().ascii().ofMinLength(0).ofMaxLength(20),
+                Arbitraries.of("", " ", "   ", "\t", "\n", " \t\n "),
+                boundaries().map(boundary -> ContinuationToken.encode(boundary, true)));
+    }
+
+    /**
+     * {@link S3ListRequest#hasContinuationToken} decides whether a continuation token takes precedence
+     * over a conflicting {@code start-after}; {@link ContinuationToken#decode} decides what that token
+     * resumes at. The two must classify every string the same way. Were a string ever "present" here
+     * and absent there, the request would discard its start-after in favor of a token that resolves to
+     * no boundary — restarting from the top a walk the client asked to resume, silently and with no
+     * error to notice.
+     */
+    @Property(tries = 500)
+    void hasContinuationTokenAgreesWithDecodeOnEveryString(@ForAll("tokenStrings") String token) {
+        boolean decodeReadsAToken;
+        try {
+            decodeReadsAToken = ContinuationToken.decode(token) != null;
+        } catch (S3Error rejected) {
+            decodeReadsAToken = true;   // structurally invalid is still a token the client meant to send
+        }
+
+        assertThat(new S3ListRequest("bucket", null, null, null, token, 1000, true, false)
+                .hasContinuationToken())
+                .as("token %s", token.isEmpty() ? "<empty>" : "'" + token + "'")
+                .isEqualTo(decodeReadsAToken);
     }
 }

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/ListObjectsV2PagerTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/ListObjectsV2PagerTest.java
@@ -88,13 +88,28 @@ class ListObjectsV2PagerTest {
     void rejectsBadContinuationToken() {
         ListObjectsV2Pager pager = pager("a/1");
         assertThatThrownBy(() -> pager.list(new S3ListRequest(
+                "bucket", null, null, null, "not-a-token", 1000, true, false)))
+                .isInstanceOf(S3Error.class)
+                .hasMessageContaining("invalid continuation-token");
+    }
+
+    /** Precedence resumes at a token; it does not make a valid start-after a fallback for a broken one. */
+    @Test
+    void rejectsBadContinuationTokenEvenWhenStartAfterCouldHaveServed() {
+        ListObjectsV2Pager pager = pager("a/1");
+        assertThatThrownBy(() -> pager.list(new S3ListRequest(
                 "bucket", null, null, bytes("a/1"), "not-a-token", 1000, true, false)))
                 .isInstanceOf(S3Error.class)
                 .hasMessageContaining("invalid continuation-token");
     }
 
+    /**
+     * Real S3 accepts both parameters and resumes at the token. The start-after here sorts AFTER the
+     * token's boundary, so honoring it — or taking the later of the two — would drop {@code a/3}: a
+     * client that keeps its original start-after while paging would silently lose keys.
+     */
     @Test
-    void continuationTokenTakesPrecedenceOverConflictingStartAfter() {
+    void continuationTokenTakesPrecedenceOverALaterStartAfter() {
         ListObjectsV2Pager pager = pager("a/1", "a/2", "a/3", "a/4");
         S3ListResult first = pager.list(new S3ListRequest(
                 "bucket", null, null, null, null, 2, true, false));
@@ -103,6 +118,57 @@ class ListObjectsV2PagerTest {
                 "bucket", null, null, bytes("a/3"), first.nextContinuationToken(), 1000, true, false));
 
         assertThat(keys(resumed)).containsExactly("a/3", "a/4");
+    }
+
+    /**
+     * The mirror case: a start-after sorting BEFORE the token's boundary. Honoring it — or taking the
+     * earlier of the two — re-emits {@code a/2}, which the first page already returned, so a full walk
+     * would report duplicates. Together with the later-start-after case this pins the resume boundary
+     * to the token itself rather than to any combination of the two.
+     */
+    @Test
+    void continuationTokenTakesPrecedenceOverAnEarlierStartAfter() {
+        ListObjectsV2Pager pager = pager("a/1", "a/2", "a/3", "a/4");
+        S3ListResult first = pager.list(new S3ListRequest(
+                "bucket", null, null, null, null, 2, true, false));
+
+        S3ListResult resumed = pager.list(new S3ListRequest(
+                "bucket", null, null, bytes("a/1"), first.nextContinuationToken(), 1000, true, false));
+
+        assertThat(keys(resumed)).containsExactly("a/3", "a/4");
+    }
+
+    /** Precedence holds on the delimiter path too, where the boundary drives CommonPrefix rollup. */
+    @Test
+    void continuationTokenTakesPrecedenceOverStartAfterOnTheDelimiterPath() {
+        ListObjectsV2Pager pager = pager("d/a1/c1", "d/a1/c2", "d/a2/c1", "d/a3/c1");
+        S3ListResult first = pager.list(new S3ListRequest(
+                "bucket", bytes("d/"), bytes("/"), null, null, 1, true, false));
+        assertThat(render(first.entries())).containsExactly("P:d/a1/");
+
+        S3ListResult resumed = pager.list(new S3ListRequest(
+                "bucket", bytes("d/"), bytes("/"), bytes("d/a3/"), first.nextContinuationToken(), 1000, true, false));
+
+        assertThat(render(resumed.entries())).containsExactly("P:d/a2/", "P:d/a3/");
+    }
+
+    /**
+     * {@code continuation-token=} arrives as an empty string, not as an absent parameter.
+     * {@link ContinuationToken#decode} reads blank as absent, so the pager must too: treating it as a
+     * present-but-empty token would discard the start-after and restart a walk from the top, handing
+     * the client keys it already has instead of an error.
+     */
+    @Test
+    void blankContinuationTokenLeavesStartAfterAsTheBoundary() {
+        ListObjectsV2Pager pager = pager("a/1", "a/2", "a/3", "a/4");
+
+        for (String blank : new String[]{"", "   "}) {
+            S3ListResult result = pager.list(new S3ListRequest(
+                    "bucket", null, null, bytes("a/2"), blank, 1000, true, false));
+
+            assertThat(keys(result)).as("blank token %s", blank.isEmpty() ? "<empty>" : "<whitespace>")
+                    .containsExactly("a/3", "a/4");
+        }
     }
 
     @Test

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/ListObjectsV2PagerTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/ListObjectsV2PagerTest.java
@@ -88,18 +88,21 @@ class ListObjectsV2PagerTest {
     void rejectsBadContinuationToken() {
         ListObjectsV2Pager pager = pager("a/1");
         assertThatThrownBy(() -> pager.list(new S3ListRequest(
-                "bucket", null, null, null, "not-a-token", 1000, true, false)))
+                "bucket", null, null, bytes("a/1"), "not-a-token", 1000, true, false)))
                 .isInstanceOf(S3Error.class)
                 .hasMessageContaining("invalid continuation-token");
     }
 
     @Test
-    void rejectsContinuationTokenAndStartAfterTogether() {
-        ListObjectsV2Pager pager = pager("a/1");
-        assertThatThrownBy(() -> pager.list(new S3ListRequest(
-                "bucket", null, null, bytes("a/1"), "v2:AGEvMg", 1000, true, false)))
-                .isInstanceOf(S3Error.class)
-                .hasMessageContaining("mutually exclusive");
+    void continuationTokenTakesPrecedenceOverConflictingStartAfter() {
+        ListObjectsV2Pager pager = pager("a/1", "a/2", "a/3", "a/4");
+        S3ListResult first = pager.list(new S3ListRequest(
+                "bucket", null, null, null, null, 2, true, false));
+
+        S3ListResult resumed = pager.list(new S3ListRequest(
+                "bucket", null, null, bytes("a/3"), first.nextContinuationToken(), 1000, true, false));
+
+        assertThat(keys(resumed)).containsExactly("a/3", "a/4");
     }
 
     @Test

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
@@ -91,6 +91,7 @@ class S3XmlTest {
                 .contains("<CommonPrefixes><Prefix>/%20%FF%26%3C%3E</Prefix></CommonPrefixes>");
     }
 
+    /** The response reports the boundary the pager actually resumed at, so the ignored one is omitted. */
     @Test
     void continuationTokenSuppressesIgnoredStartAfterInResponse() {
         S3ListRequest request = new S3ListRequest(
@@ -100,6 +101,24 @@ class S3XmlTest {
         assertThat(S3Xml.listBucket(result))
                 .contains("<ContinuationToken>opaque-token</ContinuationToken>")
                 .doesNotContain("<StartAfter>");
+    }
+
+    /**
+     * A blank {@code continuation-token=} is not a resume point, so it neither suppresses the
+     * start-after the pager honored nor gets echoed back as an empty element the client never sent.
+     */
+    @Test
+    void blankContinuationTokenNeitherSuppressesNorEchoes() {
+        for (String blank : new String[]{"", "   "}) {
+            S3ListRequest request = new S3ListRequest(
+                    "bucket", null, null, bytes("a/2"), blank, 1000, true, false);
+            S3ListResult result = new S3ListResult(request, List.of(), false, null);
+
+            assertThat(S3Xml.listBucket(result))
+                    .as("blank token %s", blank.isEmpty() ? "<empty>" : "<whitespace>")
+                    .contains("<StartAfter>a/2</StartAfter>")
+                    .doesNotContain("<ContinuationToken>");
+        }
     }
 
     @Test

--- a/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/protocol/S3XmlTest.java
@@ -92,6 +92,17 @@ class S3XmlTest {
     }
 
     @Test
+    void continuationTokenSuppressesIgnoredStartAfterInResponse() {
+        S3ListRequest request = new S3ListRequest(
+                "bucket", null, null, bytes("conflicting-boundary"), "opaque-token", 1000, true, false);
+        S3ListResult result = new S3ListResult(request, List.of(), false, null);
+
+        assertThat(S3Xml.listBucket(result))
+                .contains("<ContinuationToken>opaque-token</ContinuationToken>")
+                .doesNotContain("<StartAfter>");
+    }
+
+    @Test
     void boundedBufferGrowthPreservesEveryResponseByte() {
         List<S3ResultEntry> entries = new ArrayList<>();
         String longKey = "x".repeat(1_024);

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
@@ -40,6 +40,10 @@ import org.junit.jupiter.api.io.TempDir;
  * runs the {@code encoding-type=url} on/off × {@code fetch-owner} on/off matrix, and the whole thing
  * runs once more over a <b>rolled multi-file</b> sorted fixture (tiny {@code final-file-bytes}) to
  * prove the file-aware index serves identically.
+ *
+ * <p>Two request shapes cannot come from the page walk, which drops {@code start-after} once it holds
+ * a token, so they are driven directly: a token sent alongside a conflicting {@code start-after}, and
+ * a blank {@code continuation-token=} that only the query string can express.
  */
 class SortedServingFullDifferentialTest {
 
@@ -118,26 +122,52 @@ class SortedServingFullDifferentialTest {
         differential(dir, keys, manySmallGroups(), scenarios);
     }
 
+    /**
+     * A client that keeps its original {@code start-after} while paging sends both parameters from
+     * page two on; real S3 resumes at the token and ignores the start-after. Both conflict directions
+     * run here: {@code a/1} sorts before the token's boundary (honoring it would re-emit keys page one
+     * already returned) and {@code a/3} sorts after it (honoring it would drop {@code a/3}). The
+     * walk-based tests cannot cover this — they drop start-after once they hold a token — so it is
+     * proven over the whole query-parser-to-XML path instead of the pager alone.
+     */
     @Test
     void continuationTokenWinsOverConflictingStartAfterOnHttp(@TempDir Path dir) throws Exception {
         Fixture fixture = writeSorted(dir, List.of(
                 utf8("a/1"), utf8("a/2"), utf8("a/3"), utf8("a/4")), manySmallGroups());
-        try (ReplayServer sorted = new ReplayServer(
-                "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.SORTED);
-             ReplayServer duck = new ReplayServer(
-                     "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.DUCKDB)) {
-            sorted.start();
-            duck.start();
-            HttpClient client = HttpClient.newHttpClient();
+        withServers(fixture, (sorted, duck, client) -> {
+            for (String conflicting : new String[]{"a/1", "a/3"}) {
+                String response = agreedResume(sorted, duck, client,
+                        "&start-after=" + HttpProbe.percentEncode(utf8(conflicting)));
 
-            String sortedResponse = resumeWithConflictingStartAfter(sorted, client);
-            String duckResponse = resumeWithConflictingStartAfter(duck, client);
+                assertThat(response).as("start-after=%s must not move the token's boundary", conflicting)
+                        .contains("<Key>a/3</Key>", "<Key>a/4</Key>")
+                        .doesNotContain("<Key>a/1</Key>", "<Key>a/2</Key>", "<StartAfter>");
+            }
+        });
+    }
 
-            assertThat(sortedResponse).isEqualTo(duckResponse);
-            assertThat(sortedResponse)
-                    .contains("<Key>a/3</Key>", "<Key>a/4</Key>")
-                    .doesNotContain("<Key>a/1</Key>", "<Key>a/2</Key>", "<StartAfter>");
-        }
+    /**
+     * {@code continuation-token=} reaches the pager as an empty string rather than an absent
+     * parameter, which only the wire can produce. Blank is absent: {@code start-after} stays the
+     * boundary and is still echoed. Treating blank as a present token would restart the listing at
+     * {@code a/1} and hand back keys the client asked to skip.
+     */
+    @Test
+    void blankContinuationTokenLeavesStartAfterAsTheBoundaryOnHttp(@TempDir Path dir) throws Exception {
+        Fixture fixture = writeSorted(dir, List.of(
+                utf8("a/1"), utf8("a/2"), utf8("a/3"), utf8("a/4")), manySmallGroups());
+        withServers(fixture, (sorted, duck, client) -> {
+            String query = "/bucket?list-type=2&max-keys=1000&continuation-token=&start-after="
+                    + HttpProbe.percentEncode(utf8("a/1"));
+
+            String response = HttpProbe.body(sorted, client, query);
+
+            assertThat(response).isEqualTo(HttpProbe.body(duck, client, query));
+            assertThat(response)
+                    .contains("<Key>a/2</Key>", "<Key>a/3</Key>", "<Key>a/4</Key>",
+                            "<StartAfter>a/1</StartAfter>")
+                    .doesNotContain("<Key>a/1</Key>", "<ContinuationToken>");
+        });
     }
 
     @Test
@@ -216,27 +246,14 @@ class SortedServingFullDifferentialTest {
         }
         Fixture fixture = writeSorted(dir, keys, manySmallGroups());
         List<Scenario> scenarios = new ArrayList<>(projectionMatrix(null, utf8("/"), null, new int[]{1, 2, 3, 5}));
-        try (ReplayServer sorted = new ReplayServer(
-                "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.SORTED);
-             ReplayServer duck = new ReplayServer(
-                     "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.DUCKDB)) {
-            sorted.start();
-            duck.start();
-            assertThat(sorted.resolvedServingMode()).isEqualTo(ServingMode.SORTED);
-            assertThat(duck.resolvedServingMode()).isEqualTo(ServingMode.DUCKDB);
-
-            HttpClient client = HttpClient.newHttpClient();
-            for (Scenario scenario : scenarios) {
-                assertThat(walk(sorted, client, scenario))
-                        .as("sorted vs duckdb differ for %s", describe(scenario))
-                        .isEqualTo(walk(duck, client, scenario));
-            }
+        withServers(fixture, (sorted, duck, client) -> {
+            walkAll(sorted, duck, client, scenarios);
             assertThat(sorted.metrics().registry().find("swath.replay.delimiter.path")
                     .tag("path", ReplayMetrics.DELIMITER_PATH_ROLLUP).counter().count())
                     .as("no-prefix delimiter requests must be served by the store's native rollup, "
                             + "not silently fall back to the range walk")
                     .isGreaterThan(0.0);
-        }
+        });
     }
 
     @Test
@@ -290,6 +307,22 @@ class SortedServingFullDifferentialTest {
     }
 
     private void runAll(Fixture fixture, List<Scenario> scenarios) throws Exception {
+        withServers(fixture, (sorted, duck, client) -> walkAll(sorted, duck, client, scenarios));
+    }
+
+    /** The body of a differential: both servers started over one fixture, plus the client driving them. */
+    @FunctionalInterface
+    private interface Differential {
+        void run(ReplayServer sorted, ReplayServer duck, HttpClient client) throws Exception;
+    }
+
+    /**
+     * Serves one fixture through both stores and hands both servers to {@code body}. The resolved-mode
+     * assertions live here rather than in each caller because they are what makes a differential one:
+     * were either server to resolve to the other's store, every comparison below would be a response
+     * against itself and would pass for the wrong reason.
+     */
+    private static void withServers(Fixture fixture, Differential body) throws Exception {
         try (ReplayServer sorted = new ReplayServer(
                 "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.SORTED);
              ReplayServer duck = new ReplayServer(
@@ -298,13 +331,16 @@ class SortedServingFullDifferentialTest {
             duck.start();
             assertThat(sorted.resolvedServingMode()).isEqualTo(ServingMode.SORTED);
             assertThat(duck.resolvedServingMode()).isEqualTo(ServingMode.DUCKDB);
+            body.run(sorted, duck, HttpClient.newHttpClient());
+        }
+    }
 
-            HttpClient client = HttpClient.newHttpClient();
-            for (Scenario scenario : scenarios) {
-                assertThat(walk(sorted, client, scenario))
-                        .as("sorted vs duckdb differ for %s", describe(scenario))
-                        .isEqualTo(walk(duck, client, scenario));
-            }
+    private static void walkAll(ReplayServer sorted, ReplayServer duck, HttpClient client,
+                                List<Scenario> scenarios) throws Exception {
+        for (Scenario scenario : scenarios) {
+            assertThat(walk(sorted, client, scenario))
+                    .as("sorted vs duckdb differ for %s", describe(scenario))
+                    .isEqualTo(walk(duck, client, scenario));
         }
     }
 
@@ -326,8 +362,8 @@ class SortedServingFullDifferentialTest {
             if (scenario.delimiter() != null) {
                 q.append("&delimiter=").append(HttpProbe.percentEncode(scenario.delimiter()));
             }
-            // This walk sends only the token after page one; separate pager coverage proves that a
-            // request carrying both follows S3 and gives the token precedence.
+            // This walk sends only the token after page one, the shape a well-behaved client uses.
+            // continuationTokenWinsOverConflictingStartAfterOnHttp covers the shape that carries both.
             if (token != null) {
                 q.append("&continuation-token=").append(HttpProbe.percentEncode(token));
             } else if (scenario.startAfter() != null) {
@@ -344,15 +380,22 @@ class SortedServingFullDifferentialTest {
         throw new AssertionError("listing did not terminate for " + describe(scenario));
     }
 
-    private static String resumeWithConflictingStartAfter(ReplayServer server, HttpClient client)
-            throws Exception {
+    /** Resumes through both stores and returns the response they must agree on byte for byte. */
+    private static String agreedResume(ReplayServer sorted, ReplayServer duck, HttpClient client,
+                                       String extraQuery) throws Exception {
+        String response = resume(sorted, client, extraQuery);
+        assertThat(response).as("sorted vs duckdb differ for resume%s", extraQuery)
+                .isEqualTo(resume(duck, client, extraQuery));
+        return response;
+    }
+
+    /** Takes a real token from a truncated first page, then resends it with {@code extraQuery} appended. */
+    private static String resume(ReplayServer server, HttpClient client, String extraQuery) throws Exception {
         String first = HttpProbe.body(server, client, "/bucket?list-type=2&max-keys=2");
         String token = HttpProbe.extractTag(first, "NextContinuationToken");
         assertThat(token).as("the first page must carry a continuation token").isNotNull();
-        return HttpProbe.body(server, client,
-                "/bucket?list-type=2&max-keys=1000&continuation-token="
-                        + HttpProbe.percentEncode(token) + "&start-after="
-                        + HttpProbe.percentEncode("a/3"));
+        return HttpProbe.body(server, client, "/bucket?list-type=2&max-keys=1000&continuation-token="
+                + HttpProbe.percentEncode(token) + extraQuery);
     }
 
     private static String describe(Scenario s) {

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
@@ -119,6 +119,28 @@ class SortedServingFullDifferentialTest {
     }
 
     @Test
+    void continuationTokenWinsOverConflictingStartAfterOnHttp(@TempDir Path dir) throws Exception {
+        Fixture fixture = writeSorted(dir, List.of(
+                utf8("a/1"), utf8("a/2"), utf8("a/3"), utf8("a/4")), manySmallGroups());
+        try (ReplayServer sorted = new ReplayServer(
+                "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.SORTED);
+             ReplayServer duck = new ReplayServer(
+                     "127.0.0.1", 0, "bucket", fixture.path(), 2, ServingMode.DUCKDB)) {
+            sorted.start();
+            duck.start();
+            HttpClient client = HttpClient.newHttpClient();
+
+            String sortedResponse = resumeWithConflictingStartAfter(sorted, client);
+            String duckResponse = resumeWithConflictingStartAfter(duck, client);
+
+            assertThat(sortedResponse).isEqualTo(duckResponse);
+            assertThat(sortedResponse)
+                    .contains("<Key>a/3</Key>", "<Key>a/4</Key>")
+                    .doesNotContain("<Key>a/1</Key>", "<Key>a/2</Key>", "<StartAfter>");
+        }
+    }
+
+    @Test
     void giantSinglePrefixSpanningManyRowGroupsIsByteIdentical(@TempDir Path dir) throws Exception {
         List<byte[]> keys = new ArrayList<>();
         for (int i = 0; i < 220; i++) {
@@ -304,8 +326,8 @@ class SortedServingFullDifferentialTest {
             if (scenario.delimiter() != null) {
                 q.append("&delimiter=").append(HttpProbe.percentEncode(scenario.delimiter()));
             }
-            // start-after and continuation-token are mutually exclusive (a real client drops
-            // start-after once it holds a token); prefix/delimiter carry across every page.
+            // This walk sends only the token after page one; separate pager coverage proves that a
+            // request carrying both follows S3 and gives the token precedence.
             if (token != null) {
                 q.append("&continuation-token=").append(HttpProbe.percentEncode(token));
             } else if (scenario.startAfter() != null) {
@@ -320,6 +342,17 @@ class SortedServingFullDifferentialTest {
             assertThat(token).as("a truncated page must carry a continuation token").isNotNull();
         }
         throw new AssertionError("listing did not terminate for " + describe(scenario));
+    }
+
+    private static String resumeWithConflictingStartAfter(ReplayServer server, HttpClient client)
+            throws Exception {
+        String first = HttpProbe.body(server, client, "/bucket?list-type=2&max-keys=2");
+        String token = HttpProbe.extractTag(first, "NextContinuationToken");
+        assertThat(token).as("the first page must carry a continuation token").isNotNull();
+        return HttpProbe.body(server, client,
+                "/bucket?list-type=2&max-keys=1000&continuation-token="
+                        + HttpProbe.percentEncode(token) + "&start-after="
+                        + HttpProbe.percentEncode("a/3"));
     }
 
     private static String describe(Scenario s) {

--- a/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
@@ -386,8 +386,8 @@ class SimStoreDifferentialTest {
         String token = null;
         for (int guard = 0; guard <= 4096; guard++) {
             S3ListResult result = pager.list(new S3ListRequest(BUCKET, scenario.prefix(), scenario.delimiter(),
-                    // continuation-token and start-after are mutually exclusive: from page 2 on,
-                    // the token is the resume boundary.
+                    // This walk sends only the token after page one; when both are supplied, the
+                    // shared pager follows S3 and gives the token precedence.
                     token == null ? scenario.startAfter() : null,
                     token, scenario.maxKeys(), true, scenario.fetchOwner()));
             StringBuilder page = new StringBuilder();

--- a/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
@@ -386,8 +386,9 @@ class SimStoreDifferentialTest {
         String token = null;
         for (int guard = 0; guard <= 4096; guard++) {
             S3ListResult result = pager.list(new S3ListRequest(BUCKET, scenario.prefix(), scenario.delimiter(),
-                    // This walk sends only the token after page one; when both are supplied, the
-                    // shared pager follows S3 and gives the token precedence.
+                    // This walk sends only the token after page one, the shape a well-behaved client
+                    // uses. The replay tests cover the shape that carries both, where the shared
+                    // pager follows S3 and resumes at the token.
                     token == null ? scenario.startAfter() : null,
                     token, scenario.maxKeys(), true, scenario.fetchOwner()));
             StringBuilder page = new StringBuilder();


### PR DESCRIPTION
## What & why

Real S3 accepts a `ListObjectsV2` request carrying both `continuation-token` and `start-after`: it resumes at the token and ignores the start boundary. Replay rejected that shape with `400 InvalidArgument`, which breaks any client that keeps its opening `start-after` in the request template and adds the token as it pages. `s3-fast-list` in hinted mode does exactly that, and stopped on page two.

Replay now resolves the resume boundary the way S3 does:

- a continuation token naming a resume point wins over a conflicting `start-after`, and the response omits the `StartAfter` that was ignored;
- `start-after` stays the boundary when no token is supplied;
- a blank `continuation-token=` is absent, not a token, so it leaves `start-after` as the boundary instead of discarding it and restarting the listing from the top;
- a malformed token is still fatal, `start-after` present or not. Precedence chooses which boundary applies; it does not make one a fallback for the other.

`S3ListRequest.hasContinuationToken` answers "is there a token here" once, for both the pager that resolves the boundary and the renderer that echoes it, so the two cannot classify the same request differently.

`docs/swath-replay.md` records the behavior, next to the supported-parameter list it already owns.

### Evidence

An AWS CLI 2.36.1 probe against real S3 requested one key, then resent the returned token together with a deliberately conflicting `start-after=zzzzzzzzzzzzzzzz`. S3 resumed at the token successor and omitted `StartAfter` from the response.

Before the fix, the pinned replay image returned HTTP 400 during an `s3-fast-list` hinted walk. With the fix, the same 16-range, concurrency-100 walk over the 4,081,170-row `noaa-nws-fourcastnetgfs-pds` fixture completed: exit 0, 4,081,170 rows, 4,088 replay requests, and zero HTTP or query errors. The 40.54-second runtime is compatibility evidence, not a benchmark result.

### Why no test caught it

Three layers each avoided the failing shape:

- the pager unit test asserted the wrong rule outright — that the two parameters were mutually exclusive;
- the HTTP differential walkers drop `start-after` once they hold a token, so no wire-level test ever sent both;
- `ReplayConformanceComparator` skips every captured exchange carrying a `continuation-token`, because replay tokens and real S3 tokens are not interchangeable, so the real-S3 conformance gate could not have seen it either.

## How it was tested

`./gradlew build` is green, fast and integration tiers included.

New coverage, aimed at the request shapes a page walk cannot produce:

- **Pager** — precedence in both conflict directions: a `start-after` sorting before the token's boundary (honoring it re-emits keys page one already returned) and after it (honoring it drops a key). Also on the delimiter path, where the boundary drives `CommonPrefix` rollup, and with a blank token, where `start-after` has to survive.
- **Renderer** — `StartAfter` omitted when a token applies; echoed, with no empty `ContinuationToken`, when the token is blank.
- **HTTP differential** — both conflict directions and the blank token driven through the query parser to the XML, against sorted-Parquet and DuckDB, which must agree byte for byte.
- **Property (jqwik)** — `hasContinuationToken` classifies every string exactly as `ContinuationToken.decode` does. That agreement is what stops precedence and boundary resolution from drifting apart, which is how the blank-token case went wrong in the first place.
- **Restored** — `rejectsBadContinuationToken` covers a bad token alone again, alongside the new bad-token-with-valid-`start-after` case.

The three copies of the two-server differential block fold into one `withServers` helper, which carries the resolved-mode assertions that keep a differential from silently comparing a store against itself.

## Checklist

- [x] Commits are signed off (`git commit -s`, DCO)
- [x] `./gradlew build` passes
- [x] Added or updated tests where it makes sense
- [x] Updated docs if behavior or the CLI changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated S3 object listing pagination to prioritize continuation tokens when both a token and `start-after` are provided.
  * Conflicting `start-after` values are now ignored and omitted from responses.
  * Malformed continuation tokens continue to return errors.

* **Documentation**
  * Documented the updated pagination behavior and parameter precedence.

* **Tests**
  * Added regression coverage across listing responses and serving modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
