### PR TITLE
Make CI a real gate and stop the deep tier from being skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Fast gate: unit / property / concurrency tiers only (no Docker). Gates every
-  # PR. Integration (Testcontainers/LocalStack) tiers are excluded here via
-  # -PnoIntegration so the gate stays ~1 min; they run in the separate
-  # integration-tests job below (main pushes only), which never blocks a PR.
+  # Fast gate: unit / property / concurrency tiers only (no Docker). First to report on
+  # every PR. Integration (Testcontainers/LocalStack) tiers are excluded here via
+  # -PnoIntegration so this job stays ~1 min and says something useful early; they run
+  # in the separate integration-tests job below, which gates the PR alongside this one.
   fast-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -100,15 +100,14 @@ jobs:
           path: "*/build/reports/tests/"
           if-no-files-found: ignore
 
-  # Slow tier: Docker/LocalStack integration tests. Runs on `main` (merges) and
-  # manual dispatch -- NOT on PRs -- so a slow/flaky IT never blocks a PR while
-  # still giving automated real-store coverage on every merge. It also gates the
-  # image publish (docker-publish `needs` it), so it must run on every event that
-  # can publish; otherwise a skipped `needs` would silently skip the publish.
-  # Gate on `github.ref == main` (not just event_name == push) so it stays correct
-  # even if on.push.branches is ever widened. Docker is on the ubuntu-latest runner.
+  # Slow tier: Docker/LocalStack integration tests. Runs on every event, PRs included:
+  # real-store coverage that only runs after merge cannot block the bad merge, and at
+  # ~170 s this tier is affordable on the PR gate (`ci-gate` needs it). Revisit once the
+  # HAR-driven replay corridor lets these 13 LocalStack ITs retire (WP6.8). It also gates
+  # the image publish (docker-publish `needs` it), so it must run on every event that can
+  # publish; otherwise a skipped `needs` would silently skip the publish. Docker is on the
+  # ubuntu-latest runner.
   integration-tests:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -175,6 +174,12 @@ jobs:
       - name: Deep tier (schedule-sensitive + latency tests, serial)
         run: ./gradlew test -Pdeep -PtestMaxParallelForks=1 --no-daemon --stacktrace
 
+      # A tag-filtered tier that matches nothing runs zero tests and reports green. Assert the
+      # count instead of trusting it (see the script header for how the nightly job hid an
+      # empty deep run for weeks).
+      - name: Deep tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "deep tier"
+
       # The real `kill -9` -> `--resume` exactly-once path is env-gated
       # (`-Dswath.it.sigkill=true`, @EnabledIfSystemProperty) and SKIPPED everywhere else. A
       # separate, untagged invocation (not `-Pdeep`/`-PonlyIntegration`, which would tag-filter
@@ -185,12 +190,20 @@ jobs:
       - name: Real kill -9 -> --resume exactly-once
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeProcessIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
 
+      # This IT is `@EnabledIfSystemProperty`-gated, so a break in the daemon-to-test-JVM
+      # property forwarding turns it into a silent skip rather than a failure.
+      - name: Kill -9 IT executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 exactly-once IT" swath-cli
+
       # Parametric external-kill matrix (many lifecycle points x {no-sort, --sort}) ->
       # --resume -> identical-to-clean oracle. Same `-Dswath.it.sigkill=true` gate/tag as the
       # single-point IT above; separate untagged invocation for the same reason (a `-Pdeep`/
       # `-PonlyIntegration` run would tag-filter it out). Honest KILLED-vs-DEGRADED tally in output.
       - name: Real kill -9 matrix -> --resume identical-to-clean
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeMatrixIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Kill -9 matrix executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 matrix IT" swath-cli
 
       - name: Upload test reports
         if: always()
@@ -258,6 +271,56 @@ jobs:
 
       - name: Smoke — image runs and entrypoint passes arguments
         run: docker run --rm "${{ matrix.image }}" --help
+
+  # The single required status check on `main`, and the only job here that exists for the
+  # branch rule rather than for what it runs.
+  #
+  # GitHub can only require a check by NAME, and a matrix job expands into one context per leg
+  # (`docker-check (Dockerfile, swath:ci, swath)`, ...): a rule naming `docker-check` matches
+  # nothing, and naming the legs individually goes stale the moment a leg is added or renamed.
+  # One aggregate job has a single stable name, and `needs` already collapses every leg of a
+  # matrix into one result — so adding a leg extends the gate for free. Requiring the tiers
+  # individually has a second failure mode this avoids: a single-module `check` once reported a
+  # cross-module change green (08-19), and a rule listing job names cannot notice that.
+  #
+  # `if: always()` is not optional. Without it a failed dependency SKIPS this job, a skipped
+  # required check never reports a conclusion, and the pull request waits forever instead of
+  # going red.
+  ci-gate:
+    needs: [fast-tests, integration-tests, docker-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # A skipped dependency passes the gate only OFF pull_request, where jobs are legitimately
+      # event-gated (docker-check is PR-only, so it skips on every main merge). On a pull request
+      # all three dependencies run, so there `skipped` is not a pass: that is what stops a future
+      # `if:` from quietly removing a tier from the gate while the check stays green.
+      - name: Every gating job passed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          ALLOW_SKIPPED: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          if [ "$ALLOW_SKIPPED" = true ]; then
+            allowed='["success","skipped"]'
+          else
+            allowed='["success"]'
+          fi
+          {
+            echo "### CI gate"
+            echo
+            echo "| job | result |"
+            echo "| --- | --- |"
+            jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"' <<<"$NEEDS"
+          } >> "$GITHUB_STEP_SUMMARY"
+          failed=$(jq -r --argjson allowed "$allowed" \
+            'to_entries[] | select(.value.result as $r | $allowed | index($r) | not) | .key' <<<"$NEEDS")
+          if [ -n "$failed" ]; then
+            echo "::error::CI gate failed — not passing: $(echo "$failed" | paste -sd', ' -)"
+            exit 1
+          fi
+          echo "CI gate passed."
 
   # Dev-image GHCR publish + deep runtime smoke. Runs on every `main` merge and on
   # manual dispatch from any branch. Tagged releases publish through release.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,15 +49,27 @@ jobs:
       - name: Deep tier (serial)
         run: ./gradlew test -Pdeep -PtestMaxParallelForks=1 --no-daemon --stacktrace
 
+      # What this job is FOR is re-executing the tier, so the count is the result that
+      # matters: a tag filter that matches nothing, or a reused task result, would otherwise
+      # report green in 2 minutes. See the script header.
+      - name: Deep tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "deep tier"
+
       # The real `kill -9` -> `--resume` exactly-once path -- see ci.yml's
       # deep-tests job for the same step (this one is the schedule-driven backstop, matching
       # the deep tier's own "runs on every main-merge (ci.yml) + nightly" pattern above).
       - name: Real kill -9 -> --resume exactly-once
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeProcessIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
 
+      - name: Kill -9 IT executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 exactly-once IT" swath-cli
+
       # Parametric external-kill matrix (schedule-driven backstop, mirrors ci.yml's deep-tests).
       - name: Real kill -9 matrix -> --resume identical-to-clean
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeMatrixIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Kill -9 matrix executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 matrix IT" swath-cli
 
       # Perf tier ONLY (-PonlyPerf runs just the @Tag("perf") classes — not the whole fast+
       # integration suite — and the convention plugin bumps the test-worker heap to 2g for the
@@ -65,6 +77,9 @@ jobs:
       # mock-driven (the DuckDB-backed INT-6 is an integration test, not perf).
       - name: Perf tier
         run: ./gradlew test -PonlyPerf --no-daemon --stacktrace
+
+      - name: Perf tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "perf tier"
 
       # TODO: add a gated real-AWS public-bucket differential
       # (`aws s3api --no-sign-request` vs swath) once the public-bucket harness lands — the

--- a/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
@@ -183,6 +183,18 @@ tasks.withType<Test>().configureEach {
         project.name == "swath-core" -> maxOf(1, minOf(4, Runtime.getRuntime().availableProcessors() / 2))
         else -> 1
     }
+    // Re-execution backstops: the timing-sensitive tiers above plus the `kill -9` ITs, whose
+    // outcome depends on the machine and the schedule rather than on the sources alone, so a
+    // green result recorded on an earlier run says nothing about this one. Gradle cannot know
+    // that — the inputs are unchanged, so it is entitled to reuse the result — and the nightly
+    // job restores a build cache (gradle/actions/setup-gradle), which served `:swath-core:test`
+    // FROM-CACHE and let a nightly deep run "pass" in 2.4 min without executing a single deep
+    // test. Opting these invocations out of both caching and up-to-date checks is what makes the
+    // backstop a backstop; the fast tier keeps both, since that is where they pay.
+    if (timingSensitiveTier || System.getProperty("swath.it.sigkill") != null) {
+        outputs.upToDateWhen { false }
+        outputs.cacheIf { false }
+    }
     // The default Gradle test-worker heap (512 MB) is well under the §5/§7.2 GB-scale memory
     // corridors the perf tier measures against (SORT-PERF, PERF-2): without headroom, a
     // multi-million-entry perf test hits a harness OOM before the pipeline itself gets anywhere

--- a/docs/ops/dev/TESTING.md
+++ b/docs/ops/dev/TESTING.md
@@ -75,7 +75,10 @@ parallel/batched, and the populated volume **snapshotted and reused** — not re
   and/or flaky under CI contention. Runs on every **main merge** (ci.yml `deep-tests`,
   serial via `-PtestMaxParallelForks=1`) and **nightly** (`nightly.yml`). The *invariants*
   these guard are pinned per-commit by fast deterministic smokes (see the Tag convention
-  below).
+  below). This tier and `perf` always re-execute — they are opted out of Gradle's
+  up-to-date and build-cache reuse, because their result depends on the machine and the
+  schedule, not on the sources. Locally that means a repeated `-Pdeep` run costs full
+  wall-clock; that is the point.
 - **`-PnoIntegration`** `./gradlew test -PnoIntegration` — Docker-free quick inner
   loop (skips the Testcontainers ITs).
 - **`-PonlyIntegration`** `./gradlew test -PonlyIntegration` — runs **only** the

--- a/scripts/ci/report-test-counts.py
+++ b/scripts/ci/report-test-counts.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""report-test-counts — report what a test tier actually executed, and fail an empty run.
+
+The opt-in tiers select tests by tag (``-Pdeep``, ``-PonlyPerf``, the
+``-Dswath.it.sigkill=true`` ITs). A mis-typed property, a renamed tag, or a cached task
+result therefore produces an *empty* run, and an empty run reports green -- the failure
+mode the nightly deep job spent weeks in. This script turns "the tier executed nothing"
+into a red step, and prints the per-module counts the nightly log was missing.
+
+Self-contained (stdlib only) so the public CI has no external package dependency.
+The `.sh` wrapper CI invokes execs this file directly.
+
+Usage:
+    scripts/ci/report-test-counts.py --repo-root PATH <label> [module...]
+    scripts/ci/report-test-counts.sh <label> [module...]  (CI entry point)
+
+Exit codes: 0 = tests executed, 1 = nothing executed, 2 = script error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Where Gradle's XML test reports land, relative to a module directory. Gradle recreates
+# this directory when the module's `test` task executes, so its contents describe the most
+# recent execution rather than an accumulation across tiers.
+RESULTS_GLOB = "build/test-results/test/TEST-*.xml"
+
+
+class ModuleCounts:
+    """Per-module totals across every test suite the module reported."""
+
+    def __init__(self, module: str) -> None:
+        self.module = module
+        self.tests = 0
+        self.skipped = 0
+        self.failures = 0
+        self.errors = 0
+
+    @property
+    def executed(self) -> int:
+        """Tests that actually ran: JUnit counts a skipped test in ``tests`` too."""
+        return self.tests - self.skipped
+
+    def add(self, suite: ElementTree.Element) -> None:
+        self.tests += int(suite.get("tests", 0))
+        self.skipped += int(suite.get("skipped", 0))
+        self.failures += int(suite.get("failures", 0))
+        self.errors += int(suite.get("errors", 0))
+
+
+def collect(repo_root: Path, modules: list[str]) -> list[ModuleCounts]:
+    """Read every module's JUnit XML, in the module order given (or sorted, if none)."""
+    candidates = (
+        [repo_root / module for module in modules]
+        if modules
+        else sorted(path for path in repo_root.iterdir() if (path / "build/test-results/test").is_dir())
+    )
+    collected = []
+    for directory in candidates:
+        reports = sorted(directory.glob(RESULTS_GLOB))
+        if not reports:
+            continue
+        counts = ModuleCounts(directory.name)
+        for report in reports:
+            try:
+                counts.add(ElementTree.parse(report).getroot())
+            except ElementTree.ParseError as error:
+                raise SystemExit(f"error: unreadable test report {report}: {error}") from error
+        collected.append(counts)
+    return collected
+
+
+def report(label: str, collected: list[ModuleCounts]) -> str:
+    """Render the GitHub-flavoured summary table (also readable in a plain log)."""
+    lines = [f"### {label} — executed tests", "", "| module | executed | skipped | failed |", "| --- | --: | --: | --: |"]
+    for counts in collected:
+        failed = counts.failures + counts.errors
+        lines.append(f"| {counts.module} | {counts.executed} | {counts.skipped} | {failed} |")
+    total = sum(counts.executed for counts in collected)
+    lines.append(f"| **total** | **{total}** | | |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("label", help='what ran, e.g. "deep tier"')
+    parser.add_argument("modules", nargs="*", help="restrict to these modules (default: all with results)")
+    args = parser.parse_args()
+
+    collected = collect(args.repo_root, args.modules)
+    summary = report(args.label, collected)
+    print(summary)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+
+    if sum(counts.executed for counts in collected) == 0:
+        print(
+            f"::error::{args.label} executed no tests — the tag filter matched nothing, "
+            "or the task result was reused. A tier that runs nothing is not a passing tier.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/report-test-counts.sh
+++ b/scripts/ci/report-test-counts.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Reports how many tests a tier just executed, and fails if the answer is none.
+#
+# The opt-in tiers (`-Pdeep`, `-PonlyPerf`, the `-Dswath.it.sigkill=true` ITs) select their
+# tests by tag, so a mis-typed property or a tag that no longer matches anything yields an
+# empty run -- and an empty run is GREEN. That is not hypothetical: the nightly deep job
+# alternated 9 min and 2.4 min for weeks because Gradle served `:swath-core:test` FROM-CACHE,
+# and nothing in the log said the tier had executed zero tests. The conventions plugin now
+# stops the caching; this script is the assertion that the tier ran at all, so the next way
+# of arriving at an empty run is loud instead of silent.
+#
+# Counts come from the JUnit XML Gradle writes per module. Gradle recreates a module's
+# results directory when its `test` task executes, so a report taken immediately after a
+# tier's step describes that tier -- run this right after the step it is reporting on, not
+# at the end of the job.
+#
+# Usage: scripts/ci/report-test-counts.sh <label> [module...]
+#   label   what ran, e.g. "deep tier" -- used in the log and the job summary
+#   module  restrict to these module directories (default: every module that has results)
+# Exit codes: 0 = tests executed, 1 = nothing executed, 2 = script error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+exec python3 "${SCRIPT_DIR}/report-test-counts.py" --repo-root "${REPO_ROOT}" "$@"


### PR DESCRIPTION
WP0.1 of the remediation programme.

## The repository had no gate

The only rule on `main` is an org-level ruleset blocking deletion and force-push. There is no required status check at all, so nothing prevents a red merge.

Requiring the test jobs by name does not fix that. `docker-check` is a matrix and expands into one status context per leg, so a rule naming `docker-check` matches nothing, and naming the legs individually goes stale the moment a leg is added or renamed. This adds one aggregate `ci-gate` job with a stable name that `needs` the gating tiers — `needs` already collapses a matrix into a single result, so a new leg extends the gate for free.

- It runs under `if: always()`. Without that a failed dependency *skips* the job, a skipped required check never reports a conclusion, and the PR waits forever instead of going red.
- A skipped dependency passes the gate only off `pull_request`, where jobs are legitimately event-gated (`docker-check` is PR-only, so it skips on every main merge). On a pull request all three run, so `skipped` is not a pass there — that is what stops a future `if:` from quietly removing a tier from the gate while the check stays green.
- Integration tests now run on pull requests. Real-store coverage that only runs after the merge cannot block the bad merge, and ~170 s is affordable.

Verified against six `needs` shapes (all green / docker skipped / one failed / one cancelled, on and off `pull_request`).

**Requires a repository setting after merge:** make `ci-gate` the required status check on `main`. The job has to exist on `main` first, so that is deliberately not part of this PR.

## The nightly deep tier was not running

Nightly durations alternated 9.2 / 2.4 / 9.1 / 2.3 / 8.9 min. The short runs log:

```
> Task :swath-core:test FROM-CACHE
```

`gradle/actions/setup-gradle` restores a build cache and Gradle reuses the tier's result, so on those nights the deep tests never executed. Gradle is not wrong — the inputs are unchanged — but these tiers exist to *re-execute*: they assert probe budgets and latency corridors whose outcome depends on the machine and the schedule, and the `kill -9` ITs kill a real process. The deep, perf and sigkill invocations are now opted out of caching and up-to-date checks. The fast tier keeps both, since that is where they pay.

Verified locally: `:swath-model:test -Pdeep` twice re-executes; the same task without `-Pdeep` is still `UP-TO-DATE` on the second run.

## An empty tier no longer reports green

Caching was only *this* route to an empty tier. A tag filter that matches nothing also executes zero tests and passes, and the sigkill ITs are `@EnabledIfSystemProperty`-gated, so a break in the daemon-to-test-JVM property forwarding turns them into a silent skip — a gap that has bitten this build before.

`scripts/ci/report-test-counts.sh` reads the JUnit XML a tier just wrote, prints per-module counts to the job summary, and **fails when the count is zero**. Wired after each tag-filtered invocation in both workflows.

## Not included, and why

- **Nightly replay-corridor job** and the LocalStack→HAR migration: both depend on the HAR capture harness from WP6.8-6, which does not exist yet. The conformance `HarReader` is there; the fixture panel is not.
- **Nightly OSV scan**: in the stacked PR, where it lands together with the dependency pins that make it pass rather than knowingly red.
- **`delete_branch_on_merge` and pruning the 25 merged-PR branches**: repository operations, not code. Note `git branch -r --merged main` reports 0, not 28 — PRs squash-merge, so branch tips are never ancestors of `main`; the real list comes from merged PR head refs.

## Verification

`./gradlew build` (Docker-backed) green: 4164 tests, all 13 integration-test classes executed, 0 failures. `spotlessCheck` and the instrumentation-drift guard clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Integration tests now run for pull requests.
  * CI requires fast tests, integration tests, and Docker checks to complete successfully.
  * CI reports executed, skipped, failed, and errored test counts.

* **Testing**
  * Timing-sensitive deep, performance, and termination tests now always execute instead of using cached results.
  * Added reusable test-count reporting for CI and nightly test runs.

* **Documentation**
  * Updated testing guidance to explain that repeated deep-test runs incur their full execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->