### PR TITLE
Expose Parquet keys as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Parquet output now exposes `key` as a STRING logical column while retaining its byte-identical
+  BINARY storage. Downstream DuckDB, Spark, pandas, and similar queries therefore see the column
+  type change from BLOB to VARCHAR and may need to update blob comparisons, casts, or functions.
+- Parquet output now rejects malformed UTF-8 key bytes with a typed output error. Legacy captures
+  containing non-UTF-8 keys remain readable, but they can no longer be re-published as Parquet or
+  used as input for `--sort` output.

--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -398,7 +398,7 @@ not parse it.
 
 | Column | Physical / logical | Null? | Notes |
 | --- | --- | --- | --- |
-| `key` | `BINARY` | no | raw key bytes (byte-exact; not UTF-8-coerced); = the prefix for `COMMON_PREFIX` rows |
+| `key` | `BINARY` (STRING) | no | well-formed UTF-8 key; physical bytes remain byte-exact; malformed internal/fixture keys fail with a typed output error; = the prefix for `COMMON_PREFIX` rows |
 | `size` | `INT64` | **yes** | bytes; **null** for `COMMON_PREFIX` and `DELETE_MARKER` rows |
 | `last_modified` | `INT64` TIMESTAMP(MICROS,UTC) | **yes** | **null** for `COMMON_PREFIX` rows |
 | `etag` | `BINARY` (UTF8) | yes | **quotes stripped**; multipart form `hex-N` kept verbatim as string; never panic-parse |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -247,7 +247,7 @@ listing, so several columns are present but unpopulated today.
 
 | Column | Type | Nullable | Meaning |
 | --- | --- | --- | --- |
-| `key` | `BINARY` | no | Raw key bytes, preserved byte-for-byte |
+| `key` | `STRING` (physical `BINARY`) | no | UTF-8 object key; physical bytes are preserved byte-for-byte |
 | `size` | `INT64` | yes | Object size in bytes |
 | `last_modified` | `TIMESTAMP(MICROS,UTC)` | yes | Last-modified time |
 | `etag` | `BINARY (UTF8)` | yes | Quotes removed; multipart form retained |

--- a/swath-cli/src/test/java/io/varve/swath/cli/ClearDatasetForFreshRunTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ClearDatasetForFreshRunTest.java
@@ -36,7 +36,7 @@ final class ClearDatasetForFreshRunTest {
         // marker, a consumer manifest, a symlink, plus an EXTRA data/ part from a wider prior run.
         Files.writeString(layout.success(), "");
         Files.writeString(layout.state(), "{\"args_hash\":\"foreign\",\"run_id\":42}");
-        Manifest.write(outputDir, "stale", "message swath { required binary key; }",
+        Manifest.write(outputDir, "stale", "message swath { required binary key (STRING); }",
                 List.of(), false, null);
         Files.writeString(layout.symlink(), "data/part-wZ-99999.parquet\n");
         Path dataDir = Files.createDirectories(layout.dataDir());

--- a/swath-cli/src/test/java/io/varve/swath/cli/DirectoryLifecycleCharacterizationTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/DirectoryLifecycleCharacterizationTest.java
@@ -365,7 +365,7 @@ final class DirectoryLifecycleCharacterizationTest {
         Files.createDirectories(layout.dataDir());
         Files.writeString(layout.state(), "{\"args_hash\":\"" + hash + "\",\"run_id\":" + priorRunId + "}");
         Files.writeString(layout.success(), "");
-        Manifest.write(outputDir, BUCKET, "message swath { required binary key; }",
+        Manifest.write(outputDir, BUCKET, "message swath { required binary key (STRING); }",
                 List.of(), false, null);
         Path priorPart = layout.dataDir().resolve("part-w0-00000.parquet");
         Files.writeString(priorPart, "the completed prior run's real output");
@@ -493,7 +493,7 @@ final class DirectoryLifecycleCharacterizationTest {
         Files.createDirectories(layout.dataDir());
         Files.writeString(layout.state(), "{\"args_hash\":\"" + hash + "\",\"run_id\":" + priorRunId + "}");
         Files.writeString(layout.success(), "");
-        Manifest.write(outputDir, BUCKET, "message swath { required binary key; }",
+        Manifest.write(outputDir, BUCKET, "message swath { required binary key (STRING); }",
                 List.of(), false, null);
         Path ownedPart = layout.dataDir().resolve("part-w0-00000.parquet");
         Files.writeString(ownedPart, "swath-owned part from the run --restart is discarding");

--- a/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/ResumeCommandTest.java
@@ -632,7 +632,7 @@ final class ResumeCommandTest {
         DatasetLayout layout =
                 DatasetLayout.of(outputDir);
         Files.createDirectories(layout.dataDir());
-        Manifest.write(outputDir, BUCKET, "message swath { required binary key; }",
+        Manifest.write(outputDir, BUCKET, "message swath { required binary key (STRING); }",
                 List.of(), false, null);
         Files.writeString(layout.success(), "");
         // No co-located checkpoint: completion deleted it.

--- a/swath-core/src/main/java/io/varve/swath/engine/StealMath.java
+++ b/swath-core/src/main/java/io/varve/swath/engine/StealMath.java
@@ -319,7 +319,7 @@ public final class StealMath {
      * {@link #MAX_UTF8_KEY} (whole-bucket scope, or a {@code prefixCeil} that is not valid UTF-8).
      */
     private static byte[] effectiveCeiling(byte[] ceil) {
-        return (ceil == null || !ByteMidpoint.isValidUtf8(ceil)) ? MAX_UTF8_KEY : ceil;
+        return (ceil == null || !KeyBytes.isValidUtf8(ceil)) ? MAX_UTF8_KEY : ceil;
     }
 
     /**

--- a/swath-core/src/main/java/io/varve/swath/error/InvalidKeyEncodingException.java
+++ b/swath-core/src/main/java/io/varve/swath/error/InvalidKeyEncodingException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.error;
+
+import java.util.HexFormat;
+
+/** A Parquet row carried key bytes that cannot be represented by its required STRING column. */
+public final class InvalidKeyEncodingException extends OutputException {
+
+    private static final int PREFIX_BYTES = 16;
+
+    private InvalidKeyEncodingException(String message) {
+        super(message);
+    }
+
+    /** Builds the typed output failure while exposing only a bounded, byte-exact key prefix. */
+    public static InvalidKeyEncodingException forKey(byte[] key) {
+        int prefixLength = Math.min(key.length, PREFIX_BYTES);
+        String suffix = key.length > prefixLength ? "..." : "";
+        return new InvalidKeyEncodingException(
+                "Parquet key is not well-formed UTF-8: key_hex_prefix="
+                        + HexFormat.of().formatHex(key, 0, prefixLength) + suffix);
+    }
+}

--- a/swath-core/src/main/java/io/varve/swath/error/OutputException.java
+++ b/swath-core/src/main/java/io/varve/swath/error/OutputException.java
@@ -13,7 +13,7 @@ import io.varve.swath.output.DiskFull;
  * dataset-publication failure whose already-durable parts permit a publication-only retry.
  */
 public sealed class OutputException extends SwathException
-        permits MergePendingException, PublicationPendingException {
+        permits InvalidKeyEncodingException, MergePendingException, PublicationPendingException {
 
     /**
      * {@code EX_IOERR} (sysexits.h) for the out-of-space case. It is repeated literally because

--- a/swath-core/src/main/java/io/varve/swath/output/Utf8TsvFormatter.java
+++ b/swath-core/src/main/java/io/varve/swath/output/Utf8TsvFormatter.java
@@ -98,7 +98,7 @@ public final class Utf8TsvFormatter {
 
     private void appendKey(KeyBytes key) {
         byte[] bytes = key.rawUnsafe();
-        if (isValidUtf8(bytes)) {
+        if (KeyBytes.isValidUtf8(bytes)) {
             appendEscapedBytes(bytes);
         } else {
             appendText(key.asString());
@@ -187,47 +187,4 @@ public final class Utf8TsvFormatter {
         }
     }
 
-    /** Strict UTF-8 validation; malformed bytes must retain the existing replacement semantics. */
-    private static boolean isValidUtf8(byte[] bytes) {
-        int i = 0;
-        while (i < bytes.length) {
-            int first = bytes[i++] & 0xff;
-            if (first < 0x80) {
-                continue;
-            }
-            if (first >= 0xc2 && first <= 0xdf) {
-                if (i >= bytes.length || !continuation(bytes[i++])) return false;
-                continue;
-            }
-            if (first >= 0xe0 && first <= 0xef) {
-                if (i + 1 >= bytes.length) return false;
-                int second = bytes[i++] & 0xff;
-                int third = bytes[i++] & 0xff;
-                if ((first == 0xe0 && second < 0xa0)
-                        || (first == 0xed && second >= 0xa0)
-                        || !continuation(second) || !continuation(third)) return false;
-                continue;
-            }
-            if (first >= 0xf0 && first <= 0xf4) {
-                if (i + 2 >= bytes.length) return false;
-                int second = bytes[i++] & 0xff;
-                int third = bytes[i++] & 0xff;
-                int fourth = bytes[i++] & 0xff;
-                if ((first == 0xf0 && second < 0x90)
-                        || (first == 0xf4 && second >= 0x90)
-                        || !continuation(second) || !continuation(third) || !continuation(fourth)) return false;
-                continue;
-            }
-            return false;
-        }
-        return true;
-    }
-
-    private static boolean continuation(byte value) {
-        return continuation(value & 0xff);
-    }
-
-    private static boolean continuation(int value) {
-        return (value & 0xc0) == 0x80;
-    }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ListEntryParquetWriters.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ListEntryParquetWriters.java
@@ -114,6 +114,15 @@ public final class ListEntryParquetWriters {
             return writer;
         }
 
+        /** Writes one row, restoring a checked output failure with the affected part's path. */
+        public void write(ListEntry entry) throws IOException {
+            try {
+                writer.write(entry);
+            } catch (UncheckedOutputException e) {
+                throw new IOException("failed to write Parquet part " + path, e.getCause());
+            }
+        }
+
         public boolean periodicSyncEnabled() {
             return periodicSync.enabled();
         }

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ListEntryWriteSupport.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ListEntryWriteSupport.java
@@ -5,8 +5,11 @@
  */
 package io.varve.swath.output.parquet;
 
+import io.varve.swath.error.InvalidKeyEncodingException;
+import io.varve.swath.error.OutputException;
 import io.varve.swath.model.CommonPrefixEntry;
 import io.varve.swath.model.DeleteMarkerEntry;
+import io.varve.swath.model.KeyBytes;
 import io.varve.swath.model.ListEntry;
 import io.varve.swath.model.ObjectEntry;
 import io.varve.swath.model.RowType;
@@ -40,8 +43,12 @@ public final class ListEntryWriteSupport extends WriteSupport<ListEntry> {
 
     @Override
     public void write(ListEntry e) {
+        byte[] key = e.key().rawUnsafe();
+        if (!KeyBytes.isValidUtf8(key)) {
+            throw new UncheckedOutputException(InvalidKeyEncodingException.forKey(key));
+        }
         rc.startMessage();
-        binary("key", 0, e.key().rawUnsafe());
+        binary("key", 0, key);
         switch (e) {
             case ObjectEntry o -> {
                 longField("size", 1, o.size());
@@ -105,5 +112,18 @@ public final class ListEntryWriteSupport extends WriteSupport<ListEntry> {
         rc.startField(name, index);
         rc.addBoolean(value);
         rc.endField(name, index);
+    }
+}
+
+/** Checked-output-error bridge for parquet-mr's {@code WriteSupport.write} callback. */
+final class UncheckedOutputException extends RuntimeException {
+
+    UncheckedOutputException(OutputException cause) {
+        super(cause);
+    }
+
+    @Override
+    public synchronized OutputException getCause() {
+        return (OutputException) super.getCause();
     }
 }

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetSchema.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/ParquetSchema.java
@@ -24,7 +24,7 @@ public final class ParquetSchema {
 
     public static MessageType canonical() {
         return Types.buildMessage()
-                .required(PrimitiveTypeName.BINARY).named("key")                       // raw key bytes
+                .required(PrimitiveTypeName.BINARY).as(LogicalTypeAnnotation.stringType()).named("key")
                 .optional(PrimitiveTypeName.INT64).named("size")                        // null for prefixes/markers
                 .optional(PrimitiveTypeName.INT64)
                 .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))

--- a/swath-core/src/main/java/io/varve/swath/output/parquet/PartWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/output/parquet/PartWriter.java
@@ -53,7 +53,7 @@ public final class PartWriter implements AutoCloseable, DatasetPartWriter {
     }
 
     public void write(ListEntry e) throws IOException {
-        writer.write(e);
+        tracked.write(e);
         rows++;
     }
 

--- a/swath-core/src/main/java/io/varve/swath/sort/SortedParquetWriter.java
+++ b/swath-core/src/main/java/io/varve/swath/sort/SortedParquetWriter.java
@@ -136,7 +136,7 @@ public final class SortedParquetWriter implements SortedFileWriter {
 
     @Override
     public void write(ListEntry e) throws IOException {
-        writer.write(e);
+        tracked.write(e);
         byte[] key = e.key().rawUnsafe();
         if (firstKey == null) {
             firstKey = key.clone();

--- a/swath-core/src/test/java/io/varve/swath/engine/StealMathTest.java
+++ b/swath-core/src/test/java/io/varve/swath/engine/StealMathTest.java
@@ -9,6 +9,7 @@ import static io.varve.swath.engine.StealMath.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.varve.swath.model.ByteMidpoint;
+import io.varve.swath.model.KeyBytes;
 import io.varve.swath.testkit.ScalarSafety;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -258,7 +259,7 @@ class StealMathTest {
         byte[] ceil = prefixCeil(utf8("data/"));   // "data0"
         byte[] m    = extrapolate(lo, c, ceil);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).as("pivot must be valid UTF-8").isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).as("pivot must be valid UTF-8").isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();      // c < m
         assertThat(Arrays.compareUnsigned(m, ceil)).isNegative();   // m < ceil
     }
@@ -271,7 +272,7 @@ class StealMathTest {
         byte[] c  = utf8("flat/00000123");
         byte[] m  = extrapolate(lo, c, null);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();
         // m shares the dense common prefix "flat/0000" rather than galloping out of it.
         assertThat(new String(m, StandardCharsets.UTF_8)).startsWith("flat/0000");
@@ -286,7 +287,7 @@ class StealMathTest {
         byte[] ceil = prefixCeil(utf8("data/"));
         byte[] m    = extrapolate(lo, c, ceil);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();
         assertThat(Arrays.compareUnsigned(m, ceil)).isNegative();
     }
@@ -299,7 +300,7 @@ class StealMathTest {
         byte[] ceil = prefixCeil(utf8("flat/"));   // "flat0"
         byte[] m    = extrapolate(null, c, ceil);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();
         assertThat(Arrays.compareUnsigned(m, ceil)).isNegative();
         assertThat(new String(m, StandardCharsets.UTF_8)).startsWith("flat/");
@@ -328,7 +329,7 @@ class StealMathTest {
         byte[] max = b(0xF4, 0x8F, 0xBF, 0xBF);
         byte[] m   = extrapolate(null, c, null);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();               // c < m
         assertThat(Arrays.compareUnsigned(m, max)).isLessThanOrEqualTo(0);   // m <= U+10FFFF
     }
@@ -338,11 +339,11 @@ class StealMathTest {
         // A prefixCeil that bumped a continuation byte (0xCF 0xBF → 0xCF 0xC0) is NOT valid UTF-8.
         // extrapolate must NOT pass it to byteMidpoint; it falls back to the max-UTF-8 ceiling.
         byte[] badCeil = b(0xCF, 0xC0);
-        assertThat(ByteMidpoint.isValidUtf8(badCeil)).isFalse();
+        assertThat(KeyBytes.isValidUtf8(badCeil)).isFalse();
         byte[] c = utf8("A");
         byte[] m = extrapolate(null, c, badCeil);   // must not throw
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, c)).isPositive();
     }
 
@@ -361,7 +362,7 @@ class StealMathTest {
                 for (byte[] loArg : new byte[][]{null, lo}) {
                     byte[] m = extrapolate(loArg, c, ceil);
                     if (m != null) {
-                        assertThat(ByteMidpoint.isValidUtf8(m))
+                        assertThat(KeyBytes.isValidUtf8(m))
                                 .as("valid UTF-8 for cursor %s", p + s).isTrue();
                         assertThat(Arrays.compareUnsigned(m, c))
                                 .as("c < m for cursor %s", p + s).isPositive();
@@ -453,7 +454,7 @@ class StealMathTest {
         byte[] hi = interpolate(a, b, 0.75);
         for (byte[] m : new byte[][]{lo, mid, hi}) {
             assertThat(m).isNotNull();
-            assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+            assertThat(KeyBytes.isValidUtf8(m)).isTrue();
             assertThat(Arrays.compareUnsigned(a, m)).isNegative();
             assertThat(Arrays.compareUnsigned(m, b)).isNegative();
         }
@@ -492,7 +493,7 @@ class StealMathTest {
         // valid-UTF-8 pivot below hi.
         byte[] m = interpolate(null, utf8("mmmm"), 0.75);
         assertThat(m).isNotNull();
-        assertThat(ByteMidpoint.isValidUtf8(m)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).isTrue();
         assertThat(Arrays.compareUnsigned(m, utf8("mmmm"))).isNegative();
     }
 

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/Int6DuckDbReadIT.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/Int6DuckDbReadIT.java
@@ -70,7 +70,7 @@ class Int6DuckDbReadIT {
         // information_schema.columns name) — duckdb binds the column name strictly.
         String types = duck(duckdb, "SELECT lower(string_agg(column_name || ':' || column_type, ',' ORDER BY column_name))"
                 + " FROM (DESCRIBE SELECT * FROM read_parquet('" + glob + "'))");
-        assertThat(types).contains("key:blob").contains("size:bigint").contains("etag:varchar")
+        assertThat(types).contains("key:varchar").contains("size:bigint").contains("etag:varchar")
                 .contains("row_type:varchar").contains("is_delete_marker:boolean");
 
         // ETag stored verbatim (multipart hex-N), and size NULL for the common-prefix row.

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ManifestJsonTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ManifestJsonTest.java
@@ -29,7 +29,7 @@ class ManifestJsonTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private static final String SCHEMA = "message swath { required binary key (UTF8); }";
+    private static final String SCHEMA = "message swath { required binary key (STRING); }";
 
     @Test
     void sortedManifestCarriesEveryFieldInOrder(@TempDir Path dir) throws IOException {

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetPoolTestSupport.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetPoolTestSupport.java
@@ -35,18 +35,26 @@ final class ParquetPoolTestSupport {
         return PageBatches.batch(nodeId, seq, from, to);
     }
 
-    /** One naturally row-group-sized batch with non-compressible binary keys. */
+    /** One naturally row-group-sized batch with high-entropy, well-formed UTF-8 keys. */
     static PageBatch incompressibleRowGroupBatch(long nodeId, long seq) {
         Random random = new Random(0x51A7B00BL);
-        List<ListEntry> entries = new ArrayList<>(36_000);
-        for (int row = 0; row < 36_000; row++) {
+        List<ListEntry> entries = new ArrayList<>(44_000);
+        for (int row = 0; row < 44_000; row++) {
             byte[] key = new byte[2048];
             random.nextBytes(key);
+            printableAscii(key);
             entries.add(new ObjectEntry(KeyBytes.of(key), row,
                     1_700_000_000_000_000L + row, "etag", "STANDARD",
                     null, true, null, null, null, null));
         }
         return new PageBatch(nodeId, seq, entries);
+    }
+
+    /** Maps random bytes one-for-one onto printable ASCII without reducing the row size. */
+    static void printableAscii(byte[] bytes) {
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) (0x20 + (bytes[i] & 0xFF) % 95);
+        }
     }
 
     /** Finalized data parts live under {@code <root>/data/}. */

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetRoundTripTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/ParquetRoundTripTest.java
@@ -6,16 +6,21 @@
 package io.varve.swath.output.parquet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.varve.swath.error.InvalidKeyEncodingException;
 import io.varve.swath.model.KeyBytes;
 import io.varve.swath.model.ObjectEntry;
 import io.varve.swath.testkit.ParquetReads;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.parquet.example.data.Group;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Validates the Parquet toolchain (parquet-mr + ZSTD via zstd-jni + LocalOutput/
@@ -39,6 +44,9 @@ class ParquetRoundTripTest {
         assertThat(ParquetReads.schema(part).getColumns())
                 .extracting(c -> c.getPath()[0])
                 .contains("key", "size", "last_modified", "etag", "storage_class", "row_type", "is_delete_marker");
+        assertThat(ParquetReads.schema(part).getType("key").asPrimitiveType().getLogicalTypeAnnotation())
+                .as("consumer-visible key logical type")
+                .isEqualTo(LogicalTypeAnnotation.stringType());
 
         List<Group> rows = ParquetReads.readAll(part);
         assertThat(rows).hasSize(2);
@@ -46,5 +54,36 @@ class ParquetRoundTripTest {
         assertThat(rows.getFirst().getString("row_type", 0)).isEqualTo("OBJECT");
         assertThat(rows.getFirst().getBoolean("is_delete_marker", 0)).isFalse();
         assertThat(rows.getFirst().getLong("size", 0)).isEqualTo(10);
+    }
+
+    @ParameterizedTest(name = "rejects malformed UTF-8 {0}")
+    @MethodSource("malformedUtf8")
+    void rejectsMalformedUtf8KeyWithTypedOutputError(
+            String description, byte[] malformed, @TempDir Path dir) throws Exception {
+        Path part = dir.resolve("invalid-key.parquet");
+
+        assertThatThrownBy(() -> {
+            try (PartWriter writer = new PartWriter(part, ParquetSchema.canonical())) {
+                writer.write(ObjectEntry.withoutOwnerDisplayNameAndChecksumType(
+                        KeyBytes.of(malformed), 1L, 0L, null, null, null, true, null, null));
+            }
+        }).isInstanceOf(java.io.IOException.class)
+                .hasMessage("failed to write Parquet part " + part)
+                .hasCauseInstanceOf(InvalidKeyEncodingException.class)
+                .rootCause()
+                .hasMessage("Parquet key is not well-formed UTF-8: key_hex_prefix=" + hex(malformed));
+    }
+
+    private static Object[][] malformedUtf8() {
+        return new Object[][]{
+                {"invalid lead", new byte[]{'a', (byte) 0xFF, 'z'}},
+                {"surrogate", new byte[]{(byte) 0xED, (byte) 0xA0, (byte) 0x80}},
+                {"overlong", new byte[]{(byte) 0xE0, (byte) 0x80, (byte) 0x80}},
+                {"truncated tail", new byte[]{(byte) 0xF0, (byte) 0x9F, (byte) 0x9A}}
+        };
+    }
+
+    private static String hex(byte[] bytes) {
+        return java.util.HexFormat.of().formatHex(bytes);
     }
 }

--- a/swath-core/src/test/java/io/varve/swath/output/parquet/PartWriterStreamingDigestTest.java
+++ b/swath-core/src/test/java/io/varve/swath/output/parquet/PartWriterStreamingDigestTest.java
@@ -98,6 +98,7 @@ final class PartWriterStreamingDigestTest {
             for (int batchRow = 0; batchRow < 1000; batchRow++) {
                 byte[] key = new byte[1024];
                 random.nextBytes(key);
+                ParquetPoolTestSupport.printableAscii(key);
                 writer.write(new ObjectEntry(KeyBytes.of(key), rows, 1_700_000_000_000_000L + rows,
                         "etag", "STANDARD", null, true, null, null, null, null));
                 rows++;

--- a/swath-core/src/test/java/io/varve/swath/sort/FinalizationPipelinePropertyTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/FinalizationPipelinePropertyTest.java
@@ -31,10 +31,11 @@ class FinalizationPipelinePropertyTest {
             new byte[]{},
             new byte[]{0},
             new byte[]{0, 0},
-            new byte[]{0, (byte) 0xFF},
-            new byte[]{(byte) 0xFF},
-            new byte[]{(byte) 0xFF, 0},
-            new byte[]{(byte) 0xFF, (byte) 0xFF},
+            new byte[]{0, (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF},
+            new byte[]{(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF},
+            new byte[]{(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF, 0},
+            new byte[]{(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF,
+                    (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF},
     };
 
     private final ListEntryComparator comparator = new ListEntryComparator();

--- a/swath-core/src/test/java/io/varve/swath/sort/PropSortContractTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/PropSortContractTest.java
@@ -57,8 +57,8 @@ import org.apache.parquet.schema.MessageType;
  *       {@code version_id} and equal-comparing cross-type entries; (iii) equal-comparing entries all
  *       survive the merge — none dropped — and keep stable input order within one segment.</li>
  *   <li><b>PROP-SORT-2</b> — canonical Parquet → {@link SegmentReader} round-trips every {@link
- *       ListEntry} subtype for arbitrary generated entries incl. {@code 0x00}/{@code 0xFF} bytes in
- *       keys, 1&nbsp;KB keys, unicode, null optional fields, the empty segment, and a single
+ *       ListEntry} subtype for arbitrary generated entries incl. NUL/U+10FFFF in keys,
+ *       1&nbsp;KB keys, unicode, null optional fields, the empty segment, and a single
  *       record.</li>
  *   <li><b>PROP-SORT-3</b> — {@link SortedFileIndex#firstKeysPerRowGroup} equals each row group's
  *       true first row for adversarial key shapes, and provably NOT the (truncated) footer stats:
@@ -196,16 +196,18 @@ class PropSortContractTest {
     }
 
     @Example
-    void nulAndFfAndKiloKeysRoundTrip() throws IOException {
+    void nulAndHighScalarAndKiloKeysRoundTrip() throws IOException {
         List<ListEntry> es = new ArrayList<>();
         es.add(new ObjectEntry(KeyBytes.of(new byte[]{0, 0, 0}), 1L, 0L, null, null, null, false,
                 null, null, null, null));
-        es.add(new ObjectEntry(KeyBytes.of(new byte[]{(byte) 0xFF, (byte) 0xFF}), 2L, 0L, null, null,
+        es.add(new ObjectEntry(KeyBytes.of("\uDBFF\uDFFF".getBytes(StandardCharsets.UTF_8)), 2L, 0L, null, null,
                 null, false, null, null, null, null));
         es.add(new ObjectEntry(KeyBytes.of(kiloKey(7)), 3L, 0L, "日本語etag", "STANDARD", null, false,
                 null, null, null, null));
         es.add(new CommonPrefixEntry(KeyBytes.of("café/😀/".getBytes(StandardCharsets.UTF_8))));
-        es.add(new DeleteMarkerEntry(KeyBytes.of(new byte[]{0, (byte) 0xFF}), "vDel", true, 99L, "o"));
+        es.add(new DeleteMarkerEntry(KeyBytes.of(new byte[]{0, (byte) 0xF4, (byte) 0x8F,
+                (byte) 0xBF, (byte) 0xBF}),
+                "vDel", true, 99L, "o"));
         assertRoundTrips(es);
     }
 
@@ -291,7 +293,7 @@ class PropSortContractTest {
             "b".getBytes(StandardCharsets.UTF_8),
             "m".getBytes(StandardCharsets.UTF_8),
             new byte[]{0},
-            new byte[]{(byte) 0xFF},
+            "\uDBFF\uDFFF".getBytes(StandardCharsets.UTF_8),
             "😀".getBytes(StandardCharsets.UTF_8));
 
     private Arbitrary<ListEntry> collidingEntry() {
@@ -330,17 +332,18 @@ class PropSortContractTest {
 
     private Arbitrary<byte[]> richKey() {
         Arbitrary<byte[]> pool = Arbitraries.of(KEY_POOL);
-        Arbitrary<byte[]> nulFf = Arbitraries.of(
-                new byte[]{0, 0, 0}, new byte[]{(byte) 0xFF, (byte) 0xFF},
-                new byte[]{0, (byte) 0xFF, 0, (byte) 0xFF});
+        Arbitrary<byte[]> nulAndHighScalar = Arbitraries.of(
+                new byte[]{0, 0, 0}, "\uDBFF\uDFFF".getBytes(StandardCharsets.UTF_8),
+                new byte[]{0, (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF,
+                        0, (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF});
         Arbitrary<byte[]> kilo = Arbitraries.integers().between(0, 1 << 20).map(PropSortContractTest::kiloKey);
         Arbitrary<byte[]> unicode = Arbitraries.of("café/1", "мир/2", "emoji/😀/x")
                 .map(s -> s.getBytes(StandardCharsets.UTF_8));
-        return Arbitraries.oneOf(pool, nulFf, kilo, unicode);
+        return Arbitraries.oneOf(pool, nulAndHighScalar, kilo, unicode);
     }
 
     enum KeyShape {
-        /** 1 KB keys embedding {@code 0x00} and {@code 0xFF}, ascending in a fixed tail. */
+        /** 1 KB valid UTF-8 keys embedding NUL and U+10FFFF, ascending in a fixed tail. */
         KILO_ADVERSARIAL,
         /** Short ascending ASCII keys (small files → often a single row group). */
         ASCII_SHORT,
@@ -413,15 +416,17 @@ class PropSortContractTest {
         return keys;
     }
 
-    /** {@code i}-th 1024-byte key: embeds {@code 0x00}/{@code 0xFF} at the head, ascending in the tail. */
+    /** {@code i}-th 1024-byte key: embeds NUL/U+10FFFF at the head, ascending in the tail. */
     private static byte[] kiloKey(int i) {
         byte[] key = new byte[1024];
         key[0] = 0x00;
-        key[1] = (byte) 0xFF;
-        key[1020] = (byte) ((i >>> 24) & 0xFF);
-        key[1021] = (byte) ((i >>> 16) & 0xFF);
-        key[1022] = (byte) ((i >>> 8) & 0xFF);
-        key[1023] = (byte) (i & 0xFF);
+        key[1] = (byte) 0xF4;
+        key[2] = (byte) 0x8F;
+        key[3] = (byte) 0xBF;
+        key[4] = (byte) 0xBF;
+        java.util.Arrays.fill(key, 5, key.length - 8, (byte) 'x');
+        byte[] suffix = String.format("%08x", i).getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(suffix, 0, key, key.length - suffix.length, suffix.length);
         return key;
     }
 

--- a/swath-core/src/test/java/io/varve/swath/sort/SortedFileIndexTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortedFileIndexTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * {@link SortedFileIndex#firstKeysPerRowGroup} — the index-derive API (§9.1): derived first keys
  * must exactly match the true first row of each row group (never Parquet footer stats), including
- * for adversarial key shapes (1&nbsp;KB, embedded {@code 0x00}/{@code 0xFF} bytes) and for a file
+ * for adversarial key shapes (1&nbsp;KB, embedded NUL/U+10FFFF) and for a file
  * whose truncated footer stats provably diverge from the true first row.
  */
 class SortedFileIndexTest {
@@ -102,10 +102,10 @@ class SortedFileIndexTest {
     }
 
     @Test
-    void derivesTrueFirstKeysFor1KbKeysWithEmbeddedNulAndFfBytes(@TempDir Path dir) throws IOException {
+    void derivesTrueFirstKeysFor1KbKeysWithEmbeddedNulAndHighScalar(@TempDir Path dir) throws IOException {
         List<byte[]> keys = new ArrayList<>();
         for (int i = 0; i < 150; i++) {
-            keys.add(adversarialKey(i));   // 1024 B, ascending, embeds 0x00 and 0xFF
+            keys.add(adversarialKey(i));   // 1024 B, ascending, embeds NUL and U+10FFFF
         }
         Path path = dir.resolve("part-00001.parquet");
         SortConfig tinyRowGroups = config(Map.of("final-row-group-bytes", "4096"));
@@ -259,16 +259,17 @@ class SortedFileIndexTest {
         }
     }
 
-    /** {@code i}-th 1024-byte key: ascending, embeds a run of {@code 0x00} then a run of {@code 0xFF}. */
+    /** {@code i}-th 1024-byte key: ascending, valid UTF-8 with NUL and U+10FFFF. */
     private static byte[] adversarialKey(int i) {
         byte[] key = new byte[1024];
         key[0] = 0x00;
-        key[1] = (byte) 0xFF;
-        // Ascending, distinguishing suffix at a fixed tail position (unsigned byte order).
-        key[1020] = (byte) ((i >>> 24) & 0xFF);
-        key[1021] = (byte) ((i >>> 16) & 0xFF);
-        key[1022] = (byte) ((i >>> 8) & 0xFF);
-        key[1023] = (byte) (i & 0xFF);
+        key[1] = (byte) 0xF4;
+        key[2] = (byte) 0x8F;
+        key[3] = (byte) 0xBF;
+        key[4] = (byte) 0xBF;
+        java.util.Arrays.fill(key, 5, key.length - 8, (byte) 'x');
+        byte[] suffix = String.format("%08x", i).getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(suffix, 0, key, key.length - suffix.length, suffix.length);
         return key;
     }
 

--- a/swath-core/src/test/java/io/varve/swath/sort/SortedParquetWriterTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/SortedParquetWriterTest.java
@@ -332,6 +332,9 @@ class SortedParquetWriterTest {
         byte[] prefix = String.format("%08d-", row).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
         byte[] suffix = new byte[key.length - prefix.length];
         random.nextBytes(suffix);
+        for (int i = 0; i < suffix.length; i++) {
+            suffix[i] = (byte) (0x20 + (suffix[i] & 0x3F));
+        }
         System.arraycopy(prefix, 0, key, 0, prefix.length);
         System.arraycopy(suffix, 0, key, prefix.length, suffix.length);
         return new ObjectEntry(KeyBytes.of(key), row, 1_700_000_000_000_000L + row,

--- a/swath-model/src/main/java/io/varve/swath/model/ByteMidpoint.java
+++ b/swath-model/src/main/java/io/varve/swath/model/ByteMidpoint.java
@@ -220,20 +220,6 @@ public final class ByteMidpoint {
     }
 
     /**
-     * True iff {@code bytes} is valid UTF-8 — the precondition {@link #between} enforces on
-     * its bounds. Lets callers screen a synthetic bound (e.g. a {@code prefixCeil} that bumped
-     * a continuation byte) before passing it in, rather than catching the precondition throw.
-     */
-    public static boolean isValidUtf8(byte[] bytes) {
-        try {
-            strictDecoder().decode(ByteBuffer.wrap(bytes));
-            return true;
-        } catch (CharacterCodingException e) {
-            return false;
-        }
-    }
-
-    /**
      * Open-frontier forward pivot (algorithms.md §3.1): reflect the consumed span {@code (lo, c]}
      * forward in <b>code-point</b> space to a valid-UTF-8 {@code m > c} that shares {@code c}'s
      * leading code points, so a retry-nearer-cursor can refine an overshoot by bisecting within

--- a/swath-model/src/main/java/io/varve/swath/model/KeyBytes.java
+++ b/swath-model/src/main/java/io/varve/swath/model/KeyBytes.java
@@ -46,6 +46,54 @@ public final class KeyBytes implements Comparable<KeyBytes> {
         return Arrays.compareUnsigned(a, b);
     }
 
+    /** True when {@code bytes} is a well-formed UTF-8 encoding. */
+    public static boolean isValidUtf8(byte[] bytes) {
+        int end = bytes.length;
+        for (int p = 0; p < end; ) {
+            int first = bytes[p] & 0xFF;
+            int width;
+            int secondMin = 0x80;
+            int secondMax = 0xBF;
+            if (first <= 0x7F) {
+                p++;
+                continue;
+            } else if (first >= 0xC2 && first <= 0xDF) {
+                width = 2;
+            } else if (first >= 0xE0 && first <= 0xEF) {
+                width = 3;
+                if (first == 0xE0) {
+                    secondMin = 0xA0;
+                } else if (first == 0xED) {
+                    secondMax = 0x9F;
+                }
+            } else if (first >= 0xF0 && first <= 0xF4) {
+                width = 4;
+                if (first == 0xF0) {
+                    secondMin = 0x90;
+                } else if (first == 0xF4) {
+                    secondMax = 0x8F;
+                }
+            } else {
+                return false;
+            }
+            if (p > end - width) {
+                return false;
+            }
+            int second = bytes[p + 1] & 0xFF;
+            if (second < secondMin || second > secondMax) {
+                return false;
+            }
+            for (int i = 2; i < width; i++) {
+                int continuation = bytes[p + i] & 0xFF;
+                if (continuation < 0x80 || continuation > 0xBF) {
+                    return false;
+                }
+            }
+            p += width;
+        }
+        return true;
+    }
+
     @Override
     public int compareTo(KeyBytes o) {
         return Arrays.compareUnsigned(this.raw, o.raw);

--- a/swath-model/src/test/java/io/varve/swath/model/ByteMidpointEdgeCasesTest.java
+++ b/swath-model/src/test/java/io/varve/swath/model/ByteMidpointEdgeCasesTest.java
@@ -60,7 +60,7 @@ class ByteMidpointEdgeCasesTest {
     }
 
     private static void assertValidUtf8(byte[] bytes) {
-        assertThat(ByteMidpoint.isValidUtf8(bytes)).as("not valid UTF-8: %s", Arrays.toString(bytes)).isTrue();
+        assertThat(KeyBytes.isValidUtf8(bytes)).as("not valid UTF-8: %s", Arrays.toString(bytes)).isTrue();
     }
 
     private static void assertNoSurrogate(byte[] m) {

--- a/swath-model/src/test/java/io/varve/swath/model/ByteMidpointHostileChooserTest.java
+++ b/swath-model/src/test/java/io/varve/swath/model/ByteMidpointHostileChooserTest.java
@@ -97,7 +97,7 @@ final class ByteMidpointHostileChooserTest {
             } else {
                 assertThat(Arrays.compareUnsigned(a, m)).as("a < m (%s)", Arrays.toString(m)).isNegative();
                 assertThat(Arrays.compareUnsigned(m, b)).as("m < b (%s)", Arrays.toString(m)).isNegative();
-                assertThat(ByteMidpoint.isValidUtf8(m)).as("m is valid UTF-8 (%s)", Arrays.toString(m)).isTrue();
+                assertThat(KeyBytes.isValidUtf8(m)).as("m is valid UTF-8 (%s)", Arrays.toString(m)).isTrue();
                 assertNoExcludedScalar(m);
             }
         }

--- a/swath-model/src/test/java/io/varve/swath/model/ByteMidpointPropertyTest.java
+++ b/swath-model/src/test/java/io/varve/swath/model/ByteMidpointPropertyTest.java
@@ -51,7 +51,7 @@ class ByteMidpointPropertyTest {
         } else {
             assertThat(Arrays.compareUnsigned(a, m)).as("a < m").isNegative();
             assertThat(Arrays.compareUnsigned(m, b)).as("m < b").isNegative();
-            assertThat(ByteMidpoint.isValidUtf8(m)).as("m is valid UTF-8: %s", Arrays.toString(m)).isTrue();
+            assertThat(KeyBytes.isValidUtf8(m)).as("m is valid UTF-8: %s", Arrays.toString(m)).isTrue();
         }
     }
 
@@ -114,7 +114,7 @@ class ByteMidpointPropertyTest {
             assertThat(m).isNotNull();
             assertThat(Arrays.compareUnsigned(a, m)).as("a < m").isNegative();
             assertThat(Arrays.compareUnsigned(m, b)).as("m < b").isNegative();
-            assertThat(ByteMidpoint.isValidUtf8(m)).as("m is valid UTF-8").isTrue();
+            assertThat(KeyBytes.isValidUtf8(m)).as("m is valid UTF-8").isTrue();
             assertNoExcluded(m, "between");   // a is safe and the synthesized scalar is safe
         }
     }
@@ -137,7 +137,7 @@ class ByteMidpointPropertyTest {
         assertThat(m.length).isLessThanOrEqualTo(1024);
         assertThat(Arrays.compareUnsigned(a, m)).as("a < m").isNegative();
         assertThat(Arrays.compareUnsigned(m, b)).as("m < b").isNegative();
-        assertThat(ByteMidpoint.isValidUtf8(m)).as("m is valid UTF-8").isTrue();
+        assertThat(KeyBytes.isValidUtf8(m)).as("m is valid UTF-8").isTrue();
     }
 
     /** ASCII leads whose +1 successor is still a single-byte scalar (0x41..0x7D ⇒ ≤0x7E). */

--- a/swath-model/src/test/java/io/varve/swath/model/KeyBytesTest.java
+++ b/swath-model/src/test/java/io/varve/swath/model/KeyBytesTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * UNIT-1 (I10): {@code KeyBytes.compareUnsigned} (S3's UTF-8 byte
@@ -17,6 +19,42 @@ import org.junit.jupiter.api.Test;
  * {@code String} comparison for boundaries is a silent correctness bug.
  */
 class KeyBytesTest {
+
+    @ParameterizedTest(name = "accepts well-formed UTF-8 {0}")
+    @MethodSource("wellFormedUtf8")
+    void recognizesWellFormedUtf8(String description, byte[] bytes) {
+        assertThat(KeyBytes.isValidUtf8(bytes)).as(description).isTrue();
+    }
+
+    @ParameterizedTest(name = "rejects malformed UTF-8 {0}")
+    @MethodSource("malformedUtf8")
+    void rejectsMalformedUtf8(String description, byte[] bytes) {
+        assertThat(KeyBytes.isValidUtf8(bytes)).as(description).isFalse();
+    }
+
+    private static Object[][] malformedUtf8() {
+        return new Object[][]{
+                {"bare continuation", new byte[]{(byte) 0x80}},
+                {"invalid lead", new byte[]{(byte) 0xFF}},
+                {"two-byte overlong", new byte[]{(byte) 0xC0, (byte) 0x80}},
+                {"three-byte overlong", new byte[]{(byte) 0xE0, (byte) 0x80, (byte) 0x80}},
+                {"four-byte overlong", new byte[]{(byte) 0xF0, (byte) 0x80, (byte) 0x80, (byte) 0x80}},
+                {"surrogate", new byte[]{(byte) 0xED, (byte) 0xA0, (byte) 0x80}},
+                {"above Unicode maximum", new byte[]{(byte) 0xF4, (byte) 0x90, (byte) 0x80, (byte) 0x80}},
+                {"truncated multibyte tail", new byte[]{(byte) 0xE2, (byte) 0x82}}
+        };
+    }
+
+    private static Object[][] wellFormedUtf8() {
+        return new Object[][]{
+                {"empty", new byte[0]},
+                {"ASCII", "plain/ascii".getBytes(StandardCharsets.UTF_8)},
+                {"two-byte minimum", new byte[]{(byte) 0xC2, (byte) 0x80}},
+                {"BMP below surrogate", new byte[]{(byte) 0xED, (byte) 0x9F, (byte) 0xBF}},
+                {"BMP above surrogate", new byte[]{(byte) 0xEE, (byte) 0x80, (byte) 0x80}},
+                {"Unicode maximum", new byte[]{(byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF}}
+        };
+    }
 
     @Test
     void supplementaryVsBmpKeysOrderOppositelyUnderByteVsUtf16() {

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/DuckDbListingStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/DuckDbListingStore.java
@@ -215,19 +215,34 @@ public final class DuckDbListingStore implements ListingStore {
         try (var st = connection.createStatement()) {
             st.execute("CREATE TEMP VIEW replay_parquet_source AS SELECT * FROM read_parquet(%s)".formatted(path));
             Set<String> columns = describeColumns(connection, "replay_parquet_source");
+            String key = "VARCHAR".equals(columnType(connection, "replay_parquet_source", "key"))
+                    ? "encode(key)"
+                    : "key";
             String ownerDisplayName = optionalColumn(columns, "owner_display_name", "NULL::VARCHAR");
             String checksumType = optionalColumn(columns, "checksum_type",
                     "CASE WHEN checksum_algorithm IS NOT NULL THEN 'FULL_OBJECT' ELSE NULL END");
             st.execute("""
                     CREATE TABLE listing_objects AS
-                    SELECT key, size, last_modified, etag, storage_class, owner_id,
+                    SELECT %s AS key, size, last_modified, etag, storage_class, owner_id,
                            %s AS owner_display_name,
                            checksum_algorithm,
                            %s AS checksum_type
                     FROM replay_parquet_source
                     WHERE row_type = 'OBJECT'
-                    """.formatted(ownerDisplayName, checksumType));
+                    """.formatted(key, ownerDisplayName, checksumType));
         }
+    }
+
+    private static String columnType(Connection connection, String relation, String column) throws SQLException {
+        try (var st = connection.createStatement();
+             ResultSet rs = st.executeQuery("DESCRIBE " + relation)) {
+            while (rs.next()) {
+                if (column.equals(rs.getString("column_name"))) {
+                    return rs.getString("column_type");
+                }
+            }
+        }
+        throw new SQLException("missing required replay column: " + column);
     }
 
     private static Set<String> describeColumns(Connection connection, String relation) throws SQLException {

--- a/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
+++ b/swath-replay/src/main/java/io/varve/swath/replay/store/SortedParquetStore.java
@@ -62,12 +62,12 @@ import java.util.Set;
  * <p>Owner columns are decoded only when {@link Projection#owner()} — the whole point of the
  * projection, unlike the DuckDB store where they are behavior-cheap.
  *
- * <p>Unlike {@link DuckDbListingStore}, this store assumes the <b>canonical</b> current schema
- * unconditionally (no {@code owner_display_name}/{@code checksum_type} legacy-column backfill): every
- * sorted file is produced by the in-tree {@code SortedParquetWriter}, which always writes the full
- * canonical schema, so there is no legacy-schema
- * sorted file for this store to tolerate — unlike {@code DuckDbListingStore}, which must also serve
- * arbitrary pre-existing unsorted captures written by older schema versions.
+ * <p>Unlike {@link DuckDbListingStore}, this store assumes the <b>canonical</b> column set
+ * unconditionally (no {@code owner_display_name}/{@code checksum_type} legacy-column backfill). It
+ * derives projections from each file's own schema, so both the former unannotated BINARY {@code key}
+ * and the current STRING-annotated BINARY form remain readable. Other legacy schema variation is not
+ * supported here — unlike {@code DuckDbListingStore}, which must also serve arbitrary pre-existing
+ * unsorted captures written by older schema versions.
  *
  * <p>Row groups are addressed by the routing index and never scanned for, so a read touches no group
  * before the one it starts in. Readers are pooled because a Parquet reader carries mutable per-read

--- a/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/server/SortedServingFullDifferentialTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * <p>Keyspaces cover: flat listings; delimiter'd deep hierarchies; a giant single prefix spanning
  * many row groups; keys straddling row-group boundaries at various {@code max-keys}; a
- * {@code successor(P)}-is-a-real-key case; {@code 0xFF}-laden keys; and a multi-byte delimiter. Each
+ * {@code successor(P)}-is-a-real-key case; high-scalar UTF-8 keys; and a multi-byte delimiter. Each
  * runs the {@code encoding-type=url} on/off × {@code fetch-owner} on/off matrix, and the whole thing
  * runs once more over a <b>rolled multi-file</b> sorted fixture (tiny {@code final-file-bytes}) to
  * prove the file-aware index serves identically.
@@ -206,16 +206,15 @@ class SortedServingFullDifferentialTest {
     }
 
     @Test
-    void ffLadenKeysAreByteIdentical(@TempDir Path dir) throws Exception {
+    void highScalarKeysAreByteIdentical(@TempDir Path dir) throws Exception {
         List<byte[]> keys = new ArrayList<>();
         for (int i = 0; i < 12; i++) {
             keys.add(new byte[]{'k', (byte) i});
-            keys.add(new byte[]{'k', (byte) i, (byte) 0xFF});
-            keys.add(new byte[]{'k', (byte) i, (byte) 0xFF, (byte) 0x01});
+            keys.add(new byte[]{'k', (byte) i, (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF});
+            keys.add(new byte[]{'k', (byte) i, (byte) 0xF4, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF, 0x01});
         }
-        keys.add(new byte[]{(byte) 0xFF});                        // all-0xFF: successor is end-of-keyspace
-        keys.add(new byte[]{(byte) 0xFF, (byte) 0xFF});
-        // 0xFF is not valid UTF-8, so only encoding-type=url is safe here; both projections of it.
+        keys.add("\uDBFF\uDFFF".getBytes(StandardCharsets.UTF_8));
+        keys.add("\uDBFF\uDFFF\uDBFF\uDFFF".getBytes(StandardCharsets.UTF_8));
         List<Scenario> scenarios = new ArrayList<>();
         scenarios.add(new Scenario(null, null, null, 1, true, false));
         scenarios.add(new Scenario(null, null, null, 3, true, true));

--- a/swath-replay/src/test/java/io/varve/swath/replay/store/DuckDbListingStoreTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/store/DuckDbListingStoreTest.java
@@ -8,6 +8,10 @@ package io.varve.swath.replay.store;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.varve.swath.model.KeyBytes;
+import io.varve.swath.model.ObjectEntry;
+import io.varve.swath.output.parquet.ParquetSchema;
+import io.varve.swath.output.parquet.PartWriter;
 import io.varve.swath.replay.protocol.ByteKey;
 import io.varve.swath.replay.protocol.ByteKeys;
 import io.varve.swath.replay.protocol.ListedObject;
@@ -19,14 +23,48 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Isolated // The legacy-timestamp regression test changes java.util.TimeZone's JVM-global default.
 class DuckDbListingStoreTest {
+
+    @ParameterizedTest(name = "key STRING annotation present: {0}")
+    @ValueSource(booleans = {false, true})
+    void readsFormerAndCurrentKeyAnnotations(boolean stringAnnotation, @TempDir Path dir)
+            throws Exception {
+        Path parquet = dir.resolve(stringAnnotation ? "string-key.parquet" : "binary-key.parquet");
+        writeParquet(parquet, stringAnnotation, "a/1", "b/2");
+
+        try (DuckDbListingStore store = new DuckDbListingStore(parquet)) {
+            assertThat(keys(store.rows(null, true, null, 10, Projection.KEYS_ONLY)))
+                    .containsExactly("a/1", "b/2");
+        }
+    }
+
+    @ParameterizedTest(name = "legacy file sorts first in glob: {0}")
+    @ValueSource(booleans = {false, true})
+    void readsDatasetDirectoryMixingFormerAndCurrentKeyAnnotations(
+            boolean legacySortsFirst, @TempDir Path dir) throws Exception {
+        String legacyName = legacySortsFirst ? "a-legacy.parquet" : "z-legacy.parquet";
+        String currentName = legacySortsFirst ? "z-current.parquet" : "a-current.parquet";
+        writeParquet(dir.resolve(legacyName), false, "a/legacy");
+        writeParquet(dir.resolve(currentName), true, "b/current");
+
+        try (DuckDbListingStore store = new DuckDbListingStore(dir)) {
+            assertThat(keys(store.rows(null, true, null, 10, Projection.KEYS_ONLY)))
+                    .containsExactly("a/legacy", "b/current");
+        }
+    }
 
     @Test
     void returnsAllRowsInAscendingKeyOrderForAnOpenRange() throws Exception {
@@ -112,6 +150,23 @@ class DuckDbListingStoreTest {
 
     private static DuckDbListingStore store(Row... rows) throws Exception {
         return store(new ReplayMetrics(), rows);
+    }
+
+    private static void writeParquet(Path path, boolean stringAnnotation, String... keys)
+            throws Exception {
+        MessageType canonical = ParquetSchema.canonical();
+        MessageType schema = canonical;
+        if (!stringAnnotation) {
+            var fields = new ArrayList<>(canonical.getFields());
+            fields.set(0, Types.required(PrimitiveTypeName.BINARY).named("key"));
+            schema = new MessageType(canonical.getName(), fields);
+        }
+        try (PartWriter writer = new PartWriter(path, schema)) {
+            for (String key : keys) {
+                writer.write(ObjectEntry.withoutOwnerDisplayNameAndChecksumType(
+                        KeyBytes.ofUtf8(key), 1L, 0L, null, null, null, true, null, null));
+            }
+        }
     }
 
     private static DuckDbListingStore store(ReplayMetrics metrics, Row... rows) throws Exception {

--- a/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
+++ b/swath-replay/src/test/java/io/varve/swath/replay/store/SortedParquetStoreTest.java
@@ -13,6 +13,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.varve.swath.model.CommonPrefixEntry;
 import io.varve.swath.model.KeyBytes;
 import io.varve.swath.model.ObjectEntry;
+import io.varve.swath.output.parquet.ParquetSchema;
+import io.varve.swath.output.parquet.PartWriter;
 import io.varve.swath.replay.fixture.FixtureMetrics;
 import io.varve.swath.replay.fixture.SortedFixtures;
 import io.varve.swath.replay.fixture.SortedFixtures.IndexEntry;
@@ -44,8 +46,13 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * {@link SortedParquetStore} over real, multi-row-group stamped sorted files (built through {@link
@@ -68,6 +75,32 @@ class SortedParquetStoreTest {
                 .withFinalRowGroupBytes(1024L)
                 .withSegmentEntries(1)
                 .withMergeBudgetBytes(64L << 20);
+    }
+
+    @ParameterizedTest(name = "key STRING annotation present: {0}")
+    @ValueSource(booleans = {false, true})
+    void readsFormerAndCurrentKeyAnnotations(boolean stringAnnotation, @TempDir Path dir)
+            throws IOException {
+        MessageType canonical = ParquetSchema.canonical();
+        MessageType schema = canonical;
+        if (!stringAnnotation) {
+            var fields = new ArrayList<>(canonical.getFields());
+            fields.set(0, Types.required(PrimitiveTypeName.BINARY).named("key"));
+            schema = new MessageType(canonical.getName(), fields);
+        }
+        Path file = dir.resolve(stringAnnotation ? "string-key.parquet" : "binary-key.parquet");
+        try (PartWriter writer = new PartWriter(file, schema)) {
+            writer.write(object("a/1"));
+            writer.write(object("b/2"));
+        }
+        List<Path> files = List.of(file);
+        IndexLoadResult result = SortedFixtures.loadIndex(files, new FixtureMetrics());
+        List<IndexEntry> index = ((IndexLoadResult.Loaded) result).entries();
+
+        try (SortedParquetStore store = new SortedParquetStore(files, index, new ReplayMetrics(), 1)) {
+            assertThat(keyStrings(store.rows(null, true, null, 10, Projection.KEYS_ONLY)))
+                    .containsExactly("a/1", "b/2");
+        }
     }
 
     @Test

--- a/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
+++ b/swath-sim/src/test/java/io/varve/swath/sim/store/SimStoreDifferentialTest.java
@@ -234,16 +234,17 @@ class SimStoreDifferentialTest {
         addUtf8(keys, "/", "a", "a/", "a//b", "a/b", "a/b/", "a/b/c", "ab");
         // §11.3 / §11.13 — prefix-of and NUL cases around a boundary: "a" < "a\0" < "a/" < "ab".
         keys.add(new byte[]{'a', 0x00});
-        // §11.1 / §11.2 — arbitrary key bytes in UNSIGNED order: '~' (0x7E) sorts BEFORE every
-        // 0x80+ byte, which UTF-16 order would get wrong.
+        // §11.1 / §11.2 — UTF-8 bytes in UNSIGNED order: '~' (0x7E) sorts BEFORE every
+        // multibyte scalar, including cases whose UTF-16 order differs.
         addUtf8(keys, "~tilde", "é-accent", "日本");
         keys.add(new byte[]{'k', 0x01});
-        keys.add(new byte[]{'k', (byte) 0x80});
-        keys.add(new byte[]{'k', (byte) 0xFF});
-        keys.add(new byte[]{'k', (byte) 0xFF, (byte) 0xFF});
-        // §11.13 — 0xFF runs, including the all-0xFF key whose successor is end-of-keyspace.
-        keys.add(new byte[]{(byte) 0xFF});
-        keys.add(new byte[]{(byte) 0xFF, (byte) 0xFF});
+        keys.add(utf8("k\u0080"));
+        keys.add(utf8("k\uDBFF\uDFFF"));
+        keys.add(utf8("k\uDBFF\uDFFF\uDBFF\uDFFF"));
+        // §11.13 — high scalar runs near the maximum valid UTF-8 boundary. Raw 0xFF successor
+        // saturation remains covered by ByteKeys tests because persisted Parquet keys are STRING.
+        keys.add(utf8("\uDBFF\uDFFF"));
+        keys.add(utf8("\uDBFF\uDFFF\uDBFF\uDFFF"));
         // §11.13 — very long keys at and just under the 1024-byte ceiling, one a prefix of the other.
         keys.add(longKey(KeyArena.MAX_KEY_BYTES - 1));
         keys.add(longKey(KeyArena.MAX_KEY_BYTES));
@@ -281,7 +282,7 @@ class SimStoreDifferentialTest {
         addProjections(scenarios, utf8("wide/"), utf8("/"), null, 2, 1000);
         addProjections(scenarios, null, utf8("0"), null, 3);
         // §11.3 — start-after is exclusive: at a key, between keys, and past the last key of all
-        // (0xFF 0xFF is a real key here, so only 0xFF 0xFF 0xFF is genuinely past the end).
+        // (0xFF is outside valid UTF-8, so this raw boundary is genuinely past every fixture key).
         addProjections(scenarios, null, null, utf8("a/b"), 1, 3);
         addProjections(scenarios, null, null, utf8("wide/074"), 2, 1000);
         addProjections(scenarios, null, null, new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 5);


### PR DESCRIPTION
## Summary
WP2.1 (owner decision §D-1, decided 2026-08-29): the `key` column gets `stringType()` outright — no flag, no compatibility mode. S3/GCS/Azure keys are UTF-8 by API definition; the raw-bytes model stays correct *inside* the engine and stops leaking into the user-facing schema. Every DuckDB/Spark/pandas query stops starting with a cast.

- `ParquetSchema`: `required(BINARY).as(stringType()).named("key")` — `key` was the only unannotated BINARY column; the schema is now self-consistent.
- **Physical neutrality proven**: STRING-annotated BINARY keeps the same unsigned-lexicographic ordering, stats, and column-index truncation (verified against parquet-column 1.15.1 bytecode by the second-model review); only the footer annotation bytes change; full-row multiset digest unchanged.
- **UTF-8 guarded at write** with a typed error naming the key's hex prefix and the affected part path; validation consolidated onto `KeyBytes` (the tree had two ad-hoc validators — now one), with direct valid/invalid table tests plus rejection cases for `0xFF`, surrogates, overlong encodings, and truncated tails. Fixtures and the engine still accept arbitrary bytes — only output rejects.
- **Replay serves both forms**: `SortedParquetStore` and `DuckDbListingStore` read legacy BLOB and new VARCHAR files, including mixed-annotation dataset directories (tested in both filename orders; DuckDB unifies them).
- CHANGELOG created, documenting both consumer-facing effects: BLOB→VARCHAR for downstream queries, and legacy captures with non-UTF-8 keys can no longer be re-published or `--sort`ed.

## Review
Second-model review (Claude Opus, evidence not approval; full text follows as a comment): **CLEAN, no blockers**; its six should-fixes (rebase onto post-#169 main, DuckDB legacy-branch and mixed-dir tests, broader rejection cases, actually running the DuckDB IT, CHANGELOG completeness) are all addressed in this rebased commit. Gates: spotless, `:swath-core:test`, `:swath-replay:test`, `build -PnoIntegration`, and the DuckDB IT with `--rerun-tasks` — all green.

Refs roadmap WP2.1 / §D-1.