### PR TITLE
Spike: Avro OCF as the staging segment container (decision record; not for merge)

### DIFF
--- a/PR6B-SPIKE-EVIDENCE.md
+++ b/PR6B-SPIKE-EVIDENCE.md
@@ -4,6 +4,13 @@ Date: 2026-08-31. Branch/base: `spike/pr6b-avro-container` at `c5560c9` before
 this spike commit. This is measurement-only code in `swath-core`'s test source set; no
 production class or production-scoped dependency is changed.
 
+This corrected record incorporates the independent read-only gate at
+`../swath-notes/notes/reviews/2026-08-31-pr6b-spike-opus.md` and the hands-on
+re-measurement at
+`../swath-notes/notes/reviews/2026-08-31-pr6b-deepdive-opus.md`. The corrected
+measurements were made on `spike/pr6b-avro-deepdive`; this branch's spike code remains
+unchanged.
+
 ## Result
 
 The Avro OCF candidate works as a sequential container, but **sync-marker-only integrity
@@ -12,19 +19,32 @@ test flips one bit in an LZ4-packed payload: the custom PageRun frame rejects it
 CRC32C check, while OCF accepts the record and the Avro reader emits changed row data
 without an exception. OCF sync markers recover the next block's alignment, but they do
 not authenticate the damaged block and production cannot skip that block without losing
-rows.
+rows. The result was independently verified on four Avro read shapes. Adding the needed
+CRC32C costs about 0.8 ms over a 25.5 MB merge, or about 0.3%, but requires more custom
+format code.
 
 Against the owner's condition—choose **(b) if it removes more custom format code and
-improves debuggability**—the recommendation is **choose (a), the stripped custom frame,
-on the present evidence**. Relative to the brief's approximately 200-line post-PR-6a
-custom frame, the production-shaped portion of (b) is approximately 312 SLOC (about
-+112, before adding the checksum that the integrity result requires), so it does not
-remove more custom format code. Avro improves generic envelope inspection: official
-`avro-tools` shows the schema, codec, metadata, and record count, and sync positions are
-easy to enumerate. It does not interpret the opaque `PageBlock` payload or understand the
-custom seal convention without swath-specific code, while this base already has
-`dump-run`; therefore the observed debuggability gain is too narrow to satisfy the second
-half of the condition.
+improves debuggability**—the recommendation remains **choose (a), the stripped custom
+frame**. The decisive axes are integrity, LOC, and debuggability. Performance is
+explicitly not an argument for (a): warm Avro merge overhead is at most 5.8% for the
+spike-shaped reader and 1.6% for the production-shaped routing-first raw-block variant.
+
+The brief's approximately 200-SLOC post-PR-6a custom frame is an estimate, not a
+measurement; the mechanical count must wait for PR 6a. The Avro candidate is about 312
+production-shaped SLOC as spiked. Variants that reduce warm merge overhead to 1.6% are
+about 360–400 SLOC because their hand-written record decoder and OCF block walk are
+themselves custom format code, before the required CRC32C is added. On the available
+evidence, (b) does not remove more custom format code, and it fails that condition harder
+as it approaches performance parity. The post-PR-6a mechanical diff remains necessary to
+replace the estimated custom magnitude with a measured one.
+
+Avro improves generic envelope inspection: official `avro-tools` shows the schema,
+codec, metadata, and record count, and sync positions are easy to enumerate. It does not
+interpret the opaque `PageBlock` payload or understand the custom seal and checksum
+conventions without swath-specific code, while this base already has `dump-run`.
+Moreover, `avro-tools` 1.11.5 cannot run on JDK 25 because its Hadoop path adapter calls
+a removed JDK API; the official tool needs a different JDK than swath builds and ships
+on. The debuggability gain is therefore real but too narrow to satisfy the condition.
 
 ## Implemented candidate
 
@@ -41,7 +61,7 @@ The test-only OCF writer and reader use Avro 1.11.5 from the version catalog:
 - Successful close forces the file and parent directory, matching the custom writer's
   durability work.
 
-The harness is runnable with:
+The original harness is runnable with:
 
 ```bash
 ./gradlew :swath-core:pr6bSpike \
@@ -69,15 +89,18 @@ compression is `null`.
 The listing-cost case uses four prepacked 1,000-row pages per segment at 8 and 64
 simultaneously active segments. Retained heap is `(used heap after GC with N open
 writers - baseline after GC) / N`; it is a coarse HotSpot heap-delta measurement.
-Per-flush CPU and allocated bytes are summed from `ThreadMXBean` counters on the N worker
-threads and divided by N. Both full flush paths are warmed first. The payload column is
-the shared serialized `PageBlock` allocation; the remaining allocation identifies the
-container shape.
+Corrected retention measurements cover both just-opened writers and writers after one
+real page. Per-flush CPU and allocated bytes are summed from `ThreadMXBean` counters on
+the N worker threads and divided by N. Both full flush paths are warmed first. The
+payload column is the shared serialized `PageBlock` allocation; the remaining allocation
+identifies the container shape.
 
-Merge samples run in fresh child JVMs with `-Xms128m -Xmx2g`. The timed region includes a
-sequential projected-header pass over every segment, reopening the files, K=8 body decode,
-and `StreamingMerger` consumption into a count and key digest. RSS is Linux `VmHWM` from
-`/proc/self/status`. Samples are interleaved custom/Avro to reduce page-cache order bias.
+The original merge samples each ran once in a fresh child JVM with `-Xms128m -Xmx2g`.
+That protocol put cold Avro schema-parser and Jackson class initialization inside the
+timed region, so it measures one-shot child-JVM startup, not steady-state merge cost. The
+corrected merge protocol repeats the complete header-pass-plus-K=8-decode-and-merge path
+inside the same JVM and reports the third-run steady-state medians. Arm order was reversed
+in one round to check page-cache and ordering bias.
 
 Host: a KVM Google Cloud VM with 8 vCPUs (4 cores / 2 threads), Intel Xeon Platinum 8581C
 at 2.30 GHz, 15 GiB RAM, no swap, and ext4 local storage. The build uses Eclipse Temurin
@@ -86,40 +109,92 @@ not release performance claims.
 
 ## 1. Writer cost during listing
 
-Each flush writes 4,000 rows in four LZ4-packed pages. Heap figures below are bytes per
-retained open low-level writer; CPU and allocation are per completed, durable flush.
+Each flush writes 4,000 rows in four LZ4-packed pages. The original warmed flush
+measurements were:
 
-| Arm | Open segments | Heap/open (bytes) | CPU/flush (ms) | Allocated/flush (bytes) | Shared PageBlock bytes | Container allocation (bytes) |
-|---|---:|---:|---:|---:|---:|---:|
-| custom | 8 | 1,364 | 1.041 | 188,475 | 109,459 | 79,016 |
-| Avro OCF | 8 | 89,834 | 1.092 | 220,883 | 109,459 | 111,424 |
-| custom | 64 | 522 | 0.710 | 188,371 | 109,459 | 78,912 |
-| Avro OCF | 64 | 89,333 | 0.722 | 220,887 | 109,459 | 111,428 |
+| Arm | Open segments | CPU/flush (ms) | Allocated/flush (bytes) | Shared PageBlock bytes | Container allocation (bytes) |
+|---|---:|---:|---:|---:|---:|
+| custom | 8 | 1.041 | 188,475 | 109,459 | 79,016 |
+| Avro OCF | 8 | 1.092 | 220,883 | 109,459 | 111,424 |
+| custom | 64 | 0.710 | 188,371 | 109,459 | 78,912 |
+| Avro OCF | 64 | 0.722 | 220,887 | 109,459 | 111,428 |
 
-The stable allocation shape is one common serialized `byte[]` per page in both arms.
 Avro adds about 32.5 KiB per flush through `GenericRecord`, `ByteBuffer`, datum-encoder,
-and OCF block-buffer objects. Its open `DataFileWriter` retains about 87.5 KiB per segment
-versus the custom encoder's sub-2-KiB coarse heap delta; at 64 opens that is approximately
-5.45 MiB for Avro. CPU was close after warmup (Avro +4.9% at 8 and +1.7% at 64).
+and OCF block-buffer objects. CPU was close after warmup (Avro +4.9% at 8 and +1.7% at
+64). The custom flush also builds the extension PR 6a is expected to remove and performs
+page repack checks, so this comparison is conservative toward Avro.
+
+The original heap figures measured untuned, idle Avro writers and therefore did not
+describe the structural steady-state floor. The corrected retained-heap measurements are:
+
+| Shape | 8 open, just opened | 8 open, after 1 page | 64 open, just opened | 64 open, after 1 page |
+|---|---:|---:|---:|---:|
+| custom | 1,561 B | 570 B | 538 B | 539 B |
+| Avro, `syncInterval=64` | 10,055 B | 64,858 B | 9,998 B | 64,239 B |
+| Avro, `syncInterval=32768` | 50,902 B | 51,443 B | 50,879 B | 51,520 B |
+
+Tuning drops the idle Avro floor to about 10 KiB, but after one real page the best
+observed structural floor is about 51 KiB per open writer versus about 0.54 KiB custom:
+roughly 95×, or about 3.2 MiB at 64 opens. OCF must buffer a complete block before it can
+write the block-length prefix, so this floor is structural rather than tunable. The
+custom heap arm models a retained low-level encoder even though current production opens
+and closes that encoder within each flush; it is an Avro-shaped comparison, not a claim
+about current listing retention.
 
 ## 2. Torn-file and corruption behavior
 
 | Damage | Custom PageRun | Avro OCF + required seal |
 |---|---|---|
 | Truncate in header | Rejected on open | Rejected on open |
-| Truncate in first page block | Rejected because the trailer is absent/torn | OCF decode/header scan fails |
-| Truncate exactly after a complete page block | Rejected because the trailer is absent | OCF framing reaches clean EOF, then swath reader rejects `missing final SEAL record` |
+| Truncate in first page block | Rejected on open because the trailer is absent/torn | OCF decode/header scan fails |
+| Truncate exactly after a complete page block | Rejected at open because the trailer is absent, before any row is handed off | OCF reaches clean EOF and rejects only after reading every preceding record because the final `SEAL` is missing |
 | Damage first block, ask to resync from inside it | No resync convention; CRC rejects the page | `DataFileReader.sync` lands on the following `PAGE` block and exposes its expected min key |
 | One-bit mutation in LZ4 PageBlock payload | Per-record CRC32C mismatch before PageBlock handoff | OCF framing and seal remain valid; reader emits row data different from the original |
 
-Resync is useful for diagnosis and alignment discovery only. It cannot make a production
-listing complete after a damaged page, because continuing at the next marker creates an
-undetectable logical gap unless the run is abandoned and rebuilt.
+Both integrity findings were independently verified across four Avro read shapes: the
+spike's `GenericRecord` reader, raw-block iteration, routing-first raw-block iteration,
+and the seeking header pass. The seeking header pass is silent by construction because
+it skips the payload. Resync is useful for diagnosis and alignment discovery only. It
+cannot make a production listing complete after a damaged page, because continuing at
+the next marker creates an undetectable logical gap unless the run is abandoned and
+rebuilt.
+
+An explicit CRC32C over the exact serialized `PageBlock` bytes fixes payload integrity.
+Its measured cost was 0.809 ms over 1,000 page bodies totaling 25,465,371 bytes, about
+0.3% of a warm merge. It is cheap in CPU but adds a custom field, writer logic, reader
+verification, and corruption reporting. The custom body arm already performs this CRC
+verification for every record while no Avro arm verifies payload integrity, and the
+custom arm still wins the warm comparison; performance is conservative toward Avro in
+that respect.
 
 ## 3. Sequential header pass + K=8 decode/merge
 
 Every sample produced exactly 1,000,000 rows and digest
-`-5792676755096495795` in both arms.
+`-5792676755096495795` in all arms.
+
+The corrected steady-state medians are the third complete run in the same JVM:
+
+| Arm | Wall (ms) | Header (ms) | Body + merge (ms) | Peak RSS (KiB) | Difference vs custom |
+|---|---:|---:|---:|---:|---:|
+| custom | **273.8** | 5.39 | 267.9 | 258,088 | — |
+| Avro, spike shape | 289.7 | 10.68 | 277.3 | 275,244 | **+5.8%** |
+| Avro, raw-block reader | 282.4 | 8.74 | 271.1 | 254,940 | **+3.1%** |
+| Avro, routing-first raw-block reader (`avro-raw2`) | 278.2 | **2.89** | 273.4 | 265,636 | **+1.6%** |
+
+The routing-first schema places routing fields before the opaque page and uses the OCF
+block length to seek over the payload. Its 2.89 ms header pass is 1.9× faster than the
+custom frame's 5.39 ms pass, but it requires a hand-written OCF block walk. The spike
+shape instead streams all 25 MB because its payload precedes routing metadata; projection
+avoids decoding that payload but cannot avoid reading it.
+
+Performance is not a reason to reject Avro: warm overhead is 1.6–5.8%, and the custom arm
+performs the CRC32C work the Avro arms omit. Warm peak RSS does not support a general Avro
+penalty claim because the raw-block arm is slightly below custom while the other Avro
+shapes are above it.
+
+### Historical aside: what a one-shot child JVM measures
+
+The original fresh-JVM table is retained only to document the measurement artifact:
 
 | Sample | Arm | Wall (ms) | Peak RSS (KiB) |
 |---:|---|---:|---:|
@@ -132,10 +207,13 @@ Every sample produced exactly 1,000,000 rows and digest
 | median | custom | 663.416 | 263,968 |
 | median | Avro OCF | 1,043.019 | 245,960 |
 
-Avro's median wall time is 57.2% higher. `VmHWM` varied enough across fresh JVMs that it
-does not support an RSS penalty claim: Avro was higher in sample 1 and lower in samples 2
-and 3. The extra OCF reader/schema work is visible in wall time; output identity is pinned
-by count and digest.
+The apparent +57.2% is not a merge penalty. The first Avro schema parse in a fresh JVM
+takes 291–312 ms versus 0.27–0.39 ms warm; total fixed Avro bootstrap is about 342 ms
+versus about 6 ms custom. That approximately 336 ms difference explains essentially the
+entire cold gap. Nothing in production loads Avro today, so adoption would add roughly
+300 ms of startup latency once per process. Finalization occurs in the long-lived listing
+process after segment writes would already have loaded Avro, so that startup cost does
+not belong in merge throughput.
 
 ## 4. Bytes on disk
 
@@ -151,18 +229,27 @@ custom frame; against that relevant post-PR-6a shape, Avro costs 249,416 extra b
 
 ## 5. LOC and debuggability
 
-SLOC below means nonblank, noncomment Java source lines. The production projection removes
-the spike-only resync/inspector/layout-return bookkeeping but keeps schema, writer,
-projected header pass, reader, seal validation, metadata validation, and durability.
+SLOC means nonblank, noncomment Java source lines. The custom figure below is the spike
+brief's estimate; it has not been mechanically measured because PR 6a is not in this
+worktree. The Avro counts are measured or projected from working spike variants.
 
 | Item | SLOC | Treatment |
 |---|---:|---|
-| Post-PR-6a stripped custom frame | ~200 | Deletion opportunity stated in the spike brief; PR 6a is not in this worktree |
+| Post-PR-6a stripped custom frame | ~200 | Brief estimate; mechanical diff waits for PR 6a |
 | OCF candidate container, actual spike file | 365 | Writer, reader, seal, resync, inspector, helpers |
-| OCF production-shaped projection | ~312 | Added production custom integration code |
-| Net production format code vs owner's condition | **about +112** | 312 added minus about 200 deleted |
+| OCF production-shaped projection, spike reader | ~312 | Keeps schema, writer, projected pass, reader, seal, validation, and durability |
+| OCF production-shaped fast variants | ~360–400 | Adds hand-written record decode and OCF block walk; about 399 SLOC in the deep-dive subset |
 | OCF focused tests | 230 | Added test code |
 | Measurement harness | 501 | Spike-only; not production candidate |
+
+The earlier "+112 net SLOC" was not a valid measured comparison and is withdrawn. The
+approximately 312-SLOC spike projection already exceeds the estimated approximately
+200-SLOC custom target, and the variants that reach +1.6% warm overhead cost more because
+their decoder and block walk are custom format code. Production integration concerns and
+the required CRC32C add further Avro-side code. Thus the condition "removes more custom
+format code" still fails on the available evidence, and fails harder the faster Avro
+gets. The exact magnitude remains the one unmeasured part of the decision and must come
+from a mechanical diff against what PR 6a actually leaves.
 
 For context only, the current base's four format-owning files total 844 SLOC, but that is
 not a valid deletion claim: much of `PageRunSegmentIo` is logical routing/ordering
@@ -199,13 +286,16 @@ block 126 sync=3193923 records=1 kind=SEAL totalRecords=125 totalEntries=125000
 blocks=126 records=126
 ```
 
-The official tool clearly improves generic metadata and record-count inspection. Two
-limits matter: the packed page remains opaque bytes, and `SEAL` is a swath convention,
-not an OCF guarantee. In addition, Avro tools 1.11.5's Hadoop path adapter calls a JDK API
-removed in JDK 25, so the documented Gradle task runs the official tool on the installed
-JDK 21; the OCF writer/reader and all swath tests still compile and run on JDK 25.
+The official tool improves generic metadata and record-count inspection, but the packed
+page remains opaque bytes and `SEAL` and CRC32C are swath conventions rather than OCF
+guarantees. `avro-tools` 1.11.5 cannot run on the project's JDK 25 because its Hadoop path
+adapter calls a removed JDK API; the documented Gradle task requires the separately
+installed JDK 21. The OCF writer/reader and swath tests themselves still compile and run
+on JDK 25.
 
-## Validation
+## Validation provenance
+
+The original spike completed:
 
 - `./gradlew spotlessApply`
 - `./gradlew :swath-core:test --tests 'io.varve.swath.sort.AvroPageRunContainerTest'`
@@ -213,7 +303,11 @@ JDK 21; the OCF writer/reader and all swath tests still compile and run on JDK 2
 - `./gradlew :swath-core:pr6bAvroTools` and the `count` invocation shown above
 - `./gradlew build -PnoIntegration`
 
-All completed successfully on the host described above.
+The deep-dive correction completed in-JVM phase-split measurements across the original
+and production-shaped readers, writer-heap measurements before and after appending a
+page, a CRC32C cost probe, cold-bootstrap attribution, and integrity tests on all four
+Avro read shapes. Both reviews independently reproduced the disk bytes, row count,
+digest, integrity result, and the cold measurement shape.
 
 ## Integrity decision for (b)
 
@@ -226,11 +320,14 @@ Do not treat sync resync as permission to continue a production merge after corr
 ## What to remeasure after PR 6a lands
 
 The (a) arm here is the base branch's existing writer and still writes the trailer
-extension. After PR 6a lands, rerun the same harness against its final sequential writer
-and reader, specifically: bytes on disk without the 255,080-byte extension observed here;
-8/64-open retained heap; flush CPU/allocation; three header-pass-plus-merge wall/RSS
-samples; and the exact production SLOC deleted by choosing Avro. Replace the brief's
-approximately 200-line estimate with a mechanical diff against PR 6a before making the
-owner-condition decision. The torn-file tests should also be rerun, although removing an
-unused extension should not change the custom frame's header, record CRC, or sealed-tail
-behavior.
+extension. After PR 6a lands, rerun the harness against its final sequential writer and
+reader: bytes on disk without the 255,080-byte extension; 8/64-open retained heap before
+and after a real page; flush CPU/allocation; header-pass-plus-merge wall/RSS; and the
+exact production SLOC deleted by choosing Avro. Rerun the torn-file tests as well,
+although removing an unused extension should not change the custom frame's header,
+record CRC, or sealed-tail behavior.
+
+Merge measurements must use repeated runs inside one JVM, or an explicit warmup before
+the timed sample—never a one-shot child JVM. The mechanical LOC diff against what PR 6a
+actually leaves is the one unmeasured piece of the decision; replace the brief's
+approximately 200-line estimate with that result.

--- a/PR6B-SPIKE-EVIDENCE.md
+++ b/PR6B-SPIKE-EVIDENCE.md
@@ -1,0 +1,236 @@
+# PR 6b container decision spike evidence
+
+Date: 2026-08-31. Branch/base: `spike/pr6b-avro-container` at `c5560c9` before
+this spike commit. This is measurement-only code in `swath-core`'s test source set; no
+production class or production-scoped dependency is changed.
+
+## Result
+
+The Avro OCF candidate works as a sequential container, but **sync-marker-only integrity
+is not acceptable**. The current `PageBlock` bytes have no checksum of their own. A
+test flips one bit in an LZ4-packed payload: the custom PageRun frame rejects it at its
+CRC32C check, while OCF accepts the record and the Avro reader emits changed row data
+without an exception. OCF sync markers recover the next block's alignment, but they do
+not authenticate the damaged block and production cannot skip that block without losing
+rows.
+
+Against the owner's condition—choose **(b) if it removes more custom format code and
+improves debuggability**—the recommendation is **choose (a), the stripped custom frame,
+on the present evidence**. Relative to the brief's approximately 200-line post-PR-6a
+custom frame, the production-shaped portion of (b) is approximately 312 SLOC (about
++112, before adding the checksum that the integrity result requires), so it does not
+remove more custom format code. Avro improves generic envelope inspection: official
+`avro-tools` shows the schema, codec, metadata, and record count, and sync positions are
+easy to enumerate. It does not interpret the opaque `PageBlock` payload or understand the
+custom seal convention without swath-specific code, while this base already has
+`dump-run`; therefore the observed debuggability gain is too narrow to satisfy the second
+half of the condition.
+
+## Implemented candidate
+
+The test-only OCF writer and reader use Avro 1.11.5 from the version catalog:
+
+- OCF codec is `null`; each `PageBlock` remains packed once with swath's LZ4 codec.
+- Each `PAGE` record is forced into one OCF block with `sync()`.
+- A projected routing record duplicates min key, max key, count, and raw payload length,
+  so the benchmark can perform a header pass without materializing a `PageBlock` object.
+- A final `SEAL` record carries exact page count, entry count, and last key. The reader
+  requires it to be the last record and cross-checks it against every preceding page.
+- The reader also cross-checks duplicated routing metadata against the serialized
+  `PageBlock` header and enforces strictly disjoint, ascending OBJECTS page ranges.
+- Successful close forces the file and parent directory, matching the custom writer's
+  durability work.
+
+The harness is runnable with:
+
+```bash
+./gradlew :swath-core:pr6bSpike \
+  -PspikeArgs='measure build/pr6b-spike 1000000'
+```
+
+The focused correctness suite is:
+
+```bash
+./gradlew :swath-core:test \
+  --tests 'io.varve.swath.sort.AvroPageRunContainerTest'
+```
+
+## Protocol and hardware
+
+The large corpus has 1,000,000 sorted object rows split round-robin across K=8 sorted
+segments, so the output merge genuinely interleaves all inputs. Pages contain 1,000 rows.
+Keys are deterministic hierarchical paths averaging exactly 109 bytes; object sizes span
+512 bytes through approximately 64 MiB; timestamps, 32-hex-character etags, storage
+classes, owner IDs, and optional checksum fields are deterministic and realistic. Each
+page is packed once with `PageCodec.LZ4`, then the exact same `PageBlock` objects are sent
+to the existing listing `PageRunSegmentWriter.flush` and the OCF writer. Avro-level
+compression is `null`.
+
+The listing-cost case uses four prepacked 1,000-row pages per segment at 8 and 64
+simultaneously active segments. Retained heap is `(used heap after GC with N open
+writers - baseline after GC) / N`; it is a coarse HotSpot heap-delta measurement.
+Per-flush CPU and allocated bytes are summed from `ThreadMXBean` counters on the N worker
+threads and divided by N. Both full flush paths are warmed first. The payload column is
+the shared serialized `PageBlock` allocation; the remaining allocation identifies the
+container shape.
+
+Merge samples run in fresh child JVMs with `-Xms128m -Xmx2g`. The timed region includes a
+sequential projected-header pass over every segment, reopening the files, K=8 body decode,
+and `StreamingMerger` consumption into a count and key digest. RSS is Linux `VmHWM` from
+`/proc/self/status`. Samples are interleaved custom/Avro to reduce page-cache order bias.
+
+Host: a KVM Google Cloud VM with 8 vCPUs (4 cores / 2 threads), Intel Xeon Platinum 8581C
+at 2.30 GHz, 15 GiB RAM, no swap, and ext4 local storage. The build uses Eclipse Temurin
+JDK 25.0.4+7-LTS. The host was not CPU-isolated, so these are comparative observations,
+not release performance claims.
+
+## 1. Writer cost during listing
+
+Each flush writes 4,000 rows in four LZ4-packed pages. Heap figures below are bytes per
+retained open low-level writer; CPU and allocation are per completed, durable flush.
+
+| Arm | Open segments | Heap/open (bytes) | CPU/flush (ms) | Allocated/flush (bytes) | Shared PageBlock bytes | Container allocation (bytes) |
+|---|---:|---:|---:|---:|---:|---:|
+| custom | 8 | 1,364 | 1.041 | 188,475 | 109,459 | 79,016 |
+| Avro OCF | 8 | 89,834 | 1.092 | 220,883 | 109,459 | 111,424 |
+| custom | 64 | 522 | 0.710 | 188,371 | 109,459 | 78,912 |
+| Avro OCF | 64 | 89,333 | 0.722 | 220,887 | 109,459 | 111,428 |
+
+The stable allocation shape is one common serialized `byte[]` per page in both arms.
+Avro adds about 32.5 KiB per flush through `GenericRecord`, `ByteBuffer`, datum-encoder,
+and OCF block-buffer objects. Its open `DataFileWriter` retains about 87.5 KiB per segment
+versus the custom encoder's sub-2-KiB coarse heap delta; at 64 opens that is approximately
+5.45 MiB for Avro. CPU was close after warmup (Avro +4.9% at 8 and +1.7% at 64).
+
+## 2. Torn-file and corruption behavior
+
+| Damage | Custom PageRun | Avro OCF + required seal |
+|---|---|---|
+| Truncate in header | Rejected on open | Rejected on open |
+| Truncate in first page block | Rejected because the trailer is absent/torn | OCF decode/header scan fails |
+| Truncate exactly after a complete page block | Rejected because the trailer is absent | OCF framing reaches clean EOF, then swath reader rejects `missing final SEAL record` |
+| Damage first block, ask to resync from inside it | No resync convention; CRC rejects the page | `DataFileReader.sync` lands on the following `PAGE` block and exposes its expected min key |
+| One-bit mutation in LZ4 PageBlock payload | Per-record CRC32C mismatch before PageBlock handoff | OCF framing and seal remain valid; reader emits row data different from the original |
+
+Resync is useful for diagnosis and alignment discovery only. It cannot make a production
+listing complete after a damaged page, because continuing at the next marker creates an
+undetectable logical gap unless the run is abandoned and rebuilt.
+
+## 3. Sequential header pass + K=8 decode/merge
+
+Every sample produced exactly 1,000,000 rows and digest
+`-5792676755096495795` in both arms.
+
+| Sample | Arm | Wall (ms) | Peak RSS (KiB) |
+|---:|---|---:|---:|
+| 1 | custom | 647.405 | 263,404 |
+| 1 | Avro OCF | 935.880 | 274,516 |
+| 2 | custom | 695.367 | 265,788 |
+| 2 | Avro OCF | 1,043.019 | 245,960 |
+| 3 | custom | 663.416 | 263,968 |
+| 3 | Avro OCF | 1,084.080 | 243,784 |
+| median | custom | 663.416 | 263,968 |
+| median | Avro OCF | 1,043.019 | 245,960 |
+
+Avro's median wall time is 57.2% higher. `VmHWM` varied enough across fresh JVMs that it
+does not support an RSS penalty claim: Avro was higher in sample 1 and lower in samples 2
+and 3. The extra OCF reader/schema work is visible in wall time; output identity is pinned
+by count and digest.
+
+## 4. Bytes on disk
+
+| Arm | Bytes across 8 segments | Difference vs as-is custom |
+|---|---:|---:|
+| custom on this base | 25,730,651 | — |
+| Avro OCF | 25,724,987 | -5,664 (-0.022%) |
+
+The as-is custom files include 255,080 bytes of the listing trailer extension across the
+eight segments. Subtracting only that extension gives 25,475,571 bytes for the sequential
+custom frame; against that relevant post-PR-6a shape, Avro costs 249,416 extra bytes
+(+0.979%). This spike deliberately did not reimplement a stripped custom writer.
+
+## 5. LOC and debuggability
+
+SLOC below means nonblank, noncomment Java source lines. The production projection removes
+the spike-only resync/inspector/layout-return bookkeeping but keeps schema, writer,
+projected header pass, reader, seal validation, metadata validation, and durability.
+
+| Item | SLOC | Treatment |
+|---|---:|---|
+| Post-PR-6a stripped custom frame | ~200 | Deletion opportunity stated in the spike brief; PR 6a is not in this worktree |
+| OCF candidate container, actual spike file | 365 | Writer, reader, seal, resync, inspector, helpers |
+| OCF production-shaped projection | ~312 | Added production custom integration code |
+| Net production format code vs owner's condition | **about +112** | 312 added minus about 200 deleted |
+| OCF focused tests | 230 | Added test code |
+| Measurement harness | 501 | Spike-only; not production candidate |
+
+For context only, the current base's four format-owning files total 844 SLOC, but that is
+not a valid deletion claim: much of `PageRunSegmentIo` is logical routing/ordering
+validation that an Avro reader still needs, and PR 6a is expected to remove the seek/index
+surface independently.
+
+Official tool transcript (Avro tools is isolated from the benchmark classpath):
+
+```text
+$ ./gradlew :swath-core:pr6bAvroTools
+avro.schema    {"type":"record","name":"PageRunFrame",...}
+avro.codec     null
+swath.page-codec       lz4
+swath.format   swath-pageseg-avro-spike-v1
+
+$ ./gradlew :swath-core:pr6bAvroTools \
+    -PavroToolArgs='count build/pr6b-spike/avro-00.avro'
+126
+```
+
+That count is 125 one-record `PAGE` blocks plus one `SEAL` block. The spike inspector uses
+the Avro library's sync/block APIs to make the block convention visible:
+
+```text
+$ ./gradlew :swath-core:pr6bSpike \
+    -PspikeArgs='inspect build/pr6b-spike/avro-00.avro'
+metadata avro.codec=null
+metadata swath.format=swath-pageseg-avro-spike-v1
+metadata swath.page-codec=lz4
+block 1 sync=26067 records=1 kind=PAGE entries=1000 pageBytes=25252
+...
+block 125 sync=3193782 records=1 kind=PAGE entries=1000 pageBytes=25254
+block 126 sync=3193923 records=1 kind=SEAL totalRecords=125 totalEntries=125000
+blocks=126 records=126
+```
+
+The official tool clearly improves generic metadata and record-count inspection. Two
+limits matter: the packed page remains opaque bytes, and `SEAL` is a swath convention,
+not an OCF guarantee. In addition, Avro tools 1.11.5's Hadoop path adapter calls a JDK API
+removed in JDK 25, so the documented Gradle task runs the official tool on the installed
+JDK 21; the OCF writer/reader and all swath tests still compile and run on JDK 25.
+
+## Validation
+
+- `./gradlew spotlessApply`
+- `./gradlew :swath-core:test --tests 'io.varve.swath.sort.AvroPageRunContainerTest'`
+- `./gradlew :swath-core:pr6bSpike -PspikeArgs='measure build/pr6b-spike 1000000'`
+- `./gradlew :swath-core:pr6bAvroTools` and the `count` invocation shown above
+- `./gradlew build -PnoIntegration`
+
+All completed successfully on the host described above.
+
+## Integrity decision for (b)
+
+**Reject (b) as specified with sync-marker-only integrity.** If Avro is reconsidered, add
+an explicit CRC32C field over the exact serialized `PageBlock` bytes (or put an equivalent
+checksum inside `PageBlock`) and verify it before parsing or handing off the block. Keep
+the final seal for truncation/completeness; checksum and seal solve different failures.
+Do not treat sync resync as permission to continue a production merge after corruption.
+
+## What to remeasure after PR 6a lands
+
+The (a) arm here is the base branch's existing writer and still writes the trailer
+extension. After PR 6a lands, rerun the same harness against its final sequential writer
+and reader, specifically: bytes on disk without the 255,080-byte extension observed here;
+8/64-open retained heap; flush CPU/allocation; three header-pass-plus-merge wall/RSS
+samples; and the exact production SLOC deleted by choosing Avro. Replace the brief's
+approximately 200-line estimate with a mechanical diff against PR 6a before making the
+owner-condition decision. The torn-file tests should also be rerun, although removing an
+unused extension should not change the custom frame's header, record CRC, or sealed-tail
+behavior.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons
 # plugin) is what lets Dependabot raise the floors.
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
+avro-tools = { module = "org.apache.avro:avro-tools", version.ref = "avro" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonscompress" }
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commonsbeanutils" }
 commons-configuration2 = { module = "org.apache.commons:commons-configuration2", version.ref = "commonsconfiguration2" }

--- a/swath-core/build.gradle.kts
+++ b/swath-core/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
     alias(libs.plugins.jmh)
 }
 
+val pr6bAvroTools by configurations.creating
+
 // Hadoop ships as a cluster runtime, so it drags its whole service stack: an embedded Jetty web
 // server and Jersey REST layer for the NameNode/DataNode UIs, Guice servlet wiring, JSch for the
 // SFTP FileSystem, Kerby for Kerberos, and netty-all for HDFS transport. swath uses exactly one
@@ -110,6 +112,13 @@ dependencies {
     testImplementation(libs.logback.classic)
     testImplementation(libs.jqwik)
     testImplementation(libs.awaitility)
+    // PR 6b measurement spike: test-only OCF candidate; never enters the production closure.
+    testImplementation(libs.avro)
+    add(pr6bAvroTools.name, "org.apache.avro:avro-tools:${libs.versions.avro.get()}") {
+        // avro-tools 1.11.5 publishes stale test-classifier Trevni edges; getmeta needs neither.
+        exclude(group = "org.apache.avro", module = "trevni-avro")
+        exclude(group = "org.apache.avro", module = "trevni-core")
+    }
     // The export-path test needs the real OTLP wire types to read the exported counter value.
     testImplementation(libs.opentelemetry.proto)
     testRuntimeOnly(libs.junit.platform.launcher)
@@ -124,4 +133,34 @@ jmh {
     fork = 1
     failOnError = true
     // Benchmarks do NOT run during `./gradlew build` — invoke explicitly: ./gradlew :swath-core:jmh
+}
+
+// PR 6b is a disposable, test-source-set-only container measurement spike.
+tasks.register<JavaExec>("pr6bSpike") {
+    group = "verification"
+    description = "Runs the PR 6b Avro OCF versus PageRun container spike"
+    dependsOn(tasks.testClasses)
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass = "io.varve.swath.sort.PageRunContainerSpike"
+    maxHeapSize = "4g"
+    argumentProviders.add(CommandLineArgumentProvider {
+        providers.gradleProperty("spikeArgs").orElse("measure build/pr6b-spike 1000000")
+            .get().split(Regex("\\s+"))
+    })
+}
+
+tasks.register<JavaExec>("pr6bAvroTools") {
+    group = "verification"
+    description = "Runs official avro-tools against the PR 6b sample OCF"
+    classpath = pr6bAvroTools
+    mainClass = "org.apache.avro.tool.Main"
+    // Hadoop's path adapter in avro-tools 1.11.5 still calls Subject.getSubject, removed in JDK 25.
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    argumentProviders.add(CommandLineArgumentProvider {
+        providers.gradleProperty("avroToolArgs")
+            .orElse("getmeta build/pr6b-spike/avro-00.avro")
+            .get().split(Regex("\\s+"))
+    })
 }

--- a/swath-core/src/test/java/io/varve/swath/sort/AvroPageRunContainer.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/AvroPageRunContainer.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sort;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+
+/** Test-only Avro OCF candidate for the PR 6b container decision spike. */
+final class AvroPageRunContainer {
+
+    private static final String FORMAT = "swath-pageseg-avro-spike-v1";
+    private static final String FORMAT_META = "swath.format";
+    private static final String PAGE_CODEC_META = "swath.page-codec";
+    private static final String SCHEMA_JSON = """
+            {
+              "type":"record", "name":"PageRunFrame", "namespace":"io.varve.swath.spike",
+              "fields":[
+                {"name":"kind", "type":{"type":"enum", "name":"FrameKind",
+                  "symbols":["PAGE","SEAL"]}},
+                {"name":"page", "type":"bytes"},
+                {"name":"minKey", "type":"bytes"},
+                {"name":"maxKey", "type":"bytes"},
+                {"name":"count", "type":"int"},
+                {"name":"rawPayloadLength", "type":"int"},
+                {"name":"totalEntries", "type":"long"},
+                {"name":"totalRecords", "type":"long"},
+                {"name":"lastKey", "type":"bytes"}
+              ]
+            }
+            """;
+    private static final String HEADER_SCHEMA_JSON = """
+            {
+              "type":"record", "name":"PageRunFrame", "namespace":"io.varve.swath.spike",
+              "fields":[
+                {"name":"kind", "type":{"type":"enum", "name":"FrameKind",
+                  "symbols":["PAGE","SEAL"]}},
+                {"name":"minKey", "type":"bytes"},
+                {"name":"maxKey", "type":"bytes"},
+                {"name":"count", "type":"int"},
+                {"name":"rawPayloadLength", "type":"int"},
+                {"name":"totalEntries", "type":"long"},
+                {"name":"totalRecords", "type":"long"},
+                {"name":"lastKey", "type":"bytes"}
+              ]
+            }
+            """;
+
+    static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_JSON);
+    private static final Schema HEADER_SCHEMA = new Schema.Parser().parse(HEADER_SCHEMA_JSON);
+    private static final Schema KIND_SCHEMA = SCHEMA.getField("kind").schema();
+
+    private AvroPageRunContainer() {
+    }
+
+    static Writer openWriter(Path path, PageCodec pageCodec) throws IOException {
+        return new Writer(path, pageCodec);
+    }
+
+    static Reader openReader(Path path) throws IOException {
+        return new Reader(path);
+    }
+
+    static HeaderSummary scanHeaders(Path path) throws IOException {
+        long pages = 0;
+        long entries = 0;
+        byte[] previousMax = null;
+        boolean sealed = false;
+        try (DataFileReader<GenericRecord> file = openProjected(path)) {
+            while (file.hasNext()) {
+                GenericRecord frame = file.next();
+                String kind = frame.get("kind").toString();
+                if (kind.equals("PAGE")) {
+                    if (sealed) {
+                        throw corrupt(path, "PAGE follows SEAL");
+                    }
+                    byte[] min = bytes(frame, "minKey");
+                    byte[] max = bytes(frame, "maxKey");
+                    int count = (int) frame.get("count");
+                    int rawLength = (int) frame.get("rawPayloadLength");
+                    if (count <= 0 || rawLength <= 0
+                            || Arrays.compareUnsigned(min, max) > 0
+                            || previousMax != null
+                            && Arrays.compareUnsigned(previousMax, min) >= 0) {
+                        throw corrupt(path, "invalid projected PAGE metadata");
+                    }
+                    pages++;
+                    entries += count;
+                    previousMax = max;
+                } else if (kind.equals("SEAL")) {
+                    validateSeal(path, frame, pages, entries, previousMax);
+                    sealed = true;
+                    if (file.hasNext()) {
+                        throw corrupt(path, "SEAL is not the last OCF record");
+                    }
+                } else {
+                    throw corrupt(path, "unknown frame kind " + kind);
+                }
+            }
+        } catch (EOFException e) {
+            throw corrupt(path, "truncated OCF", e);
+        }
+        if (!sealed) {
+            throw corrupt(path, "missing final SEAL record");
+        }
+        return new HeaderSummary(pages, entries);
+    }
+
+    static ResyncResult resync(Path path, long damagedOffset) throws IOException {
+        try (DataFileReader<GenericRecord> file = openFull(path)) {
+            file.sync(damagedOffset);
+            long alignedAt = file.previousSync();
+            if (!file.hasNext()) {
+                throw corrupt(path, "no block after resync offset " + damagedOffset);
+            }
+            GenericRecord frame = file.next();
+            return new ResyncResult(alignedAt, frame.get("kind").toString(),
+                    bytes(frame, "minKey"));
+        }
+    }
+
+    static String inspect(Path path) throws IOException {
+        StringBuilder out = new StringBuilder();
+        try (DataFileReader<GenericRecord> file = openFull(path)) {
+            List<String> keys = new ArrayList<>(file.getMetaKeys());
+            keys.sort(Comparator.naturalOrder());
+            out.append("file=").append(path).append('\n');
+            for (String key : keys) {
+                byte[] value = file.getMeta(key);
+                out.append("metadata ").append(key).append('=');
+                if (key.equals("avro.schema")) {
+                    out.append("<schema, ").append(value.length).append(" bytes>");
+                } else {
+                    out.append(new String(value, java.nio.charset.StandardCharsets.UTF_8));
+                }
+                out.append('\n');
+            }
+            int block = 0;
+            while (file.hasNext()) {
+                GenericRecord frame = file.next();
+                block++;
+                out.append("block ").append(block)
+                        .append(" sync=").append(file.previousSync())
+                        .append(" records=1 kind=").append(frame.get("kind"));
+                if (frame.get("kind").toString().equals("PAGE")) {
+                    out.append(" entries=").append(frame.get("count"))
+                            .append(" pageBytes=").append(bytes(frame, "page").length);
+                } else {
+                    out.append(" totalRecords=").append(frame.get("totalRecords"))
+                            .append(" totalEntries=").append(frame.get("totalEntries"));
+                }
+                out.append('\n');
+            }
+            out.append("blocks=").append(block).append(" records=").append(block).append('\n');
+        }
+        return out.toString();
+    }
+
+    private static DataFileReader<GenericRecord> openFull(Path path) throws IOException {
+        DataFileReader<GenericRecord> file = new DataFileReader<>(
+                path.toFile(), new GenericDatumReader<>(SCHEMA));
+        try {
+            validateMetadata(path, file);
+            return file;
+        } catch (IOException | RuntimeException failure) {
+            file.close();
+            throw failure;
+        }
+    }
+
+    private static DataFileReader<GenericRecord> openProjected(Path path) throws IOException {
+        DataFileReader<GenericRecord> file = new DataFileReader<>(path.toFile(),
+                new GenericDatumReader<>(SCHEMA, HEADER_SCHEMA));
+        try {
+            validateMetadata(path, file);
+            return file;
+        } catch (IOException | RuntimeException failure) {
+            file.close();
+            throw failure;
+        }
+    }
+
+    private static void validateMetadata(Path path, DataFileReader<GenericRecord> file)
+            throws IOException {
+        if (!FORMAT.equals(file.getMetaString(FORMAT_META))) {
+            throw corrupt(path, "missing or unsupported " + FORMAT_META);
+        }
+        if (!"null".equals(file.getMetaString("avro.codec"))) {
+            throw corrupt(path, "Avro codec must be null");
+        }
+    }
+
+    private static void validateSeal(Path path, GenericRecord frame, long pages, long entries,
+            byte[] previousMax) throws IOException {
+        long declaredPages = (long) frame.get("totalRecords");
+        long declaredEntries = (long) frame.get("totalEntries");
+        byte[] lastKey = bytes(frame, "lastKey");
+        if (declaredPages != pages || declaredEntries != entries
+                || !Arrays.equals(lastKey, previousMax == null ? new byte[0] : previousMax)) {
+            throw corrupt(path, "SEAL totals or last key do not match preceding PAGE records");
+        }
+    }
+
+    private static byte[] bytes(GenericRecord record, String field) {
+        ByteBuffer source = ((ByteBuffer) record.get(field)).duplicate();
+        byte[] bytes = new byte[source.remaining()];
+        source.get(bytes);
+        return bytes;
+    }
+
+    private static IOException corrupt(Path path, String message) {
+        return new IOException("Avro page-run segment " + path + ": " + message);
+    }
+
+    private static IOException corrupt(Path path, String message, Throwable cause) {
+        return new IOException("Avro page-run segment " + path + ": " + message, cause);
+    }
+
+    record WriteResult(long headerEnd, List<Long> pageBoundaries, long sealBoundary) {
+    }
+
+    record HeaderSummary(long pages, long entries) {
+    }
+
+    record ResyncResult(long alignedAt, String kind, byte[] minKey) {
+    }
+
+    static final class Writer implements Closeable {
+
+        private final Path path;
+        private final DataFileWriter<GenericRecord> file;
+        private final List<Long> pageBoundaries = new ArrayList<>();
+        private final long headerEnd;
+        private long totalEntries;
+        private long totalRecords;
+        private byte[] lastKey = new byte[0];
+        private boolean sealed;
+
+        Writer(Path path, PageCodec pageCodec) throws IOException {
+            this.path = Objects.requireNonNull(path, "path");
+            this.file = new DataFileWriter<>(new GenericDatumWriter<>(SCHEMA));
+            file.setCodec(CodecFactory.nullCodec());
+            file.setMeta(FORMAT_META, FORMAT);
+            file.setMeta(PAGE_CODEC_META, pageCodec.name().toLowerCase(java.util.Locale.ROOT));
+            try {
+                file.create(SCHEMA, path.toFile());
+                headerEnd = file.sync();
+            } catch (IOException | RuntimeException failure) {
+                file.close();
+                throw failure;
+            }
+        }
+
+        void append(PageBlock page) throws IOException {
+            requireOpen();
+            byte[] body = page.serialize();
+            PageBlockCodec.Header header = PageBlockCodec.parseHeader(body);
+            GenericRecord frame = baseFrame("PAGE");
+            frame.put("page", ByteBuffer.wrap(body));
+            frame.put("minKey", ByteBuffer.wrap(header.minKey()));
+            frame.put("maxKey", ByteBuffer.wrap(header.maxKey()));
+            frame.put("count", header.count());
+            frame.put("rawPayloadLength", header.rawPayloadLength());
+            file.append(frame);
+            pageBoundaries.add(file.sync());
+            totalRecords++;
+            totalEntries += header.count();
+            lastKey = header.maxKey();
+        }
+
+        WriteResult seal() throws IOException {
+            requireOpen();
+            GenericRecord frame = baseFrame("SEAL");
+            frame.put("totalEntries", totalEntries);
+            frame.put("totalRecords", totalRecords);
+            frame.put("lastKey", ByteBuffer.wrap(lastKey));
+            file.append(frame);
+            long sealBoundary = file.sync();
+            file.close();
+            sealed = true;
+            force(path);
+            return new WriteResult(headerEnd, List.copyOf(pageBoundaries), sealBoundary);
+        }
+
+        private GenericRecord baseFrame(String kind) {
+            GenericRecord frame = new GenericData.Record(SCHEMA);
+            frame.put("kind", new GenericData.EnumSymbol(KIND_SCHEMA, kind));
+            frame.put("page", ByteBuffer.wrap(new byte[0]));
+            frame.put("minKey", ByteBuffer.wrap(new byte[0]));
+            frame.put("maxKey", ByteBuffer.wrap(new byte[0]));
+            frame.put("count", 0);
+            frame.put("rawPayloadLength", 0);
+            frame.put("totalEntries", -1L);
+            frame.put("totalRecords", -1L);
+            frame.put("lastKey", ByteBuffer.wrap(new byte[0]));
+            return frame;
+        }
+
+        private void requireOpen() {
+            if (sealed) {
+                throw new IllegalStateException("Avro page-run writer is sealed");
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!sealed) {
+                file.close();
+                sealed = true;
+            }
+        }
+    }
+
+    static final class Reader implements Closeable {
+
+        private final Path path;
+        private final DataFileReader<GenericRecord> file;
+        private long pages;
+        private long entries;
+        private byte[] previousMax;
+        private boolean done;
+
+        Reader(Path path) throws IOException {
+            this.path = path;
+            this.file = openFull(path);
+        }
+
+        PageBlock nextPage() throws IOException {
+            if (done) {
+                return null;
+            }
+            if (!file.hasNext()) {
+                throw corrupt(path, "missing final SEAL record");
+            }
+            GenericRecord frame = file.next();
+            String kind = frame.get("kind").toString();
+            if (kind.equals("SEAL")) {
+                validateSeal(path, frame, pages, entries, previousMax);
+                if (file.hasNext()) {
+                    throw corrupt(path, "SEAL is not the last OCF record");
+                }
+                done = true;
+                return null;
+            }
+            if (!kind.equals("PAGE")) {
+                throw corrupt(path, "unknown frame kind " + kind);
+            }
+            byte[] body = bytes(frame, "page");
+            PageBlockCodec.Header header;
+            try {
+                header = PageRunSegmentIo.parsePageHeader(body);
+            } catch (IllegalArgumentException failure) {
+                throw corrupt(path, "malformed PageBlock", failure);
+            }
+            if (!Arrays.equals(header.minKey(), bytes(frame, "minKey"))
+                    || !Arrays.equals(header.maxKey(), bytes(frame, "maxKey"))
+                    || header.count() != (int) frame.get("count")
+                    || header.rawPayloadLength() != (int) frame.get("rawPayloadLength")) {
+                throw corrupt(path, "PageBlock metadata disagrees with OCF record metadata");
+            }
+            if (previousMax != null
+                    && Arrays.compareUnsigned(previousMax, header.minKey()) >= 0) {
+                throw corrupt(path, "PAGE ranges overlap or regress");
+            }
+            pages++;
+            entries += header.count();
+            previousMax = header.maxKey();
+            return PageBlockCodec.deserialize(body, header, path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            file.close();
+        }
+    }
+
+    private static void force(Path path) throws IOException {
+        try (FileChannel file = FileChannel.open(path, StandardOpenOption.WRITE)) {
+            file.force(true);
+        }
+        try (FileChannel directory = FileChannel.open(path.getParent(), StandardOpenOption.READ)) {
+            directory.force(true);
+        }
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/sort/AvroPageRunContainerTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/AvroPageRunContainerTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.varve.swath.model.KeyBytes;
+import io.varve.swath.model.ListEntry;
+import io.varve.swath.model.ObjectEntry;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AvroPageRunContainerTest {
+
+    private static final ListEntryComparator CMP = new ListEntryComparator();
+
+    @Test
+    void roundTripsPagesAndRequiresExactSeal(@TempDir Path dir) throws IOException {
+        List<PageBlock> pages = pages(3, 4, PageCodec.LZ4);
+        Path path = dir.resolve("roundtrip.avro");
+        writeAvro(path, pages, PageCodec.LZ4);
+
+        List<ListEntry> decoded = new ArrayList<>();
+        try (AvroPageRunContainer.Reader reader = AvroPageRunContainer.openReader(path)) {
+            PageBlock page;
+            while ((page = reader.nextPage()) != null) {
+                PageBlockCursor cursor = page.cursor();
+                while (cursor.hasNext()) {
+                    decoded.add(cursor.next());
+                }
+            }
+        }
+
+        assertThat(decoded).hasSize(12);
+        assertThat(decoded.getFirst().key().asString()).isEqualTo(key(0));
+        assertThat(decoded.getLast().key().asString()).isEqualTo(key(11));
+        assertThat(AvroPageRunContainer.scanHeaders(path))
+                .isEqualTo(new AvroPageRunContainer.HeaderSummary(3, 12));
+        assertThat(AvroPageRunContainer.inspect(path))
+                .contains("avro.codec=null", "kind=SEAL", "blocks=4 records=4");
+    }
+
+    @Test
+    void bothArmsRejectMidHeaderMidBlockAndBlockBoundaryTruncation(@TempDir Path dir)
+            throws IOException {
+        List<PageBlock> pages = pages(3, 5, PageCodec.NONE);
+        Path custom = dir.resolve("complete.pageseg");
+        writeCustom(custom, pages);
+        Path avro = dir.resolve("complete.avro");
+        AvroPageRunContainer.WriteResult avroLayout = writeAvro(avro, pages, PageCodec.NONE);
+
+        byte[] customBytes = Files.readAllBytes(custom);
+        int firstCustomLength = ByteBuffer.wrap(customBytes, PageRunSegmentWriter.HEADER_BYTES, 4)
+                .getInt();
+        int customBoundary = PageRunSegmentWriter.HEADER_BYTES + 8 + firstCustomLength;
+        byte[] avroBytes = Files.readAllBytes(avro);
+        long avroBoundary = avroLayout.pageBoundaries().getFirst();
+
+        Path customMidHeader = writePrefix(dir.resolve("custom-mid-header"), customBytes,
+                PageRunSegmentWriter.HEADER_BYTES / 2);
+        Path avroMidHeader = writePrefix(dir.resolve("avro-mid-header"), avroBytes,
+                avroLayout.headerEnd() / 2);
+        assertThatThrownBy(() -> PageRunSegmentIo.open(customMidHeader, SortMetrics.NO_OP))
+                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> AvroPageRunContainer.openReader(avroMidHeader))
+                .isInstanceOf(IOException.class);
+
+        Path customMidBlock = writePrefix(dir.resolve("custom-mid-block"), customBytes,
+                PageRunSegmentWriter.HEADER_BYTES + 8L + firstCustomLength / 2L);
+        Path avroMidBlock = writePrefix(dir.resolve("avro-mid-block"), avroBytes,
+                avroLayout.headerEnd() + (avroBoundary - avroLayout.headerEnd()) / 2);
+        assertThatThrownBy(() -> PageRunSegmentIo.open(customMidBlock, SortMetrics.NO_OP))
+                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> AvroPageRunContainer.scanHeaders(avroMidBlock))
+                .isInstanceOf(IOException.class);
+
+        Path customAtBoundary = writePrefix(dir.resolve("custom-at-boundary"), customBytes,
+                customBoundary);
+        Path avroAtBoundary = writePrefix(dir.resolve("avro-at-boundary"), avroBytes,
+                avroBoundary);
+        assertThatThrownBy(() -> PageRunSegmentIo.open(customAtBoundary, SortMetrics.NO_OP))
+                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> AvroPageRunContainer.scanHeaders(avroAtBoundary))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("missing final SEAL");
+    }
+
+    @Test
+    void avroSyncMarkerRecoversAlignmentAfterDamagedBlock(@TempDir Path dir) throws IOException {
+        List<PageBlock> pages = pages(3, 3, PageCodec.NONE);
+        byte[] firstBody = pages.getFirst().serialize();
+        Path path = dir.resolve("resync.avro");
+        writeAvro(path, pages, PageCodec.NONE);
+        byte[] bytes = Files.readAllBytes(path);
+        int bodyOffset = indexOf(bytes, firstBody);
+        assertThat(bodyOffset).isPositive();
+        bytes[bodyOffset + 4] ^= 0x40;
+        Files.write(path, bytes);
+
+        assertThatThrownBy(() -> drainAvro(path)).isInstanceOf(IOException.class);
+
+        AvroPageRunContainer.ResyncResult recovered =
+                AvroPageRunContainer.resync(path, bodyOffset + firstBody.length / 2L);
+        assertThat(recovered.kind()).isEqualTo("PAGE");
+        assertThat(recovered.minKey()).containsExactly(pages.get(1).firstKey());
+    }
+
+    @Test
+    void syncOnlyAvroSilentlyAcceptsLz4PayloadBitFlipThatCustomCrcRejects(@TempDir Path dir)
+            throws IOException {
+        List<PageBlock> pages = pages(1, 20, PageCodec.LZ4);
+        PageBlock page = pages.getFirst();
+        byte[] body = page.serialize();
+        PageBlockCodec.Header header = PageBlockCodec.parseHeader(body);
+        List<ListEntry> original = drainPage(page);
+        SilentMutation mutation = findSilentMutation(body, header);
+
+        Path custom = dir.resolve("bitflip.pageseg");
+        writeCustom(custom, pages);
+        byte[] customBytes = Files.readAllBytes(custom);
+        customBytes[PageRunSegmentWriter.HEADER_BYTES + 8 + mutation.offset()] ^=
+                mutation.mask();
+        Files.write(custom, customBytes);
+        try (PageRunSegmentIo io = PageRunSegmentIo.open(custom, SortMetrics.NO_OP)) {
+            assertThatThrownBy(io::nextPage)
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("CRC32C mismatch");
+        }
+
+        Path avro = dir.resolve("bitflip.avro");
+        writeAvro(avro, pages, PageCodec.LZ4);
+        byte[] avroBytes = Files.readAllBytes(avro);
+        int avroBodyOffset = indexOf(avroBytes, body);
+        assertThat(avroBodyOffset).isPositive();
+        avroBytes[avroBodyOffset + mutation.offset()] ^= mutation.mask();
+        Files.write(avro, avroBytes);
+
+        List<ListEntry> corrupted;
+        try (AvroPageRunContainer.Reader reader = AvroPageRunContainer.openReader(avro)) {
+            corrupted = drainPage(reader.nextPage());
+            assertThat(reader.nextPage()).isNull();
+        }
+        assertThat(corrupted).isEqualTo(mutation.decoded()).isNotEqualTo(original);
+    }
+
+    private static List<ListEntry> drainAvro(Path path) throws IOException {
+        List<ListEntry> entries = new ArrayList<>();
+        try (AvroPageRunContainer.Reader reader = AvroPageRunContainer.openReader(path)) {
+            PageBlock page;
+            while ((page = reader.nextPage()) != null) {
+                PageBlockCursor cursor = page.cursor();
+                while (cursor.hasNext()) {
+                    entries.add(cursor.next());
+                }
+            }
+        }
+        return entries;
+    }
+
+    private static AvroPageRunContainer.WriteResult writeAvro(
+            Path path, List<PageBlock> pages, PageCodec codec) throws IOException {
+        try (AvroPageRunContainer.Writer writer = AvroPageRunContainer.openWriter(path, codec)) {
+            for (PageBlock page : pages) {
+                writer.append(page);
+            }
+            return writer.seal();
+        }
+    }
+
+    private static void writeCustom(Path path, List<PageBlock> pages) throws IOException {
+        try (PageRunSegmentEncoder writer = PageRunSegmentEncoder.open(
+                path, SortMetrics.NO_OP, null, SortMode.OBJECTS)) {
+            for (PageBlock page : pages) {
+                writer.append(page);
+            }
+            writer.finish(SegmentKind.CASCADE_INTERMEDIATE);
+        }
+    }
+
+    private static List<PageBlock> pages(int pageCount, int rowsPerPage, PageCodec codec) {
+        List<PageBlock> pages = new ArrayList<>();
+        for (int page = 0; page < pageCount; page++) {
+            List<ListEntry> rows = new ArrayList<>();
+            for (int row = 0; row < rowsPerPage; row++) {
+                int ordinal = page * rowsPerPage + row;
+                rows.add(object(ordinal));
+            }
+            pages.add(PageBlock.pack(rows, CMP, codec));
+        }
+        return pages;
+    }
+
+    private static ObjectEntry object(int ordinal) {
+        return new ObjectEntry(KeyBytes.ofUtf8(key(ordinal)), 4096L + ordinal,
+                1_788_131_200_000_000L + ordinal, String.format("%032x", ordinal),
+                "STANDARD", null, false, "owner-0001", null, "SHA256", "FULL_OBJECT");
+    }
+
+    private static String key(int ordinal) {
+        return String.format("tenant=0042/region=us-east-1/year=2026/month=08/day=31/"
+                + "hour=12/partition=0017/object-%012d.dat", ordinal);
+    }
+
+    private static Path writePrefix(Path target, byte[] source, long length) throws IOException {
+        Files.write(target, Arrays.copyOf(source, Math.toIntExact(length)));
+        return target;
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        outer:
+        for (int i = 0; i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static List<ListEntry> drainPage(PageBlock page) {
+        List<ListEntry> entries = new ArrayList<>();
+        PageBlockCursor cursor = page.cursor();
+        while (cursor.hasNext()) {
+            entries.add(cursor.next());
+        }
+        return entries;
+    }
+
+    private static SilentMutation findSilentMutation(
+            byte[] original, PageBlockCodec.Header header) {
+        List<ListEntry> expected = drainPage(PageBlock.deserialize(original.clone()));
+        int end = header.payloadOffset() + header.payloadLength();
+        for (int offset = header.payloadOffset(); offset < end; offset++) {
+            for (int bit = 0; bit < Byte.SIZE; bit++) {
+                byte mask = (byte) (1 << bit);
+                byte[] candidate = original.clone();
+                candidate[offset] ^= mask;
+                try {
+                    List<ListEntry> decoded = drainPage(PageBlock.deserialize(candidate));
+                    if (!decoded.equals(expected)) {
+                        return new SilentMutation(offset, mask, decoded);
+                    }
+                } catch (RuntimeException rejected) {
+                    // This mutation was structurally noticed; keep searching for a silent one.
+                }
+            }
+        }
+        throw new AssertionError("no silently accepted LZ4 payload mutation found");
+    }
+
+    private record SilentMutation(int offset, byte mask, List<ListEntry> decoded) {
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/sort/PageRunContainerSpike.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/PageRunContainerSpike.java
@@ -1,0 +1,563 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sort;
+
+import com.sun.management.ThreadMXBean;
+import io.varve.swath.model.KeyBytes;
+import io.varve.swath.model.ListEntry;
+import io.varve.swath.model.ObjectEntry;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/** Runnable measurement harness for the PR 6b container decision spike. */
+public final class PageRunContainerSpike {
+
+    private static final int SEGMENTS = 8;
+    private static final int PAGE_ROWS = 1000;
+    private static final int WRITER_PAGES = 4;
+    private static final ListEntryComparator CMP = new ListEntryComparator();
+    private static final ThreadMXBean THREADS =
+            (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    private PageRunContainerSpike() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            throw new IllegalArgumentException("usage: measure <dir> [rows] | merge <arm> <dir> <rows> | inspect <file>");
+        }
+        switch (args[0]) {
+            case "measure" -> measure(Path.of(args[1]),
+                    args.length > 2 ? Integer.parseInt(args[2]) : 1_000_000);
+            case "merge" -> mergeChild(Arm.valueOf(args[1].toUpperCase(Locale.ROOT)),
+                    Path.of(args[2]), Integer.parseInt(args[3]));
+            case "inspect" -> System.out.print(AvroPageRunContainer.inspect(Path.of(args[1])));
+            default -> throw new IllegalArgumentException("unknown mode " + args[0]);
+        }
+    }
+
+    private static void measure(Path directory, int rows) throws Exception {
+        if (rows <= 0 || rows % (SEGMENTS * PAGE_ROWS) != 0) {
+            throw new IllegalArgumentException("rows must be positive and divisible by "
+                    + (SEGMENTS * PAGE_ROWS));
+        }
+        Files.createDirectories(directory);
+        warmContainerClasses(directory);
+        System.out.printf(Locale.ROOT,
+                "PROTOCOL rows=%d segments=%d rowsPerPage=%d pageCodec=LZ4 avroCodec=null avgKeyBytes=%.1f%n",
+                rows, SEGMENTS, PAGE_ROWS, averageKeyBytes(rows));
+
+        List<WriterMeasurement> writers = new ArrayList<>();
+        for (int concurrency : List.of(8, 64)) {
+            writers.add(measureWriters(Arm.CUSTOM, concurrency, directory));
+            writers.add(measureWriters(Arm.AVRO, concurrency, directory));
+        }
+        System.out.println("WRITERS arm concurrency retainedHeapBytesPerOpen cpuMsPerFlush allocatedBytesPerFlush payloadBytesPerFlush containerAllocationBytesPerFlush");
+        for (WriterMeasurement writer : writers) {
+            System.out.printf(Locale.ROOT, "WRITERS %s %d %d %.3f %d %d %d%n",
+                    writer.arm().label, writer.concurrency(), writer.retainedHeapBytesPerOpen(),
+                    writer.cpuNanosPerFlush() / 1_000_000.0, writer.allocatedBytesPerFlush(),
+                    writer.payloadBytesPerFlush(), writer.containerAllocationBytesPerFlush());
+        }
+
+        prepareCorpus(directory, rows);
+        long customBytes = corpusBytes(directory, Arm.CUSTOM);
+        long avroBytes = corpusBytes(directory, Arm.AVRO);
+        long customExtensionBytes = customExtensionBytes(directory);
+        System.out.printf(Locale.ROOT, "DISK customBytes=%d customTrailerExtensionBytes=%d avroBytes=%d deltaBytes=%d deltaPercent=%.4f%n",
+                customBytes, customExtensionBytes, avroBytes, avroBytes - customBytes,
+                100.0 * (avroBytes - customBytes) / customBytes);
+
+        System.out.println("MERGES sample arm wallMs rssPeakKiB rows digest");
+        Map<Arm, Integer> samples = new HashMap<>();
+        for (Arm arm : List.of(Arm.CUSTOM, Arm.AVRO, Arm.AVRO, Arm.CUSTOM, Arm.CUSTOM, Arm.AVRO)) {
+            int sample = samples.merge(arm, 1, Integer::sum);
+            MergeMeasurement result = runMergeChild(arm, directory, rows);
+            System.out.printf(Locale.ROOT, "MERGES %d %s %.3f %d %d %d%n", sample,
+                    arm.label, result.wallNanos() / 1_000_000.0, result.rssPeakKiB(),
+                    result.rows(), result.digest());
+        }
+        Path inspect = segmentPath(directory, Arm.AVRO, 0);
+        System.out.println("INSPECT_COMMAND ./gradlew :swath-core:pr6bSpike -PspikeArgs='inspect "
+                + inspect + "'");
+        System.out.print(AvroPageRunContainer.inspect(inspect));
+    }
+
+    private static void warmContainerClasses(Path directory) throws IOException {
+        List<PageBlock> page = List.of(PageBlock.pack(
+                List.of(object(0)), CMP, PageCodec.LZ4));
+        Path custom = directory.resolve("warm.pageseg");
+        try (PageRunSegmentEncoder writer = PageRunSegmentEncoder.open(
+                custom, SortMetrics.NO_OP, null, SortMode.OBJECTS)) {
+            writer.append(page.getFirst());
+            writer.finish(SegmentKind.CASCADE_INTERMEDIATE);
+        }
+        Path avro = directory.resolve("warm.avro");
+        try (AvroPageRunContainer.Writer writer =
+                AvroPageRunContainer.openWriter(avro, PageCodec.LZ4)) {
+            writer.append(page.getFirst());
+            writer.seal();
+        }
+        try (PageRunSegmentIo ignored = PageRunSegmentIo.open(custom, SortMetrics.NO_OP);
+                AvroPageRunContainer.Reader ignoredAvro =
+                        AvroPageRunContainer.openReader(avro)) {
+            // class initialization only
+        }
+        List<PageBlock> writerPages = writerPages();
+        flush(Arm.CUSTOM, directory.resolve("warm-flush.pageseg"), writerPages);
+        flush(Arm.AVRO, directory.resolve("warm-flush.avro"), writerPages);
+    }
+
+    private static WriterMeasurement measureWriters(Arm arm, int concurrency, Path directory)
+            throws Exception {
+        long retained = retainedOpenWriterHeap(arm, concurrency, directory);
+        List<PageBlock> pages = writerPages();
+        long payloadBytes = pages.stream().mapToLong(page -> page.serialize().length).sum();
+        CountDownLatch ready = new CountDownLatch(concurrency);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        List<Future<ThreadCost>> futures = new ArrayList<>();
+        try {
+            for (int index = 0; index < concurrency; index++) {
+                int writerIndex = index;
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    long thread = Thread.currentThread().threadId();
+                    long cpuBefore = THREADS.getThreadCpuTime(thread);
+                    long allocationBefore = THREADS.getThreadAllocatedBytes(thread);
+                    flush(arm, directory.resolve("writers-" + arm.label + "-" + concurrency
+                            + "-" + writerIndex), pages);
+                    return new ThreadCost(THREADS.getThreadCpuTime(thread) - cpuBefore,
+                            THREADS.getThreadAllocatedBytes(thread) - allocationBefore);
+                }));
+            }
+            ready.await();
+            start.countDown();
+            long cpu = 0;
+            long allocated = 0;
+            for (Future<ThreadCost> future : futures) {
+                ThreadCost cost = future.get();
+                cpu += cost.cpuNanos();
+                allocated += cost.allocatedBytes();
+            }
+            long allocationPerFlush = allocated / concurrency;
+            return new WriterMeasurement(arm, concurrency, retained, cpu / concurrency,
+                    allocationPerFlush, payloadBytes, allocationPerFlush - payloadBytes);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static long retainedOpenWriterHeap(Arm arm, int count, Path directory)
+            throws IOException, InterruptedException {
+        forceGc();
+        long baseline = usedHeap();
+        List<AutoCloseable> open = new ArrayList<>();
+        try {
+            for (int index = 0; index < count; index++) {
+                Path path = directory.resolve("open-" + arm.label + "-" + count + "-" + index);
+                open.add(switch (arm) {
+                    case CUSTOM -> PageRunSegmentEncoder.open(
+                            path, SortMetrics.NO_OP, null, SortMode.OBJECTS);
+                    case AVRO -> AvroPageRunContainer.openWriter(path, PageCodec.LZ4);
+                });
+            }
+            forceGc();
+            return Math.max(0, usedHeap() - baseline) / count;
+        } finally {
+            IOException failure = null;
+            for (AutoCloseable writer : open) {
+                try {
+                    writer.close();
+                } catch (Exception closeFailure) {
+                    if (failure == null) {
+                        failure = new IOException("closing retained-heap writer", closeFailure);
+                    } else {
+                        failure.addSuppressed(closeFailure);
+                    }
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    private static void flush(Arm arm, Path path, List<PageBlock> source) throws IOException {
+        List<PageBlock> pages = new ArrayList<>(source);
+        switch (arm) {
+            case CUSTOM -> {
+                long entries = pages.stream().mapToLong(PageBlock::count).sum();
+                long estimated = pages.stream().mapToLong(PageBlock::stagingEstimatedBytes).sum();
+                SealedBuffer sealed = new SealedBuffer(pages, 1,
+                        Map.of(1L, pages.getLast().lastKey()), entries,
+                        SealTrigger.DRAIN, estimated);
+                new PageRunSegmentWriter(CMP, DuplicateHook.NO_OP, SortMetrics.NO_OP,
+                        PageCodec.LZ4).flush(sealed, path);
+            }
+            case AVRO -> {
+                try (AvroPageRunContainer.Writer writer =
+                        AvroPageRunContainer.openWriter(path, PageCodec.LZ4)) {
+                    for (PageBlock page : pages) {
+                        writer.append(page);
+                    }
+                    writer.seal();
+                }
+            }
+        }
+    }
+
+    private static List<PageBlock> writerPages() {
+        List<PageBlock> pages = new ArrayList<>();
+        for (int page = 0; page < WRITER_PAGES; page++) {
+            List<ListEntry> entries = new ArrayList<>(PAGE_ROWS);
+            for (int row = 0; row < PAGE_ROWS; row++) {
+                entries.add(object((long) page * PAGE_ROWS + row));
+            }
+            pages.add(PageBlock.pack(entries, CMP, PageCodec.LZ4));
+        }
+        return pages;
+    }
+
+    private static void prepareCorpus(Path directory, int rows) throws IOException {
+        int perSegment = rows / SEGMENTS;
+        for (int segment = 0; segment < SEGMENTS; segment++) {
+            List<PageBlock> pages = new ArrayList<>(perSegment / PAGE_ROWS);
+            for (int offset = 0; offset < perSegment; offset += PAGE_ROWS) {
+                List<ListEntry> page = new ArrayList<>(PAGE_ROWS);
+                for (int row = 0; row < PAGE_ROWS; row++) {
+                    page.add(object(segment + (long) (offset + row) * SEGMENTS));
+                }
+                pages.add(PageBlock.pack(page, CMP, PageCodec.LZ4));
+            }
+
+            Path custom = segmentPath(directory, Arm.CUSTOM, segment);
+            long estimated = pages.stream().mapToLong(PageBlock::stagingEstimatedBytes).sum();
+            SealedBuffer sealed = new SealedBuffer(pages, 1,
+                    Map.of((long) segment, pages.getLast().lastKey()), perSegment,
+                    SealTrigger.DRAIN, estimated);
+            new PageRunSegmentWriter(CMP, DuplicateHook.NO_OP, SortMetrics.NO_OP,
+                    PageCodec.LZ4).flush(sealed, custom);
+
+            Path avro = segmentPath(directory, Arm.AVRO, segment);
+            try (AvroPageRunContainer.Writer writer =
+                    AvroPageRunContainer.openWriter(avro, PageCodec.LZ4)) {
+                for (PageBlock page : pages) {
+                    writer.append(page);
+                }
+                writer.seal();
+            }
+        }
+    }
+
+    private static void mergeChild(Arm arm, Path directory, int expectedRows) throws IOException {
+        forceGcUnchecked();
+        long start = System.nanoTime();
+        for (int segment = 0; segment < SEGMENTS; segment++) {
+            Path path = segmentPath(directory, arm, segment);
+            if (arm == Arm.CUSTOM) {
+                scanCustomHeaders(path);
+            } else {
+                AvroPageRunContainer.scanHeaders(path);
+            }
+        }
+
+        List<EntryStream> streams = new ArrayList<>();
+        try {
+            for (int segment = 0; segment < SEGMENTS; segment++) {
+                Path path = segmentPath(directory, arm, segment);
+                streams.add(arm == Arm.CUSTOM
+                        ? new CustomStream(path) : new AvroStream(path));
+            }
+            long rows = 0;
+            long digest = 0xcbf29ce484222325L;
+            try (StreamingMerger merge = new StreamingMerger(streams, CMP, ignored -> { })) {
+                while (merge.hasNext()) {
+                    ListEntry entry = merge.next();
+                    digest ^= Arrays.hashCode(entry.key().rawUnsafe());
+                    digest *= 0x100000001b3L;
+                    rows++;
+                }
+            }
+            if (rows != expectedRows) {
+                throw new IOException("merged " + rows + " rows, expected " + expectedRows);
+            }
+            long wall = System.nanoTime() - start;
+            System.out.printf(Locale.ROOT, "CHILD_RESULT %s %d %d %d %d%n",
+                    arm.label, wall, readVmHwmKiB(), rows, digest);
+        } catch (IOException | RuntimeException failure) {
+            for (EntryStream stream : streams) {
+                try {
+                    stream.close();
+                } catch (IOException closeFailure) {
+                    failure.addSuppressed(closeFailure);
+                }
+            }
+            throw failure;
+        }
+    }
+
+    private static void scanCustomHeaders(Path path) throws IOException {
+        try (PageRunSegmentIo io = PageRunSegmentIo.open(path, SortMetrics.NO_OP)) {
+            while (io.nextRoutingPage() != null) {
+                // projected routing-header pass
+            }
+            io.checkRoutingComplete();
+        }
+    }
+
+    private static MergeMeasurement runMergeChild(Arm arm, Path directory, int rows)
+            throws IOException, InterruptedException {
+        String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+        Process process = new ProcessBuilder(java, "-Xms128m", "-Xmx2g", "-cp",
+                System.getProperty("java.class.path"), PageRunContainerSpike.class.getName(),
+                "merge", arm.label, directory.toString(), Integer.toString(rows))
+                .redirectErrorStream(true)
+                .start();
+        String result = null;
+        try (BufferedReader output = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = output.readLine()) != null) {
+                if (line.startsWith("CHILD_RESULT ")) {
+                    result = line;
+                } else {
+                    System.out.println("CHILD " + line);
+                }
+            }
+        }
+        int exit = process.waitFor();
+        if (exit != 0 || result == null) {
+            throw new IOException("merge child failed for " + arm.label + " (exit " + exit + ")");
+        }
+        String[] fields = result.split(" ");
+        return new MergeMeasurement(arm, Long.parseLong(fields[2]),
+                Long.parseLong(fields[3]), Long.parseLong(fields[4]),
+                Long.parseLong(fields[5]));
+    }
+
+    private static long corpusBytes(Path directory, Arm arm) throws IOException {
+        long bytes = 0;
+        for (int segment = 0; segment < SEGMENTS; segment++) {
+            bytes += Files.size(segmentPath(directory, arm, segment));
+        }
+        return bytes;
+    }
+
+    private static long customExtensionBytes(Path directory) throws IOException {
+        long bytes = 0;
+        for (int segment = 0; segment < SEGMENTS; segment++) {
+            try (PageRunSegmentIo io = PageRunSegmentIo.open(
+                    segmentPath(directory, Arm.CUSTOM, segment), SortMetrics.NO_OP)) {
+                PageRunTrailer.Trailer trailer = PageRunTrailer.read(io);
+                bytes += io.fileSize - PageRunSegmentWriter.TRAILER_FIXED_TAIL_BYTES
+                        - trailer.extensionStart();
+            }
+        }
+        return bytes;
+    }
+
+    private static Path segmentPath(Path directory, Arm arm, int segment) {
+        return directory.resolve(String.format(Locale.ROOT, "%s-%02d.%s", arm.label, segment,
+                arm == Arm.CUSTOM ? "pageseg" : "avro"));
+    }
+
+    private static double averageKeyBytes(int rows) {
+        long samples = Math.min(rows, 10_000);
+        long bytes = 0;
+        for (int index = 0; index < samples; index++) {
+            bytes += key(index).length();
+        }
+        return (double) bytes / samples;
+    }
+
+    private static ObjectEntry object(long ordinal) {
+        long mixed = ordinal * 0x9e3779b97f4a7c15L;
+        long size = 512L + Long.remainderUnsigned(mixed, 64L * 1024 * 1024);
+        return new ObjectEntry(KeyBytes.ofUtf8(key(ordinal)), size,
+                1_788_091_200_000_000L + ordinal * 1_000_000L,
+                String.format(Locale.ROOT, "%032x", mixed),
+                ordinal % 20 == 0 ? "STANDARD_IA" : "STANDARD", null, false,
+                "79a59df900b949e55d96a1e698f0ee8f6c6e0f0d1f88d8791807b9c3d38b5d6d",
+                null, ordinal % 4 == 0 ? "SHA256" : null,
+                ordinal % 4 == 0 ? "FULL_OBJECT" : null);
+    }
+
+    private static String key(long ordinal) {
+        return String.format(Locale.ROOT,
+                "tenant=0042/root=v1/region=us-east-1/year=2026/month=08/day=%02d/hour=%02d/"
+                        + "partition=%04d/object-%012d.dat",
+                1 + (ordinal / 86_400) % 31, (ordinal / 3_600) % 24,
+                (ordinal / 1_000) % 10_000, ordinal);
+    }
+
+    private static long usedHeap() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    private static void forceGc() throws InterruptedException {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            System.gc();
+            Thread.sleep(50);
+        }
+    }
+
+    private static void forceGcUnchecked() {
+        try {
+            forceGc();
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted while settling heap", interrupted);
+        }
+    }
+
+    private static long readVmHwmKiB() throws IOException {
+        for (String line : Files.readAllLines(Path.of("/proc/self/status"))) {
+            if (line.startsWith("VmHWM:")) {
+                return Long.parseLong(line.replaceAll("[^0-9]", ""));
+            }
+        }
+        throw new IOException("/proc/self/status has no VmHWM");
+    }
+
+    private enum Arm {
+        CUSTOM("custom"),
+        AVRO("avro");
+
+        private final String label;
+
+        Arm(String label) {
+            this.label = label;
+        }
+    }
+
+    private record ThreadCost(long cpuNanos, long allocatedBytes) {
+    }
+
+    private record WriterMeasurement(Arm arm, int concurrency, long retainedHeapBytesPerOpen,
+                                     long cpuNanosPerFlush, long allocatedBytesPerFlush,
+                                     long payloadBytesPerFlush,
+                                     long containerAllocationBytesPerFlush) {
+    }
+
+    private record MergeMeasurement(Arm arm, long wallNanos, long rssPeakKiB, long rows,
+                                    long digest) {
+    }
+
+    private abstract static class BlockStream implements EntryStream {
+
+        private PageBlockCursor cursor;
+        private ListEntry head;
+
+        final void initialize() throws IOException {
+            advance();
+        }
+
+        abstract PageBlock nextBlock() throws IOException;
+
+        private void advance() throws IOException {
+            while (cursor == null || !cursor.hasNext()) {
+                PageBlock block = nextBlock();
+                if (block == null) {
+                    head = null;
+                    return;
+                }
+                cursor = block.cursor();
+            }
+            head = cursor.next();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return head != null;
+        }
+
+        @Override
+        public ListEntry peek() {
+            return head;
+        }
+
+        @Override
+        public ListEntry next() throws IOException {
+            ListEntry result = head;
+            advance();
+            return result;
+        }
+    }
+
+    private static final class CustomStream extends BlockStream {
+
+        private final PageRunSegmentIo io;
+        private long page;
+        private long entries;
+
+        CustomStream(Path path) throws IOException {
+            this(PageRunSegmentIo.open(path, SortMetrics.NO_OP));
+        }
+
+        private CustomStream(PageRunSegmentIo io) throws IOException {
+            this.io = io;
+            initialize();
+        }
+
+        @Override
+        PageBlock nextBlock() throws IOException {
+            if (page == io.totalRecords) {
+                io.checkComplete(entries);
+                return null;
+            }
+            PageRunSegmentIo.Page next = io.nextPage();
+            page++;
+            entries += next.header().count();
+            return next.decode(io.path());
+        }
+
+        @Override
+        public void close() throws IOException {
+            io.close();
+        }
+    }
+
+    private static final class AvroStream extends BlockStream {
+
+        private final AvroPageRunContainer.Reader reader;
+
+        AvroStream(Path path) throws IOException {
+            this(AvroPageRunContainer.openReader(path));
+        }
+
+        private AvroStream(AvroPageRunContainer.Reader reader) throws IOException {
+            this.reader = reader;
+            initialize();
+        }
+
+        @Override
+        PageBlock nextBlock() throws IOException {
+            return reader.nextPage();
+        }
+
+        @Override
+        public void close() throws IOException {
+            reader.close();
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Decision record for the PR 6b container question (external review §5.4, reopened narrowly by the adopted finalization pipeline): should the never-seeked `.pageseg` staging container become **(a) the stripped custom frame** that the §3.1.8 deletion sequence leaves behind, or **(b) Avro OCF** — one packed PageBlock per block, `null` codec, plus a seal-block convention?

**This PR is opened to be closed.** The decision is **(a): keep the stripped custom frame.** The branch preserves the working Avro prototype (test sources only; the production closure is untouched) and the corrected evidence (`PR6B-SPIKE-EVIDENCE.md`) so the question can be re-evaluated later without re-doing the work. A hands-on re-measurement branch with production-shaped Avro variants (`avro-raw`, `avro-raw2`, tuned writers) is preserved at `spike/pr6b-avro-deepdive`.

## Evidence (corrected — first-pass numbers were measurement artifacts)
The spike's original +57.2 % merge penalty was cold-JVM Avro bootstrap (~340 ms of schema-parser/Jackson class-init inside a one-shot child JVM's timed region) and is **struck from the record**. Two independent second-model reviews re-measured:

- **Warm merge performance: near parity.** K=8 steady state — custom 273.8 ms; Avro stock-API +5.8 %; production-shaped `avro-raw2` (routing-first schema, raw block iteration, seeking header pass) **+1.6 %**, with a header pass 1.9× *faster* than custom. Performance is explicitly **not** an argument for (a).
- **Integrity:** null-codec OCF silently accepts a one-bit payload mutation on every read shape tested (sync markers resync; they do not detect); PageBlock has no internal checksum today. Fixing it costs ~0.3 % merge CPU but adds a custom CRC convention inside the "standard" container. (A page-internal CRC32C at pack time would neutralise this axis for *any* container — recorded as a design note for the surviving frame.)
- **Completeness:** the custom trailer answers "complete, and what does it hold" at open with one tail read; OCF has no footer, so the seal-record convention answers only after scanning every preceding block.
- **Writer memory (structural, not tunable):** OCF must buffer a whole block to emit its length prefix — ~51 KiB per open writer after a real page vs ~0.54 KiB custom (~95×; ~3.2 MiB at 64 open segments during listing), for no compensating benefit.
- **LOC — the owner's recorded condition ("choose Avro if it removes more custom format code and improves debuggability") fails, and fails harder the faster Avro gets:** the stock-API shape is ~312 production-shaped SLOC at +5.8 %; reaching +1.6 % takes ~360–400 SLOC because the hand-rolled decoder and block walk *are* custom format code, plus the CRC and seal conventions. The ~200-SLOC custom-frame figure is an estimate until the §3.1.8 deletion lands; the mechanical recount is queued behind it.
- **Debuggability:** `avro-tools` shows framing/metadata only — the payload is opaque PageBlock bytes and the seal is a private convention — and avro-tools 1.11.5 does not run on JDK 25. Adoption would also add ~300 ms one-time class-loading per process (nothing loads Avro today).
- **Fairness:** the custom arm CRC-verifies every record while no Avro arm verified anything, and custom still wins the comparison.

## Re-evaluation conditions
Reopen only if: the post-§3.1.8 mechanical LOC count materially contradicts the estimate; or a real need appears for block-level salvage/resync or ecosystem-readable staging. If reopened, start from `avro-raw2` on `spike/pr6b-avro-deepdive`, adopt the page-internal CRC first, and measure with in-JVM repeats — never one-shot child JVMs.

Second-model reviews (posted below as evidence, never approvals): the read-only fairness gate and the hands-on deep-dive, both Claude Opus. Full protocol and tables: `PR6B-SPIKE-EVIDENCE.md` on this branch; decision provenance in swath-notes (`notes/2026-08-31-pr6a-6b-pr5-orchestration-log.md`, `notes/reviews/2026-08-31-pr6b-*.md`). Refs review §5.4 and the 2026-08-29 execution plan's PR 6b row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed comparison of Avro and custom page-run containers, including performance measurements, integrity findings, and follow-up validation requirements.

* **Testing**
  * Added test coverage for page round-trips, truncation, corruption detection, recovery, sealing, and metadata validation.
  * Added a runnable benchmark and inspection tool for comparing container performance and behavior.

* **Chores**
  * Added test-only Avro tooling and verification tasks for container measurements and inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->