### PR TITLE
Pin the shipped dependency closure and drop netty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Fast gate: unit / property / concurrency tiers only (no Docker). Gates every
-  # PR. Integration (Testcontainers/LocalStack) tiers are excluded here via
-  # -PnoIntegration so the gate stays ~1 min; they run in the separate
-  # integration-tests job below (main pushes only), which never blocks a PR.
+  # Fast gate: unit / property / concurrency tiers only (no Docker). First to report on
+  # every PR. Integration (Testcontainers/LocalStack) tiers are excluded here via
+  # -PnoIntegration so this job stays ~1 min and says something useful early; they run
+  # in the separate integration-tests job below, which gates the PR alongside this one.
   fast-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -100,15 +100,14 @@ jobs:
           path: "*/build/reports/tests/"
           if-no-files-found: ignore
 
-  # Slow tier: Docker/LocalStack integration tests. Runs on `main` (merges) and
-  # manual dispatch -- NOT on PRs -- so a slow/flaky IT never blocks a PR while
-  # still giving automated real-store coverage on every merge. It also gates the
-  # image publish (docker-publish `needs` it), so it must run on every event that
-  # can publish; otherwise a skipped `needs` would silently skip the publish.
-  # Gate on `github.ref == main` (not just event_name == push) so it stays correct
-  # even if on.push.branches is ever widened. Docker is on the ubuntu-latest runner.
+  # Slow tier: Docker/LocalStack integration tests. Runs on every event, PRs included:
+  # real-store coverage that only runs after merge cannot block the bad merge, and at
+  # ~170 s this tier is affordable on the PR gate (`ci-gate` needs it). Revisit once the
+  # HAR-driven replay corridor lets these 13 LocalStack ITs retire (WP6.8). It also gates
+  # the image publish (docker-publish `needs` it), so it must run on every event that can
+  # publish; otherwise a skipped `needs` would silently skip the publish. Docker is on the
+  # ubuntu-latest runner.
   integration-tests:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -175,6 +174,12 @@ jobs:
       - name: Deep tier (schedule-sensitive + latency tests, serial)
         run: ./gradlew test -Pdeep -PtestMaxParallelForks=1 --no-daemon --stacktrace
 
+      # A tag-filtered tier that matches nothing runs zero tests and reports green. Assert the
+      # count instead of trusting it (see the script header for how the nightly job hid an
+      # empty deep run for weeks).
+      - name: Deep tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "deep tier"
+
       # The real `kill -9` -> `--resume` exactly-once path is env-gated
       # (`-Dswath.it.sigkill=true`, @EnabledIfSystemProperty) and SKIPPED everywhere else. A
       # separate, untagged invocation (not `-Pdeep`/`-PonlyIntegration`, which would tag-filter
@@ -185,12 +190,20 @@ jobs:
       - name: Real kill -9 -> --resume exactly-once
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeProcessIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
 
+      # This IT is `@EnabledIfSystemProperty`-gated, so a break in the daemon-to-test-JVM
+      # property forwarding turns it into a silent skip rather than a failure.
+      - name: Kill -9 IT executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 exactly-once IT" swath-cli
+
       # Parametric external-kill matrix (many lifecycle points x {no-sort, --sort}) ->
       # --resume -> identical-to-clean oracle. Same `-Dswath.it.sigkill=true` gate/tag as the
       # single-point IT above; separate untagged invocation for the same reason (a `-Pdeep`/
       # `-PonlyIntegration` run would tag-filter it out). Honest KILLED-vs-DEGRADED tally in output.
       - name: Real kill -9 matrix -> --resume identical-to-clean
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeMatrixIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Kill -9 matrix executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 matrix IT" swath-cli
 
       - name: Upload test reports
         if: always()
@@ -258,6 +271,56 @@ jobs:
 
       - name: Smoke — image runs and entrypoint passes arguments
         run: docker run --rm "${{ matrix.image }}" --help
+
+  # The single required status check on `main`, and the only job here that exists for the
+  # branch rule rather than for what it runs.
+  #
+  # GitHub can only require a check by NAME, and a matrix job expands into one context per leg
+  # (`docker-check (Dockerfile, swath:ci, swath)`, ...): a rule naming `docker-check` matches
+  # nothing, and naming the legs individually goes stale the moment a leg is added or renamed.
+  # One aggregate job has a single stable name, and `needs` already collapses every leg of a
+  # matrix into one result — so adding a leg extends the gate for free. Requiring the tiers
+  # individually has a second failure mode this avoids: a single-module `check` once reported a
+  # cross-module change green (08-19), and a rule listing job names cannot notice that.
+  #
+  # `if: always()` is not optional. Without it a failed dependency SKIPS this job, a skipped
+  # required check never reports a conclusion, and the pull request waits forever instead of
+  # going red.
+  ci-gate:
+    needs: [fast-tests, integration-tests, docker-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # A skipped dependency passes the gate only OFF pull_request, where jobs are legitimately
+      # event-gated (docker-check is PR-only, so it skips on every main merge). On a pull request
+      # all three dependencies run, so there `skipped` is not a pass: that is what stops a future
+      # `if:` from quietly removing a tier from the gate while the check stays green.
+      - name: Every gating job passed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          ALLOW_SKIPPED: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          if [ "$ALLOW_SKIPPED" = true ]; then
+            allowed='["success","skipped"]'
+          else
+            allowed='["success"]'
+          fi
+          {
+            echo "### CI gate"
+            echo
+            echo "| job | result |"
+            echo "| --- | --- |"
+            jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"' <<<"$NEEDS"
+          } >> "$GITHUB_STEP_SUMMARY"
+          failed=$(jq -r --argjson allowed "$allowed" \
+            'to_entries[] | select(.value.result as $r | $allowed | index($r) | not) | .key' <<<"$NEEDS")
+          if [ -n "$failed" ]; then
+            echo "::error::CI gate failed — not passing: $(echo "$failed" | paste -sd', ' -)"
+            exit 1
+          fi
+          echo "CI gate passed."
 
   # Dev-image GHCR publish + deep runtime smoke. Runs on every `main` merge and on
   # manual dispatch from any branch. Tagged releases publish through release.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,15 +49,27 @@ jobs:
       - name: Deep tier (serial)
         run: ./gradlew test -Pdeep -PtestMaxParallelForks=1 --no-daemon --stacktrace
 
+      # What this job is FOR is re-executing the tier, so the count is the result that
+      # matters: a tag filter that matches nothing, or a reused task result, would otherwise
+      # report green in 2 minutes. See the script header.
+      - name: Deep tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "deep tier"
+
       # The real `kill -9` -> `--resume` exactly-once path -- see ci.yml's
       # deep-tests job for the same step (this one is the schedule-driven backstop, matching
       # the deep tier's own "runs on every main-merge (ci.yml) + nightly" pattern above).
       - name: Real kill -9 -> --resume exactly-once
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeProcessIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
 
+      - name: Kill -9 IT executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 exactly-once IT" swath-cli
+
       # Parametric external-kill matrix (schedule-driven backstop, mirrors ci.yml's deep-tests).
       - name: Real kill -9 matrix -> --resume identical-to-clean
         run: ./gradlew :swath-cli:test --tests "io.varve.swath.cli.HardCrashSigkillResumeMatrixIT" -Dswath.it.sigkill=true --no-daemon --stacktrace
+
+      - name: Kill -9 matrix executed tests
+        run: ./scripts/ci/report-test-counts.sh "kill -9 matrix IT" swath-cli
 
       # Perf tier ONLY (-PonlyPerf runs just the @Tag("perf") classes — not the whole fast+
       # integration suite — and the convention plugin bumps the test-worker heap to 2g for the
@@ -65,6 +77,9 @@ jobs:
       # mock-driven (the DuckDB-backed INT-6 is an integration test, not perf).
       - name: Perf tier
         run: ./gradlew test -PonlyPerf --no-daemon --stacktrace
+
+      - name: Perf tier executed tests
+        run: ./scripts/ci/report-test-counts.sh "perf tier"
 
       # TODO: add a gated real-AWS public-bucket differential
       # (`aws s3api --no-sign-request` vs swath) once the public-bucket harness lands — the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,10 @@
 name: Nightly deep verification
 
-# The deep + perf tiers, run on a schedule rather than per-commit. These are the tests
-# demoted off the per-commit fast gate:
+# What the per-commit gate cannot see, checked on a schedule: the tiers too slow or too
+# timing-sensitive to run per commit, and the supply-chain scan, which goes red because time
+# passed rather than because the commit changed.
+#
+# The deep + perf tiers are the tests demoted off the per-commit fast gate:
 #   - `deep`: schedule-sensitive probe-budget tests + latency-injecting retry/AIMD/throttle
 #             timing tests (also run on every main-merge via ci.yml's deep-tests job).
 #   - `perf`: the heavy scale/throughput tier (100k–1M-key mock-driven PERF-1/PERF-2/SORT-PERF),
@@ -92,3 +95,64 @@ jobs:
           name: test-reports-nightly
           path: "*/build/reports/tests/"
           if-no-files-found: ignore
+
+  # Supply-chain scan of the artifacts a user actually receives: the resolved jar closure of
+  # each application distribution, and the runtime image whose JRE base carries OS packages no
+  # Gradle constraint can reach. Nightly rather than per-commit because it is time, not the
+  # commit, that turns a green closure red — an advisory published against a dependency that
+  # has not moved. That is also why it belongs beside the deep tier: both are backstops
+  # against drift the per-commit gate cannot see.
+  #
+  # config/osv/osv-scanner.toml carries the argued exceptions, each with an expiry; anything
+  # else fails the job. See scripts/ci/osv-scan.sh.
+  osv-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+
+      # installDist, not the shadow jar: the install `lib/` directory is the resolved closure
+      # with each module still a separately identifiable artifact, which is what the scanner
+      # reads. Shading flattens that into one jar and loses the coordinates.
+      - name: Assemble the shipped distributions
+        run: ./gradlew :swath-cli:installDist :swath-replay:installDist --no-daemon --stacktrace
+
+      - name: Scan the shipped jar closures
+        run: |
+          ./scripts/ci/osv-scan.sh \
+            swath-cli/build/install/swath/lib \
+            swath-replay/build/install/swath-replay/lib
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      # Builder-native arch only, and no push: this scans the base layer's OS packages, which
+      # are the same image for both arches' JRE bases in every way this scan looks at.
+      - name: Build the runtime images (builder-native arch)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          load: true
+          tags: swath:osv
+          cache-from: type=gha,scope=swath
+
+      - name: Build the replay runtime image (builder-native arch)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile.replay
+          load: true
+          tags: swath-replay:osv
+          cache-from: type=gha,scope=swath-replay
+
+      - name: Scan the runtime images
+        run: ./scripts/ci/osv-scan.sh image:swath:osv image:swath-replay:osv

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,57 +16,46 @@ resources.
 
 ## Runtime dependency inventory
 
-- `ch.qos.logback:logback-classic:1.5.18` — Eclipse Public License 1.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
-- `ch.qos.logback:logback-core:1.5.18` — Eclipse Public License 1.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
+- `ch.qos.logback:logback-classic:1.5.38` — Eclipse Public License - v 2.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
+- `ch.qos.logback:logback-core:1.5.38` — Eclipse Public License - v 2.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
 - `com.bucket4j:bucket4j-core:8.10.1` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-annotations:2.12.7` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-core:2.12.7` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-databind:2.12.7.1` — Apache License, Version 2.0
+- `com.fasterxml.jackson.core:jackson-annotations:2.22` — Apache License, Version 2.0
+- `com.fasterxml.jackson.core:jackson-core:2.22.2` — Apache License, Version 2.0
+- `com.fasterxml.jackson.core:jackson-databind:2.22.2` — Apache License, Version 2.0
 - `com.fasterxml.woodstox:woodstox-core:7.2.2` — Apache License, Version 2.0
 - `com.github.luben:zstd-jni:1.5.6-9` — The 2-Clause BSD License
 - `com.google.code.findbugs:jsr305:3.0.2` — Apache License, Version 2.0
 - `com.google.code.gson:gson:2.9.0` — Apache License, Version 2.0
-- `com.google.guava:failureaccess:1.0` — Apache License, Version 2.0
-- `com.google.guava:guava:27.0-jre` — Apache License, Version 2.0
+- `com.google.guava:failureaccess:1.0.3` — Apache License, Version 2.0
+- `com.google.guava:guava:33.7.1-jre` — Apache License, Version 2.0
 - `com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava` — Apache License, Version 2.0
-- `com.google.j2objc:j2objc-annotations:1.1` — Apache License, Version 2.0
+- `com.google.j2objc:j2objc-annotations:3.1` — Apache License, Version 2.0
 - `com.google.protobuf:protobuf-java:4.34.0` — The 3-Clause BSD License
 - `com.google.re2j:re2j:1.1` — The Go license
-- `commons-beanutils:commons-beanutils:1.9.4` — Apache License, Version 2.0
+- `commons-beanutils:commons-beanutils:1.11.0` — Apache License, Version 2.0
 - `commons-cli:commons-cli:1.5.0` — Apache License, Version 2.0
-- `commons-codec:commons-codec:1.17.1` — Apache License, Version 2.0
+- `commons-codec:commons-codec:1.19.0` — Apache License, Version 2.0
 - `commons-collections:commons-collections:3.2.2` — Apache License, Version 2.0
-- `commons-io:commons-io:2.16.1` — Apache License, Version 2.0
-- `commons-logging:commons-logging:1.3.0` — Apache License, Version 2.0
+- `commons-io:commons-io:2.22.0` — Apache License, Version 2.0
+- `commons-logging:commons-logging:1.3.6` — Apache License, Version 2.0
 - `commons-net:commons-net:3.9.0` — Apache License, Version 2.0
 - `commons-pool:commons-pool:1.6` — Apache License, Version 2.0
 - `dnsjava:dnsjava:3.6.1` — The 3-Clause BSD License
 - `info.picocli:picocli:4.7.6` — Apache License, Version 2.0
-- `io.airlift:aircompressor:2.0.2` — Apache License, Version 2.0
+- `io.airlift:aircompressor:2.0.3` — Apache License, Version 2.0
 - `io.dropwizard.metrics:metrics-core:3.2.4` — Apache License, Version 2.0
 - `io.micrometer:micrometer-commons:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-core:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-observation:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-registry-otlp:1.17.0` — Apache License, Version 2.0
-- `io.netty:netty-buffer:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-codec:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-codec-http:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-codec-http2:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-common:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-handler:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-resolver:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-classes-epoll:4.1.118.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-native-epoll:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-native-unix-common:4.1.118.Final` — Apache License, Version 2.0
 - `io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha` — Apache License, Version 2.0
 - `jakarta.activation:jakarta.activation-api:1.2.1` — Eclipse Public License - v 2.0; GNU GENERAL PUBLIC LICENSE, Version 2; GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception; The 3-Clause BSD License
 - `javax.annotation:javax.annotation-api:1.3.2` — CDDL + GPLv2 with classpath exception; Common Development and Distribution License 1.0
-- `org.apache.avro:avro:1.9.2` — Apache License, Version 2.0
-- `org.apache.commons:commons-compress:1.26.1` — Apache License, Version 2.0
-- `org.apache.commons:commons-configuration2:2.10.1` — Apache License, Version 2.0
-- `org.apache.commons:commons-lang3:3.14.0` — Apache License, Version 2.0
-- `org.apache.commons:commons-text:1.11.0` — Apache License, Version 2.0
+- `org.apache.avro:avro:1.11.5` — Apache License, Version 2.0
+- `org.apache.commons:commons-compress:1.28.0` — Apache License, Version 2.0
+- `org.apache.commons:commons-configuration2:2.15.1` — Apache License, Version 2.0
+- `org.apache.commons:commons-lang3:3.20.0` — Apache License, Version 2.0
+- `org.apache.commons:commons-text:1.15.0` — Apache License, Version 2.0
 - `org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0` — Apache License, Version 2.0
 - `org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25:1.3.0` — Apache License, Version 2.0
 - `org.apache.hadoop:hadoop-annotations:3.4.1` — Apache License, Version 2.0
@@ -80,14 +69,12 @@ resources.
 - `org.apache.parquet:parquet-format-structures:1.15.1` — Apache License, Version 2.0
 - `org.apache.parquet:parquet-hadoop:1.15.1` — Apache License, Version 2.0
 - `org.apache.parquet:parquet-jackson:1.15.1` — Apache License, Version 2.0
-- `org.checkerframework:checker-qual:2.5.2` — MIT License
 - `org.codehaus.jettison:jettison:1.5.4` — Apache License, Version 2.0
-- `org.codehaus.mojo:animal-sniffer-annotations:1.17` — Apache License, Version 2.0; MIT License
 - `org.codehaus.woodstox:stax2-api:4.3.0` — Apache License, Version 2.0; The 2-Clause BSD License
 - `org.hdrhistogram:HdrHistogram:2.2.2` — Creative Commons Legal Code; PUBLIC DOMAIN; The 2-Clause BSD License
 - `org.jline:jline-terminal:3.30.16` — Apache License, Version 2.0; The 3-Clause BSD License
 - `org.jline:jline-terminal-ffm:3.30.16` — The 3-Clause BSD License
-- `org.jspecify:jspecify:1.0.0` — Apache License, Version 2.0
+- `org.jspecify:jspecify:1.0.1` — Apache License, Version 2.0
 - `org.reactivestreams:reactive-streams:1.0.4` — MIT-0
 - `org.slf4j:slf4j-api:2.0.17` — No license declared in resolved metadata; MIT License
 - `org.xerial.snappy:snappy-java:1.1.10.7` — Apache License, Version 2.0
@@ -111,7 +98,6 @@ resources.
 - `software.amazon.awssdk:identity-spi:2.31.78` — Apache License, Version 2.0
 - `software.amazon.awssdk:json-utils:2.31.78` — Apache License, Version 2.0
 - `software.amazon.awssdk:metrics-spi:2.31.78` — Apache License, Version 2.0
-- `software.amazon.awssdk:netty-nio-client:2.31.78` — Apache License, Version 2.0
 - `software.amazon.awssdk:profiles:2.31.78` — Apache License, Version 2.0
 - `software.amazon.awssdk:protocol-core:2.31.78` — Apache License, Version 2.0
 - `software.amazon.awssdk:regions:2.31.78` — Apache License, Version 2.0
@@ -314,13 +300,14 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).
 
-### avro-1.9.2.jar
+### avro-1.11.5.jar
 
 #### META-INF/NOTICE
 
 
     Apache Avro
-    Copyright 2009-2020 The Apache Software Foundation
+    Copyright 2009-2025 The Apache Software Foundation
+
 
     This product includes software developed at
     The Apache Software Foundation (http://www.apache.org/).
@@ -475,15 +462,15 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).
 
-### commons-beanutils-1.9.4.jar
+### commons-beanutils-1.11.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons BeanUtils
-    Copyright 2000-2019 The Apache Software Foundation
+    Copyright 2000-2025 The Apache Software Foundation
 
     This product includes software developed at
-    The Apache Software Foundation (http://www.apache.org/).
+    The Apache Software Foundation (https://www.apache.org/).
 
 ### commons-cli-1.5.0.jar
 
@@ -495,12 +482,12 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-codec-1.17.1.jar
+### commons-codec-1.19.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Codec
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -515,52 +502,52 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed by
     The Apache Software Foundation (http://www.apache.org/).
 
-### commons-compress-1.26.1.jar
+### commons-compress-1.28.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Compress
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-configuration2-2.10.1.jar
+### commons-configuration2-2.15.1.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Configuration
-    Copyright 2001-2024 The Apache Software Foundation
+    Copyright 2001-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-io-2.16.1.jar
+### commons-io-2.22.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons IO
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-lang3-3.14.0.jar
+### commons-lang3-3.20.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Lang
-    Copyright 2001-2023 The Apache Software Foundation
+    Copyright 2001-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-logging-1.3.0.jar
+### commons-logging-1.3.6.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Logging
-    Copyright 2001-2023 The Apache Software Foundation
+    Copyright 2001-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -585,12 +572,12 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed by
     The Apache Software Foundation (http://www.apache.org/).
 
-### commons-text-1.11.0.jar
+### commons-text-1.15.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Text
-    Copyright 2014-2023 The Apache Software Foundation
+    Copyright 2014-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -994,7 +981,7 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).
 
-### jackson-core-2.12.7.jar
+### jackson-annotations-2.22.jar
 
 #### META-INF/NOTICE
 
@@ -1004,6 +991,10 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
     been in development since 2007.
     It is currently developed by a community of developers.
+
+    ## Copyright
+
+    Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
 
     ## Licensing
 
@@ -1016,7 +1007,7 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     in some artifacts (usually source distributions); but is always available
     from the source code management (SCM) system project uses.
 
-### jackson-databind-2.12.7.1.jar
+### jackson-core-2.22.2.jar
 
 #### META-INF/NOTICE
 
@@ -1026,6 +1017,57 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
     been in development since 2007.
     It is currently developed by a community of developers.
+
+    ## Copyright
+
+    Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+    ## Licensing
+
+    Jackson 2.x core and extension components are licensed under Apache License 2.0
+    To find the details that apply to this artifact see the accompanying LICENSE file.
+
+    ## Credits
+
+    A list of contributors may be found from CREDITS(-2.x) file, which is included
+    in some artifacts (usually source distributions); but is always available
+    from the source code management (SCM) system project uses.
+
+    ## FastDoubleParser
+
+    jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+    That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+    under the following copyright.
+
+    Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+    See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+    included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+    ## Schubfach
+
+    jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+    That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+    under the following copyright.
+
+    Copyright 2018-2020 Raffaello Giulietti
+
+    See Schubfach-LICENSE.
+
+### jackson-databind-2.22.2.jar
+
+#### META-INF/NOTICE
+
+    # Jackson JSON processor
+
+    Jackson is a high-performance, Free/Open Source JSON processing library.
+    It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+    been in development since 2007.
+    It is currently developed by a community of developers.
+
+    ## Copyright
+
+    Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
 
     ## Licensing
 
@@ -1335,36 +1377,6 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
       * Copyright 2002-2019 the original author or authors.
       * License: Apache License v2.0
       * Homepage: https://spring.io/projects/spring-framework
-
-### netty-nio-client-2.31.78.jar
-
-#### META-INF/NOTICE.txt
-
-    AWS SDK for Java 2.0
-    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-    This product includes software developed by
-    Amazon Technologies, Inc (http://www.amazon.com/).
-
-    **********************
-    THIRD PARTY COMPONENTS
-    **********************
-    This software includes third party software subject to the following copyrights:
-    - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-    - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-    - Apache Commons Lang - https://github.com/apache/commons-lang
-    - Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-    - Jackson-core - https://github.com/FasterXML/jackson-core
-    - Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
-
-    The licenses for these third party components are included in LICENSE.txt
-
-    - For Apache Commons Lang see also this required NOTICE:
-      Apache Commons Lang
-      Copyright 2001-2020 The Apache Software Foundation
-
-      This product includes software developed at
-      The Apache Software Foundation (https://www.apache.org/).
 
 ### parquet-jackson-1.15.1.jar
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,4 +12,8 @@ dependencies {
     // script plugin (which applies it by id to stamp/verify the SPDX license header).
     // Kept in step with `spotless` in gradle/libs.versions.toml.
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.0.2")
+    // Same arrangement for the dependency-analysis plugin, which `swath.java-conventions`
+    // applies by id so every module reports into the root's aggregated `buildHealth`.
+    // Kept in step with `dependencyanalysis` in gradle/libs.versions.toml.
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin:3.19.1")
 }

--- a/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
@@ -9,6 +9,17 @@ import java.time.Duration
 plugins {
     java
     id("com.diffplug.spotless")
+    // Dependency audit, aggregated by the root's `buildHealth` task and run on demand. It is
+    // the tool that answers "does this module still need that?", which is worth having as the
+    // shipped closure gets pruned — but it is NOT wired into `check`, and should not be. Its
+    // model is that a module declares everything it touches and exposes as `api` everything
+    // that reaches its own signatures, and this build deliberately does the opposite in
+    // places: swath-core keeps parquet-hadoop and hadoop-common `implementation`-scoped
+    // precisely so no consumer can import those types, a boundary swath-replay enforces with
+    // its own verifyNoParquetOrHadoopOnCompileClasspath task. Taken as a gate, the plugin
+    // would demand that swath-core promote both to `api` and undo it. Read the report, apply
+    // judgement.
+    id("com.autonomousapps.dependency-analysis")
 }
 
 group = "io.varve.swath"
@@ -50,6 +61,97 @@ configurations.all {
     exclude(group = "org.apache.curator", module = "curator-recipes")
     exclude(group = "org.bouncycastle", module = "bcprov-jdk18on")
     exclude(group = "org.apache.commons", module = "commons-math3")
+    // Netty arrives twice and is used neither time. hadoop-common wants it for the IPC and
+    // HDFS-client paths already excluded above; the AWS SDK ships `netty-nio-client` for
+    // `S3AsyncClient`, and swath builds only the synchronous client over `apache-client`
+    // (S3ClientFactory) — no source in any module names an async client or a netty type.
+    // It was not free: eleven jars, and 40 of the 62 advisories an OSV scan of the CLI
+    // distribution reported, including a `netty-transport-native-epoll` left at 4.1.100
+    // beside `netty-transport-classes-epoll` at 4.1.118 — a native/classes version skew
+    // that would have failed at runtime had anything actually loaded epoll.
+    //
+    // The SDK's own adapter jar goes with it: dropping only `io.netty` would leave
+    // netty-nio-client shipping with nothing behind it, which is strictly worse than either
+    // state — an async HTTP provider that fails on use rather than being absent.
+    exclude(group = "io.netty")
+    exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+}
+
+// Floors for libraries no swath module declares. They arrive under hadoop-common and
+// hadoop-mapreduce-client-core, whose POMs pin versions years behind their fixed releases
+// (jackson 2.12.7, guava 27.0, avro 1.9.2 with a 9.8 RCE), and every one of them ships in
+// the CLI and replay distributions. Constraints rather than `force`: a constraint raises a
+// floor and still loses to anything that legitimately needs newer, where `force` would
+// silently pin a future dependency DOWN to this line.
+//
+// The versions live in the version catalog, so Dependabot raises them like any other
+// dependency. Applied per source set rather than to `implementation` alone so that a
+// distribution assembled from a source set of its own — swath-replay's `conformance`
+// launcher — is pinned by the same list.
+//
+// Not listed, and deliberately: commons-collections 3.2.2 is the release that removed the
+// InvokerTransformer deserialization gadget, it is the last 3.x, and OSV reports nothing
+// against it. It stays as hadoop-common resolves it.
+val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val shippedTransitiveFloors = listOf(
+    "jackson-databind",
+    "guava",
+    "avro",
+    "commons-compress",
+    "commons-beanutils",
+    "commons-configuration2",
+    "commons-lang3",
+).map { alias ->
+    versionCatalog.findLibrary(alias).orElseThrow {
+        IllegalStateException("libs.versions.toml has no library '$alias' to constrain")
+    }
+}
+
+sourceSets.configureEach {
+    val declarableConfiguration = implementationConfigurationName
+    shippedTransitiveFloors.forEach { floor ->
+        dependencies.constraints.add(declarableConfiguration, floor)
+    }
+}
+
+// Gradle resolves a version conflict within one configuration, so a distribution built from a
+// single runtime classpath cannot ship a module twice. A distribution that packs a SECOND
+// closure into the same `lib/` can, and swath-replay does exactly that for its conformance
+// launcher: it shipped jackson-core, -databind and -annotations at both 2.12.7 and 2.22, with
+// nothing but start-script classpath order deciding which generation ran. Nothing failed, and
+// nothing reported it. Assert on the shipped directory itself, which is the only place the
+// union of the closures actually exists.
+plugins.withId("application") {
+    val verifyNoDuplicateModuleVersions by tasks.registering {
+        group = "verification"
+        description = "Checks the application distribution ships at most one version of each module."
+        val installTask = tasks.named<Sync>("installDist")
+        dependsOn(installTask)
+        doLast {
+            val libraryDirectory = installTask.get().destinationDir.resolve("lib")
+            // Maven artifact names are `<module>-<version>[-<classifier>].jar`, and the version
+            // always starts with a digit — so the split point is the last hyphen followed by one.
+            val moduleAndVersion = Regex("""^(.+)-(\d[^-]*(?:-.+)?)\.jar$""")
+            val versionsByModule = (libraryDirectory.listFiles() ?: emptyArray())
+                .mapNotNull { moduleAndVersion.matchEntire(it.name)?.destructured }
+                .groupBy({ (module, _) -> module }, { (_, version) -> version })
+            // A trailing classifier is indistinguishable from a version qualifier by shape alone
+            // (`0.2.5-SNAPSHOT-conformance` against `0.2.5-SNAPSHOT`), and a classified sibling is
+            // a second ARTIFACT of one version, not a second version. Treat a group as one version
+            // when its shortest member is a hyphen-bounded prefix of every other — which
+            // `2.12.7` is not of `2.22.0`, the case this exists to catch.
+            val duplicated = versionsByModule.filterValues { versions ->
+                val shortest = versions.minBy { it.length }
+                versions.any { it != shortest && !it.startsWith("$shortest-") }
+            }
+            check(duplicated.isEmpty()) {
+                "${libraryDirectory} ships more than one version of: " +
+                    duplicated.entries.sortedBy { it.key }
+                        .joinToString("; ") { (module, versions) -> "$module ${versions.sorted()}" }
+            }
+        }
+    }
+    tasks.named("check") { dependsOn(verifyNoDuplicateModuleVersions) }
 }
 
 // Spotless enforces import hygiene and the SPDX license header on every first-party Java

--- a/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/swath.java-conventions.gradle.kts
@@ -183,6 +183,18 @@ tasks.withType<Test>().configureEach {
         project.name == "swath-core" -> maxOf(1, minOf(4, Runtime.getRuntime().availableProcessors() / 2))
         else -> 1
     }
+    // Re-execution backstops: the timing-sensitive tiers above plus the `kill -9` ITs, whose
+    // outcome depends on the machine and the schedule rather than on the sources alone, so a
+    // green result recorded on an earlier run says nothing about this one. Gradle cannot know
+    // that — the inputs are unchanged, so it is entitled to reuse the result — and the nightly
+    // job restores a build cache (gradle/actions/setup-gradle), which served `:swath-core:test`
+    // FROM-CACHE and let a nightly deep run "pass" in 2.4 min without executing a single deep
+    // test. Opting these invocations out of both caching and up-to-date checks is what makes the
+    // backstop a backstop; the fast tier keeps both, since that is where they pay.
+    if (timingSensitiveTier || System.getProperty("swath.it.sigkill") != null) {
+        outputs.upToDateWhen { false }
+        outputs.cacheIf { false }
+    }
     // The default Gradle test-worker heap (512 MB) is well under the §5/§7.2 GB-scale memory
     // corridors the perf tier measures against (SORT-PERF, PERF-2): without headroom, a
     // multi-million-entry perf test hits a harness OOM before the pipeline itself gets anywhere

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,9 @@ import com.github.jk1.license.render.ReportRenderer
 import org.gradle.api.tasks.Exec
 
 plugins {
+    // On-demand dependency audit: `./gradlew buildHealth` aggregates every module's report.
+    // Deliberately NOT wired into `check` — see the note in swath.java-conventions.
+    alias(libs.plugins.dependency.analysis)
     // Dependency-license compliance gate (jk1). Kept off the root's own classpath
     // (`apply false`) and applied per-subproject below: jk1's root-aggregation mode
     // resolves each subproject's `runtimeClasspath` from a root task, which Gradle 9

--- a/config/osv/osv-scanner.toml
+++ b/config/osv/osv-scanner.toml
@@ -1,0 +1,68 @@
+# Accepted findings for the nightly supply-chain scan (scripts/ci/osv-scan.sh).
+#
+# The scan fails on anything not listed here, so every entry is an argued exception with an
+# expiry rather than a mute: past `ignoreUntil` the finding comes back and has to be argued
+# again. Nothing is listed because it is inconvenient — everything reachable by a version
+# constraint is pinned in gradle/libs.versions.toml instead.
+#
+# ---------------------------------------------------------------------------------------
+# parquet-jackson 1.15.1 (9 advisories against jackson-core / jackson-databind 2.18.1)
+#
+# parquet-jackson is not a Jackson dependency; it is Parquet's own repackaging of Jackson,
+# relocated wholesale under `shaded/parquet/com/fasterxml/` inside the jar. A dependency
+# constraint cannot reach it: it is not a resolved module, it is bytes inside an artifact.
+# swath's own Jackson is pinned current and is the copy every swath and AWS SDK code path
+# resolves; the shaded copy is reachable only through Parquet's internal footer-metadata
+# parsing, on files the tool itself just wrote.
+#
+# The fix is upstream: parquet-hadoop 1.16+ carries a newer bundled Jackson. That is a
+# deliberate upgrade, not a pin — the Parquet writer version participates in the written
+# output, and the compatibility contract holds that output byte-identical, so it needs its
+# own change with a Parquet round-trip and a byte comparison against the current writer.
+# Revisit at the date below regardless of whether that upgrade has landed.
+# ---------------------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-72hv-8253-57qq"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-r7wm-3cxj-wff9"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-3pjw-73gf-8qr5"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-5gvw-p9qm-jgwh"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-5jmj-h7xm-6q6v"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-hgj6-7826-r7m5"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-j3rv-43j4-c7qm"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-mhm7-754m-9p8w"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."
+
+[[IgnoredVulns]]
+id = "GHSA-rmj7-2vxq-3g9f"
+ignoreUntil = 2026-11-30
+reason = "Shaded inside parquet-jackson 1.15.1; needs a Parquet upgrade, not a constraint."

--- a/docs/ops/dev/TESTING.md
+++ b/docs/ops/dev/TESTING.md
@@ -75,7 +75,10 @@ parallel/batched, and the populated volume **snapshotted and reused** — not re
   and/or flaky under CI contention. Runs on every **main merge** (ci.yml `deep-tests`,
   serial via `-PtestMaxParallelForks=1`) and **nightly** (`nightly.yml`). The *invariants*
   these guard are pinned per-commit by fast deterministic smokes (see the Tag convention
-  below).
+  below). This tier and `perf` always re-execute — they are opted out of Gradle's
+  up-to-date and build-cache reuse, because their result depends on the machine and the
+  schedule, not on the sources. Locally that means a repeated `-Pdeep` run costs full
+  wall-clock; that is the point.
 - **`-PnoIntegration`** `./gradlew test -PnoIntegration` — Docker-free quick inner
   loop (skips the Testcontainers ITs).
 - **`-PonlyIntegration`** `./gradlew test -PonlyIntegration` — runs **only** the

--- a/docs/packaging-and-docker.md
+++ b/docs/packaging-and-docker.md
@@ -129,8 +129,29 @@ Gradle plugin (`build-logic/src/main/kotlin/swath.java-conventions.gradle.kts`)
 excludes those modules at the `configurations.all { exclude(...) }` level, so
 the exclusion applies to the whole resolved dependency graph regardless of
 which transitive edge would otherwise reintroduce it. This keeps unused service
-stacks out of every distribution. `hadoop-common` still brings some runtime
-transitives; inspect the current distribution if artifact size matters to you.
+stacks out of every distribution.
+
+Netty is excluded on the same grounds and for both of its entry points: Hadoop's
+IPC/HDFS paths, and the AWS SDK's `netty-nio-client`, which exists to serve
+`S3AsyncClient` — swath builds only the synchronous client, over `apache-client`.
+The SDK's adapter jar is excluded alongside `io.netty` itself, so no async HTTP
+provider ships half-present.
+
+What `hadoop-common` does still bring, it brings at the versions its own POM
+names, which run years behind: Jackson 2.12, Guava 27, Avro 1.9. Those are
+raised by a `constraints` block in the same convention plugin, with the floors
+themselves in `gradle/libs.versions.toml` so Dependabot maintains them. A
+constraint raises a floor without capping anything that legitimately needs
+newer.
+
+Two guards keep this honest. Every application distribution is checked to ship
+at most one version of each module (`verifyNoDuplicateModuleVersions`, part of
+`check`) — the replay distribution packs a second dependency closure for its
+conformance launcher into the same `lib/`, and before the floors were pinned it
+shipped two complete Jackson generations at once. And a nightly job scans both
+distributions and both runtime images against the OSV database
+(`scripts/ci/osv-scan.sh`); accepted findings live in
+`config/osv/osv-scanner.toml`, each with an argument and an expiry date.
 
 ## 5. Docker images
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 picocli = "4.7.6"
 slf4j = "2.0.16"
-logback = "1.5.18"
+logback = "1.5.38"
 micrometer = "1.17.0"
 awssdk = "2.31.78"
 parquet = "1.15.1"
@@ -9,9 +9,20 @@ hadoop = "3.4.1"
 woodstox = "7.2.2"
 zstdjni = "1.5.6-9"
 # Pinned explicitly rather than relying on the transitive version pulled in by
-# parquet-hadoop/hadoop-mapreduce-client-core (currently the same 2.0.2) — see swath-core's
+# parquet-hadoop/hadoop-mapreduce-client-core (which is still on 2.0.2) — see swath-core's
 # PageCodec#LZ4, which references io.airlift.compress.lz4 classes directly.
-aircompressor = "2.0.2"
+aircompressor = "2.0.3"
+
+# Floors for libraries swath never declares: they arrive under hadoop-common /
+# hadoop-mapreduce-client-core, which pins versions years behind their fixed releases, and
+# they ship in every distribution. See the `constraints` block in swath.java-conventions.
+guava = "33.7.1-jre"
+avro = "1.11.5"
+commonscompress = "1.28.0"
+commonsbeanutils = "1.11.0"
+commonsconfiguration2 = "2.15.1"
+commonslang3 = "3.20.0"
+
 junit = "5.11.4"
 assertj = "3.27.3"
 jqwik = "1.9.2"
@@ -22,7 +33,7 @@ jetty = "12.1.10"
 duckdbjdbc = "1.5.4.0"
 jmh = "1.37"
 jmhplugin = "0.7.3"
-jackson = "2.22.0"
+jackson = "2.22.2"
 # Terminal geometry for the live progress display's in-place redraw, and nothing else — see
 # TerminalGeometry. The 3.x line is not the superseded one: 3.30.16 postdates 4.3.1, and it is what
 # the ecosystem's shaded consumers ship against.
@@ -32,6 +43,7 @@ commonscodec = "1.16.1"
 shadowplugin = "8.3.9"
 licensereport = "3.1.4"
 spotless = "7.0.2"
+dependencyanalysis = "3.19.1"
 otelproto = "1.10.0-alpha"
 
 [libraries]
@@ -67,6 +79,16 @@ jline-terminal-ffm = { module = "org.jline:jline-terminal-ffm", version.ref = "j
 bucket4j-core = { module = "com.bucket4j:bucket4j-core", version.ref = "bucket4j" }
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commonscodec" }
 
+# Never declared as dependencies — only constrained, so the shipped closure carries a
+# supported version of each. Keeping them here (rather than as literals in the convention
+# plugin) is what lets Dependabot raise the floors.
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+avro = { module = "org.apache.avro:avro", version.ref = "avro" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonscompress" }
+commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commonsbeanutils" }
+commons-configuration2 = { module = "org.apache.commons:commons-configuration2", version.ref = "commonsconfiguration2" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonslang3" }
+
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter" }
 testcontainers-localstack = { module = "org.testcontainers:localstack" }
@@ -88,3 +110,4 @@ jmh = { id = "me.champeau.jmh", version.ref = "jmhplugin" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadowplugin" }
 license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "licensereport" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyanalysis" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,11 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+# Published checksum for the distribution above (services.gradle.org/.../gradle-9.0.0-bin.zip.sha256).
+# CI validates the wrapper JAR, but the JAR's first act is to download this archive: without a
+# checksum the wrapper trusts whatever the URL returns. Regenerate with `./gradlew wrapper
+# --gradle-version <v> --gradle-distribution-sha256-sum <sum>` when the distribution moves.
+distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/scripts/ci/osv-scan.sh
+++ b/scripts/ci/osv-scan.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Supply-chain scan of what swath actually ships: the jars in each application distribution,
+# and the runtime container image (its JRE base carries OS packages no Gradle constraint
+# reaches). Findings are checked against config/osv/osv-scanner.toml, which holds the argued
+# exceptions; anything not listed there fails the run.
+#
+# The distributions are scanned rather than the source tree because the source tree has no
+# lockfile — the shipped `lib/` directory IS the resolved closure, and reading it means the
+# scan can never disagree with what a user downloads. `--no-ignore` is required: `lib/` lives
+# under build/, which .gitignore excludes and the scanner honours by default.
+#
+# Usage: scripts/ci/osv-scan.sh <target>...
+#   target  a directory of jars, or `image:<name>` for a local container image
+# Exit codes: 0 = clean or fully excepted, 1 = findings, 2 = script error.
+set -euo pipefail
+
+# Pinned by version AND checksum: this binary decides whether a release is allowed to ship.
+# Hand-bumped (Dependabot does not track a raw release download) -- when raising it, take the
+# new sum from the release's osv-scanner_SHA256SUMS.
+OSV_SCANNER_VERSION="2.5.1"
+OSV_SCANNER_SHA256="f9f25499a2c8cc367b3af45df2ea7eeca7fbccceab9c35079968f4b3652194be"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="${REPO_ROOT}/config/osv/osv-scanner.toml"
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 <directory|image:NAME>..." >&2
+    exit 2
+fi
+
+scanner="${RUNNER_TEMP:-/tmp}/osv-scanner-${OSV_SCANNER_VERSION}"
+if [ ! -x "$scanner" ]; then
+    curl -fsSL -o "$scanner" \
+        "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+    echo "${OSV_SCANNER_SHA256}  ${scanner}" | sha256sum --check -
+    chmod +x "$scanner"
+fi
+"$scanner" --version
+
+status=0
+for target in "$@"; do
+    echo "=== osv-scanner: ${target}"
+    case "$target" in
+        image:*)
+            # `scan image` reads the image's OS package database and the language artifacts
+            # inside it, which is the only way the JRE base layer gets looked at at all.
+            "$scanner" scan image --config "$CONFIG" "${target#image:}" || status=1
+            ;;
+        *)
+            # The `artifact` plugin is what reads a bare .jar (Maven coordinates from the
+            # embedded pom.properties); the default plugin set only understands lockfiles.
+            "$scanner" scan source --config "$CONFIG" \
+                --experimental-plugins artifact --no-ignore --recursive "$target" || status=1
+            ;;
+    esac
+done
+
+if [ "$status" -ne 0 ]; then
+    echo "::error::OSV found advisories that config/osv/osv-scanner.toml does not except." >&2
+fi
+exit "$status"

--- a/scripts/ci/report-test-counts.py
+++ b/scripts/ci/report-test-counts.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""report-test-counts — report what a test tier actually executed, and fail an empty run.
+
+The opt-in tiers select tests by tag (``-Pdeep``, ``-PonlyPerf``, the
+``-Dswath.it.sigkill=true`` ITs). A mis-typed property, a renamed tag, or a cached task
+result therefore produces an *empty* run, and an empty run reports green -- the failure
+mode the nightly deep job spent weeks in. This script turns "the tier executed nothing"
+into a red step, and prints the per-module counts the nightly log was missing.
+
+Self-contained (stdlib only) so the public CI has no external package dependency.
+The `.sh` wrapper CI invokes execs this file directly.
+
+Usage:
+    scripts/ci/report-test-counts.py --repo-root PATH <label> [module...]
+    scripts/ci/report-test-counts.sh <label> [module...]  (CI entry point)
+
+Exit codes: 0 = tests executed, 1 = nothing executed, 2 = script error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Where Gradle's XML test reports land, relative to a module directory. Gradle recreates
+# this directory when the module's `test` task executes, so its contents describe the most
+# recent execution rather than an accumulation across tiers.
+RESULTS_GLOB = "build/test-results/test/TEST-*.xml"
+
+
+class ModuleCounts:
+    """Per-module totals across every test suite the module reported."""
+
+    def __init__(self, module: str) -> None:
+        self.module = module
+        self.tests = 0
+        self.skipped = 0
+        self.failures = 0
+        self.errors = 0
+
+    @property
+    def executed(self) -> int:
+        """Tests that actually ran: JUnit counts a skipped test in ``tests`` too."""
+        return self.tests - self.skipped
+
+    def add(self, suite: ElementTree.Element) -> None:
+        self.tests += int(suite.get("tests", 0))
+        self.skipped += int(suite.get("skipped", 0))
+        self.failures += int(suite.get("failures", 0))
+        self.errors += int(suite.get("errors", 0))
+
+
+def collect(repo_root: Path, modules: list[str]) -> list[ModuleCounts]:
+    """Read every module's JUnit XML, in the module order given (or sorted, if none)."""
+    candidates = (
+        [repo_root / module for module in modules]
+        if modules
+        else sorted(path for path in repo_root.iterdir() if (path / "build/test-results/test").is_dir())
+    )
+    collected = []
+    for directory in candidates:
+        reports = sorted(directory.glob(RESULTS_GLOB))
+        if not reports:
+            continue
+        counts = ModuleCounts(directory.name)
+        for report in reports:
+            try:
+                counts.add(ElementTree.parse(report).getroot())
+            except ElementTree.ParseError as error:
+                raise SystemExit(f"error: unreadable test report {report}: {error}") from error
+        collected.append(counts)
+    return collected
+
+
+def report(label: str, collected: list[ModuleCounts]) -> str:
+    """Render the GitHub-flavoured summary table (also readable in a plain log)."""
+    lines = [f"### {label} — executed tests", "", "| module | executed | skipped | failed |", "| --- | --: | --: | --: |"]
+    for counts in collected:
+        failed = counts.failures + counts.errors
+        lines.append(f"| {counts.module} | {counts.executed} | {counts.skipped} | {failed} |")
+    total = sum(counts.executed for counts in collected)
+    lines.append(f"| **total** | **{total}** | | |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("label", help='what ran, e.g. "deep tier"')
+    parser.add_argument("modules", nargs="*", help="restrict to these modules (default: all with results)")
+    args = parser.parse_args()
+
+    collected = collect(args.repo_root, args.modules)
+    summary = report(args.label, collected)
+    print(summary)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+
+    if sum(counts.executed for counts in collected) == 0:
+        print(
+            f"::error::{args.label} executed no tests — the tag filter matched nothing, "
+            "or the task result was reused. A tier that runs nothing is not a passing tier.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/report-test-counts.sh
+++ b/scripts/ci/report-test-counts.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Reports how many tests a tier just executed, and fails if the answer is none.
+#
+# The opt-in tiers (`-Pdeep`, `-PonlyPerf`, the `-Dswath.it.sigkill=true` ITs) select their
+# tests by tag, so a mis-typed property or a tag that no longer matches anything yields an
+# empty run -- and an empty run is GREEN. That is not hypothetical: the nightly deep job
+# alternated 9 min and 2.4 min for weeks because Gradle served `:swath-core:test` FROM-CACHE,
+# and nothing in the log said the tier had executed zero tests. The conventions plugin now
+# stops the caching; this script is the assertion that the tier ran at all, so the next way
+# of arriving at an empty run is loud instead of silent.
+#
+# Counts come from the JUnit XML Gradle writes per module. Gradle recreates a module's
+# results directory when its `test` task executes, so a report taken immediately after a
+# tier's step describes that tier -- run this right after the step it is reporting on, not
+# at the end of the job.
+#
+# Usage: scripts/ci/report-test-counts.sh <label> [module...]
+#   label   what ran, e.g. "deep tier" -- used in the log and the job summary
+#   module  restrict to these module directories (default: every module that has results)
+# Exit codes: 0 = tests executed, 1 = nothing executed, 2 = script error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+exec python3 "${SCRIPT_DIR}/report-test-counts.py" --repo-root "${REPO_ROOT}" "$@"

--- a/swath-cli/build.gradle.kts
+++ b/swath-cli/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 
 // The `swath` binary: cli/* (App, ListCommand, ResumeCommand, ...),
 // wiring S3PageFetcher/S3ClientFactory from swath-s3 into picocli commands.
@@ -180,8 +181,18 @@ val verifyLegalArtifactContents by tasks.registering {
 
         // Assert actual text, not merely an arbitrary META-INF/NOTICE survivor. These
         // components exercise the Avro/Hadoop/AWS notice variants present in the CLI graph.
+        // Named by module, resolved to the shipped version: spelling the version here made a
+        // dependency bump fail this check for a reason that had nothing to do with legal text.
         val licenseReportDir = layout.buildDirectory.dir("reports/licenses").get().asFile
-        listOf("avro-1.9.2.jar", "hadoop-common-3.4.1.jar", "annotations-2.31.78.jar").forEach { artifact ->
+        val shippedVersions = configurations.runtimeClasspath.get().incoming.artifacts.artifacts
+            .mapNotNull { it.id.componentIdentifier as? ModuleComponentIdentifier }
+            .associate { it.module to it.version }
+        val noticeBearingModules = listOf("avro", "hadoop-common", "annotations")
+        noticeBearingModules.map { module ->
+            val version = shippedVersions[module]
+                ?: error("$module is no longer on the CLI runtime classpath; pick another notice sample")
+            "$module-$version.jar"
+        }.forEach { artifact ->
             val notice = licenseReportDir.resolve("$artifact/META-INF/NOTICE")
             val noticeTxt = licenseReportDir.resolve("$artifact/META-INF/NOTICE.txt")
             val source = listOf(notice, noticeTxt).firstOrNull { it.isFile }

--- a/swath-replay/THIRD_PARTY_NOTICES.md
+++ b/swath-replay/THIRD_PARTY_NOTICES.md
@@ -17,58 +17,46 @@ resources.
 
 ## Runtime dependency inventory
 
-- `ch.qos.logback:logback-classic:1.5.18` — Eclipse Public License 1.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
-- `ch.qos.logback:logback-core:1.5.18` — Eclipse Public License 1.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
+- `ch.qos.logback:logback-classic:1.5.38` — Eclipse Public License - v 2.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
+- `ch.qos.logback:logback-core:1.5.38` — Eclipse Public License - v 2.0; GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
 - `com.bucket4j:bucket4j-core:8.10.1` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-annotations:2.12.7` — Apache License, Version 2.0
 - `com.fasterxml.jackson.core:jackson-annotations:2.22` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-core:2.12.7` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-core:2.22.0` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-databind:2.12.7.1` — Apache License, Version 2.0
-- `com.fasterxml.jackson.core:jackson-databind:2.22.0` — Apache License, Version 2.0
+- `com.fasterxml.jackson.core:jackson-core:2.22.2` — Apache License, Version 2.0
+- `com.fasterxml.jackson.core:jackson-databind:2.22.2` — Apache License, Version 2.0
 - `com.fasterxml.woodstox:woodstox-core:5.4.0` — Apache License, Version 2.0
 - `com.github.luben:zstd-jni:1.5.6-9` — The 2-Clause BSD License
 - `com.google.code.findbugs:jsr305:3.0.2` — Apache License, Version 2.0
 - `com.google.code.gson:gson:2.9.0` — Apache License, Version 2.0
-- `com.google.guava:failureaccess:1.0` — Apache License, Version 2.0
-- `com.google.guava:guava:27.0-jre` — Apache License, Version 2.0
+- `com.google.guava:failureaccess:1.0.3` — Apache License, Version 2.0
+- `com.google.guava:guava:33.7.1-jre` — Apache License, Version 2.0
 - `com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava` — Apache License, Version 2.0
-- `com.google.j2objc:j2objc-annotations:1.1` — Apache License, Version 2.0
+- `com.google.j2objc:j2objc-annotations:3.1` — Apache License, Version 2.0
 - `com.google.protobuf:protobuf-java:4.34.0` — The 3-Clause BSD License
 - `com.google.re2j:re2j:1.1` — The Go license
-- `commons-beanutils:commons-beanutils:1.9.4` — Apache License, Version 2.0
+- `commons-beanutils:commons-beanutils:1.11.0` — Apache License, Version 2.0
 - `commons-cli:commons-cli:1.5.0` — Apache License, Version 2.0
-- `commons-codec:commons-codec:1.16.1` — Apache License, Version 2.0
+- `commons-codec:commons-codec:1.19.0` — Apache License, Version 2.0
 - `commons-collections:commons-collections:3.2.2` — Apache License, Version 2.0
-- `commons-io:commons-io:2.16.1` — Apache License, Version 2.0
-- `commons-logging:commons-logging:1.3.0` — Apache License, Version 2.0
+- `commons-io:commons-io:2.22.0` — Apache License, Version 2.0
+- `commons-logging:commons-logging:1.3.6` — Apache License, Version 2.0
 - `commons-net:commons-net:3.9.0` — Apache License, Version 2.0
 - `commons-pool:commons-pool:1.6` — Apache License, Version 2.0
 - `dnsjava:dnsjava:3.6.1` — The 3-Clause BSD License
 - `info.picocli:picocli:4.7.6` — Apache License, Version 2.0
-- `io.airlift:aircompressor:2.0.2` — Apache License, Version 2.0
+- `io.airlift:aircompressor:2.0.3` — Apache License, Version 2.0
 - `io.dropwizard.metrics:metrics-core:3.2.4` — Apache License, Version 2.0
 - `io.micrometer:micrometer-commons:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-core:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-observation:1.17.0` — Apache License, Version 2.0
 - `io.micrometer:micrometer-registry-otlp:1.17.0` — Apache License, Version 2.0
-- `io.netty:netty-buffer:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-codec:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-common:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-handler:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-resolver:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-classes-epoll:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-native-epoll:4.1.100.Final` — Apache License, Version 2.0
-- `io.netty:netty-transport-native-unix-common:4.1.100.Final` — Apache License, Version 2.0
 - `io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha` — Apache License, Version 2.0
 - `jakarta.activation:jakarta.activation-api:1.2.1` — Eclipse Public License - v 2.0; GNU GENERAL PUBLIC LICENSE, Version 2; GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception; The 3-Clause BSD License
 - `javax.annotation:javax.annotation-api:1.3.2` — CDDL + GPLv2 with classpath exception; Common Development and Distribution License 1.0
-- `org.apache.avro:avro:1.9.2` — Apache License, Version 2.0
-- `org.apache.commons:commons-compress:1.26.1` — Apache License, Version 2.0
-- `org.apache.commons:commons-configuration2:2.10.1` — Apache License, Version 2.0
-- `org.apache.commons:commons-lang3:3.14.0` — Apache License, Version 2.0
-- `org.apache.commons:commons-text:1.11.0` — Apache License, Version 2.0
+- `org.apache.avro:avro:1.11.5` — Apache License, Version 2.0
+- `org.apache.commons:commons-compress:1.28.0` — Apache License, Version 2.0
+- `org.apache.commons:commons-configuration2:2.15.1` — Apache License, Version 2.0
+- `org.apache.commons:commons-lang3:3.20.0` — Apache License, Version 2.0
+- `org.apache.commons:commons-text:1.15.0` — Apache License, Version 2.0
 - `org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.3.0` — Apache License, Version 2.0
 - `org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25:1.3.0` — Apache License, Version 2.0
 - `org.apache.hadoop:hadoop-annotations:3.4.1` — Apache License, Version 2.0
@@ -82,9 +70,7 @@ resources.
 - `org.apache.parquet:parquet-format-structures:1.15.1` — Apache License, Version 2.0
 - `org.apache.parquet:parquet-hadoop:1.15.1` — Apache License, Version 2.0
 - `org.apache.parquet:parquet-jackson:1.15.1` — Apache License, Version 2.0
-- `org.checkerframework:checker-qual:2.5.2` — MIT License
 - `org.codehaus.jettison:jettison:1.5.4` — Apache License, Version 2.0
-- `org.codehaus.mojo:animal-sniffer-annotations:1.17` — Apache License, Version 2.0; MIT License
 - `org.codehaus.woodstox:stax2-api:4.2.1` — Apache License, Version 2.0; The 2-Clause BSD License
 - `org.duckdb:duckdb_jdbc:1.5.4.0` — No license declared in resolved metadata; MIT License
 - `org.eclipse.jetty:jetty-http:12.1.10` — Apache License, Version 2.0; Eclipse Public License - v 2.0
@@ -92,7 +78,7 @@ resources.
 - `org.eclipse.jetty:jetty-server:12.1.10` — Apache License, Version 2.0; Eclipse Public License - v 2.0
 - `org.eclipse.jetty:jetty-util:12.1.10` — Apache License, Version 2.0; Eclipse Public License - v 2.0
 - `org.hdrhistogram:HdrHistogram:2.2.2` — Creative Commons Legal Code; PUBLIC DOMAIN; The 2-Clause BSD License
-- `org.jspecify:jspecify:1.0.0` — Apache License, Version 2.0
+- `org.jspecify:jspecify:1.0.1` — Apache License, Version 2.0
 - `org.slf4j:slf4j-api:2.0.17` — No license declared in resolved metadata; MIT License
 - `org.xerial.snappy:snappy-java:1.1.10.7` — Apache License, Version 2.0
 - `org.xerial:sqlite-jdbc:3.47.1.0` — Apache License, Version 2.0
@@ -167,26 +153,27 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
 
 ## Embedded upstream notice resources
 
-### avro-1.9.2.jar
+### avro-1.11.5.jar
 
 #### META-INF/NOTICE
 
 
     Apache Avro
-    Copyright 2009-2020 The Apache Software Foundation
+    Copyright 2009-2025 The Apache Software Foundation
+
 
     This product includes software developed at
     The Apache Software Foundation (http://www.apache.org/).
 
-### commons-beanutils-1.9.4.jar
+### commons-beanutils-1.11.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons BeanUtils
-    Copyright 2000-2019 The Apache Software Foundation
+    Copyright 2000-2025 The Apache Software Foundation
 
     This product includes software developed at
-    The Apache Software Foundation (http://www.apache.org/).
+    The Apache Software Foundation (https://www.apache.org/).
 
 ### commons-cli-1.5.0.jar
 
@@ -198,12 +185,12 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-codec-1.16.1.jar
+### commons-codec-1.19.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Codec
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -218,52 +205,52 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed by
     The Apache Software Foundation (http://www.apache.org/).
 
-### commons-compress-1.26.1.jar
+### commons-compress-1.28.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Compress
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-configuration2-2.10.1.jar
+### commons-configuration2-2.15.1.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Configuration
-    Copyright 2001-2024 The Apache Software Foundation
+    Copyright 2001-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-io-2.16.1.jar
+### commons-io-2.22.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons IO
-    Copyright 2002-2024 The Apache Software Foundation
+    Copyright 2002-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-lang3-3.14.0.jar
+### commons-lang3-3.20.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Lang
-    Copyright 2001-2023 The Apache Software Foundation
+    Copyright 2001-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
 
-### commons-logging-1.3.0.jar
+### commons-logging-1.3.6.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Logging
-    Copyright 2001-2023 The Apache Software Foundation
+    Copyright 2001-2026 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -288,12 +275,12 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     This product includes software developed by
     The Apache Software Foundation (http://www.apache.org/).
 
-### commons-text-1.11.0.jar
+### commons-text-1.15.0.jar
 
 #### META-INF/NOTICE.txt
 
     Apache Commons Text
-    Copyright 2014-2023 The Apache Software Foundation
+    Copyright 2014-2025 The Apache Software Foundation
 
     This product includes software developed at
     The Apache Software Foundation (https://www.apache.org/).
@@ -483,29 +470,7 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
     in some artifacts (usually source distributions); but is always available
     from the source code management (SCM) system project uses.
 
-### jackson-core-2.12.7.jar
-
-#### META-INF/NOTICE
-
-    # Jackson JSON processor
-
-    Jackson is a high-performance, Free/Open Source JSON processing library.
-    It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-    been in development since 2007.
-    It is currently developed by a community of developers.
-
-    ## Licensing
-
-    Jackson 2.x core and extension components are licensed under Apache License 2.0
-    To find the details that apply to this artifact see the accompanying LICENSE file.
-
-    ## Credits
-
-    A list of contributors may be found from CREDITS(-2.x) file, which is included
-    in some artifacts (usually source distributions); but is always available
-    from the source code management (SCM) system project uses.
-
-### jackson-core-2.22.0.jar
+### jackson-core-2.22.2.jar
 
 #### META-INF/NOTICE
 
@@ -552,29 +517,7 @@ Zstandard code. The wrapper's BSD 2-Clause terms and the native library's BSD
 
     See Schubfach-LICENSE.
 
-### jackson-databind-2.12.7.1.jar
-
-#### META-INF/NOTICE
-
-    # Jackson JSON processor
-
-    Jackson is a high-performance, Free/Open Source JSON processing library.
-    It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-    been in development since 2007.
-    It is currently developed by a community of developers.
-
-    ## Licensing
-
-    Jackson 2.x core and extension components are licensed under Apache License 2.0
-    To find the details that apply to this artifact see the accompanying LICENSE file.
-
-    ## Credits
-
-    A list of contributors may be found from CREDITS(-2.x) file, which is included
-    in some artifacts (usually source distributions); but is always available
-    from the source code management (SCM) system project uses.
-
-### jackson-databind-2.22.0.jar
+### jackson-databind-2.22.2.jar
 
 #### META-INF/NOTICE
 

--- a/swath-replay/build.gradle.kts
+++ b/swath-replay/build.gradle.kts
@@ -143,6 +143,17 @@ distributions {
             into("lib") {
                 from(conformanceJar)
                 from(configurations.named(conformanceSourceSet.runtimeClasspathConfigurationName))
+                // The application plugin already puts `runtimeClasspath` here, and the conformance
+                // closure is largely the same libraries, so the two overlap by design — `lib/` is
+                // their union, not their concatenation. Gradle resolves each configuration
+                // separately, so before the shipped-closure floors were pinned the overlap arrived
+                // as *different* versions under different names and both were copied: this
+                // directory carried jackson-{core,databind,annotations} at 2.12.7 AND 2.22 at once,
+                // with the start script's classpath order deciding which one won. Now the two
+                // closures agree, the overlap is the same file twice, and taking the first is
+                // correct. verifyNoDuplicateModuleVersions (swath.java-conventions) is what keeps
+                // a future divergence from silently going back to shipping both.
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             }
             into("bin") {
                 from(conformanceScriptsDir)


### PR DESCRIPTION
WP0.2 of the remediation programme. **Stacked on #153** — review that first; the base retargets to `main` automatically when #153 merges.

## What the shipped closure actually contained

An OSV scan of the CLI distribution reported **62 advisories across 16 packages, one a 9.8 RCE**. Almost none of it came from anything swath declares — it came from `hadoop-common` / `hadoop-mapreduce-client-core`, whose POMs name jackson 2.12, guava 27 and avro 1.9.2, and from netty.

## Netty: unused, and shipped broken

Netty arrived twice and was used neither time — Hadoop's IPC/HDFS paths (already excluded here for exactly this reason) and the AWS SDK's `netty-nio-client`, which exists to serve `S3AsyncClient`. No source in any module names an async client or a netty type; the S3 client is synchronous over `apache-client`.

It shipped eleven jars and **40 of the 62 advisories**, and it shipped them broken: `netty-transport-native-epoll` stayed at 4.1.100 beside `netty-transport-classes-epoll` at 4.1.118 — a native/classes version skew that would have failed at runtime had anything actually loaded epoll. The SDK's adapter jar is excluded alongside `io.netty` rather than left behind it, so no async provider ships half-present.

## The rest are constraints

Floors live in `gradle/libs.versions.toml`, so Dependabot maintains them like any other version. Constraints rather than `force`: a floor that still loses to anything legitimately needing newer, where `force` would silently pin a *future* dependency down to this line.

`commons-collections` 3.2.2 stays as hadoop resolves it — it is the release that removed the `InvokerTransformer` deserialization gadget, it is the last 3.x, and OSV reports nothing against it.

## Aligning the versions surfaced a second bug

The replay distribution packs its conformance launcher's closure into the same `lib/` as the main one. The two configurations resolved Jackson independently, so the directory shipped **two complete Jackson generations at once** — `jackson-core`, `-databind` and `-annotations` at both 2.12.7 and 2.22 — with nothing but start-script classpath order deciding which one ran. Nothing failed and nothing reported it.

The floors make the closures agree, so the overlap is now one file twice. `verifyNoDuplicateModuleVersions` (wired into `check`) asserts every application distribution ships at most one version of each module, so a future divergence cannot go back to shipping both.

## Result: 62 → 9

The nine remaining are one root cause. `parquet-jackson` is not a Jackson dependency; it is Parquet's own repackaging, relocated under `shaded/parquet/com/fasterxml/` inside the jar, where no constraint can reach it. Fixing it means upgrading Parquet, which participates in the written output and so needs its own change with a byte-comparison against the current writer.

They are **excepted, not muted**: `config/osv/osv-scanner.toml` carries each with its argument and an expiry date, and the scan fails on anything not listed. A nightly job scans both distributions and both runtime images.

| | before | after |
| --- | --- | --- |
| CLI distribution | 87 MB, 111 jars | 84 MB, 98 jars |
| replay distribution | 175 MB, 83 jars | 171 MB, 69 jars |
| OSV advisories | 62 (1 critical, 26 high) | 9 (0 critical, 3 high), all excepted |

## Also here

- **Gradle distribution checksum-pinned.** CI validated the wrapper jar, whose first act was to download an unverified archive.
- **The CLI's legal check names its sample artifacts by module** and resolves the shipped version, instead of spelling `avro-1.9.2.jar` and failing on an unrelated bump.
- **`dependency-analysis` is available as `./gradlew buildHealth`, deliberately not wired into `check`.** Its model wants every module to declare what it touches and expose as `api` what reaches its signatures; this build does the opposite on purpose — swath-core keeps parquet-hadoop and hadoop-common `implementation`-scoped so no consumer can import those types, a boundary swath-replay has its own task to enforce. As a gate the plugin would demand that boundary be undone. Its report is worth reading (~120 items, mostly ABI-strictness); acting on it is separate work.
- Per the decision on this WP, `gradle/verification-metadata.xml` is **not** included: Dependabot cannot regenerate it, so every dependency PR would land red until fixed by hand.

## Verification

`./gradlew build` (Docker-backed) green: 4164 tests, all 13 integration-test classes executed including the LocalStack S3 suites and the DuckDB Parquet readback, 0 failures. The deep container smoke passes on the built image — real S3 listing → Parquet write → 7 objects read back by DuckDB → resume no-op, which is the check designed to catch a dependency-exclusion regression in the shaded jar.

The replay *container* smoke could not run in the devcontainer: it curls the Docker host's published loopback port, unreachable from here. Verified environmental — the unchanged `ghcr.io/varveio/swath-replay:main` image fails identically. The replay server is covered in-process by `SwathRoundTripIT` and `OversizedPageRefusalIT` (10 tests, passing), and CI runs the container smoke on a real runner.