### PR TITLE
Stabilize CI regression fixtures

### DIFF
--- a/swath-core/src/test/java/io/varve/swath/runtime/SortPerfTest.java
+++ b/swath-core/src/test/java/io/varve/swath/runtime/SortPerfTest.java
@@ -60,9 +60,9 @@ import org.junit.jupiter.api.io.TempDir;
  *   <li><b>1&nbsp;KB-key variant</b> (the key-size-independence proof, the worst-case key-size
  *       envelope): the byte gate, not entry count, must still cap the buffer under the SAME
  *       corridor, and {@code SORT.buffer_byte_gated} must have engaged.</li>
- *   <li><b>Merge-phase stress</b>: hundreds of tiny staging segments and a
- *       tiny {@code merge-budget-bytes} so {@code SortConfig#effectiveFanIn()} forces
- *       a genuine multi-pass cascade — measured peak heap over the WHOLE run must still sit under the
+ *   <li><b>Merge-phase stress</b>: hundreds of tiny staging segments, a small pinned fan-in, and a
+ *       merge budget only large enough for the pipeline's minimum encoder residency force a genuine
+ *       multi-pass cascade — measured peak heap over the WHOLE run must still sit under the
  *       SAME corridor (the budget bound, not segment count, caps merge memory, I11), the cascade must
  *       actually have engaged ({@code swath.sort.merge.passes > 1} / {@code SORT.merge_pass_cascaded}),
  *       and every entry must survive exactly once.</li>
@@ -123,16 +123,17 @@ final class SortPerfTest {
     private static final int VARIANT_PAGE_MAX_KEYS = 20_000;
     private static final long VARIANT_SEGMENT_BYTES = 16L << 20;  // smaller gate: forces many byte-gated flushes
 
-    // Merge-phase stress: a MODEST entry count but a tiny segment-entries
-    // cap forces hundreds of staging segments, and a tiny merge-budget-bytes forces a small
-    // effectiveFanIn() (SortConfig §7) so the cascade genuinely runs multiple passes, exercising the
-    // budget-bounded merge end to end through the production pipeline.
+    // Merge-phase stress: a MODEST entry count but a tiny segment-entries cap forces hundreds of
+    // staging segments. The small pinned fan-in makes the cascade genuinely run multiple passes,
+    // while the merge budget remains close to the pipeline's minimum encoder-residency floor.
     private static final int MERGE_STRESS_N = 60_000;
     // == segment-entries, so every admitted PAGE trips the entry cap on its own (SortLane.admit checks
     // the trigger once per page, not per key) — a deterministic MERGE_STRESS_N/PAGE_MAX_KEYS segments.
     private static final int MERGE_STRESS_PAGE_MAX_KEYS = 100;
     private static final long MERGE_STRESS_SEGMENT_ENTRIES = 100;         // ⇒ ~600 staging segments
-    private static final long MERGE_STRESS_MERGE_BUDGET_BYTES = 8L << 20;
+    // A pipeline writer alone is conservatively priced at 8 MiB; leave room for its reference wave,
+    // decoded-page residency, and body read instead of configuring an impossible 8 MiB total.
+    private static final long MERGE_STRESS_MERGE_BUDGET_BYTES = 16L << 20;
     private static final int MERGE_STRESS_FAN_IN = 8;                            // pin fan-in = 8 directly
 
     private static RunKey sortKey(String label) {
@@ -295,12 +296,12 @@ final class SortPerfTest {
                         result.peakHeapBytes() / (1024 * 1024))
                 .isLessThan(HEAP_CORRIDOR_BYTES);
 
-        // (b) the merge actually cascaded — the tiny budget, not luck, forced multiple passes.
+        // (b) the merge actually cascaded — the pinned fan-in, not luck, forced multiple passes.
         assertThat(counter(result.ctx(), "swath.sort.merge.passes"))
                 .as("swath.sort.merge.passes > 1 — a genuine multi-pass cascade, not a single pass")
                 .isGreaterThan(1.0);
         assertThat(counter(result.ctx(), "swath.steal_reason", "merge_pass_cascaded"))
-                .as("SORT.merge_pass_cascaded engaged — the merge budget forced the cascade")
+                .as("SORT.merge_pass_cascaded engaged — the pinned fan-in forced the cascade")
                 .isGreaterThan(0.0);
     }
 

--- a/swath-core/src/test/java/io/varve/swath/testkit/MockPageFetcherTest.java
+++ b/swath-core/src/test/java/io/varve/swath/testkit/MockPageFetcherTest.java
@@ -31,6 +31,18 @@ class MockPageFetcherTest {
         return s.getBytes(StandardCharsets.UTF_8);
     }
 
+    @Test
+    void longKeyFixtureKeepsItsTailWidthAndS3LimitAcrossTheDecimalBoundary() {
+        int[] indices = {0, 99_999, 100_000, Integer.MAX_VALUE};
+        String[] tails = {"/0000000000", "/0000099999", "/0000100000", "/2147483647"};
+
+        for (int i = 0; i < indices.length; i++) {
+            byte[] key = Keyspaces.longKey1024(indices[i]);
+            assertThat(key).hasSize(1024);
+            assertThat(new String(key, StandardCharsets.UTF_8)).endsWith(tails[i]);
+        }
+    }
+
     /** Drain a flat OBJECTS listing by paginating on the last emitted key. */
     private static List<String> drainFlat(MockPageFetcher f, byte[] prefix) throws Exception {
         List<String> keys = new ArrayList<>();

--- a/swath-core/src/testFixtures/java/io/varve/swath/testkit/Keyspaces.java
+++ b/swath-core/src/testFixtures/java/io/varve/swath/testkit/Keyspaces.java
@@ -5,6 +5,7 @@
  */
 package io.varve.swath.testkit;
 
+import io.varve.swath.model.ByteMidpoint;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -137,17 +138,30 @@ public final class Keyspaces {
      * short numeric tail — exercises {@code byteMidpoint}'s long-key / cap-fallback path.
      */
     public static List<byte[]> longKeys1024(int n) {
-        int padLen = 1018;
-        byte[] pad = new byte[padLen];
-        Arrays.fill(pad, (byte) 'a');
         List<byte[]> keys = new ArrayList<>(n);
         for (int i = 0; i < n; i++) {
-            byte[] tail = String.format("/%05d", i).getBytes(StandardCharsets.UTF_8);
-            byte[] k = Arrays.copyOf(pad, padLen + tail.length);
-            System.arraycopy(tail, 0, k, padLen, tail.length);
-            keys.add(k);   // 1024 bytes total — long, multi-page-prefix, valid ASCII
+            keys.add(longKey1024(i));
         }
         return keys;
+    }
+
+    /** One fixture key at the requested index, exposed package-locally for cap-boundary tests. */
+    static byte[] longKey1024(int index) {
+        if (index < 0) {
+            throw new IllegalArgumentException("long-key fixture index must be non-negative");
+        }
+        // Ten decimal digits cover every non-negative int. Keeping that width fixed means the
+        // 100,000th key cannot silently grow to 1,025 bytes as it did with a five-digit tail.
+        int tailDigits = 10;
+        int padLen = ByteMidpoint.MAX_KEY_LEN - 1 - tailDigits;
+        byte[] key = new byte[ByteMidpoint.MAX_KEY_LEN];
+        Arrays.fill(key, 0, padLen, (byte) 'a');
+        key[padLen] = (byte) '/';
+        byte[] digits = Integer.toString(index).getBytes(StandardCharsets.US_ASCII);
+        int digitsStart = key.length - digits.length;
+        Arrays.fill(key, padLen + 1, digitsStart, (byte) '0');
+        System.arraycopy(digits, 0, key, digitsStart, digits.length);
+        return key;
     }
 
     /**

--- a/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
+++ b/swath-s3/src/test/java/io/varve/swath/store/s3/ProcessBearerTokenSupplierTest.java
@@ -159,9 +159,15 @@ class ProcessBearerTokenSupplierTest {
 
         long started = System.nanoTime();
         try {
-            assertThatThrownBy(supplier::token)
-                    .isInstanceOf(BearerTokenCommandException.class)
-                    .hasMessageContaining("output streams did not close within");
+            try {
+                // UnixProcess handling differs across JDK/platform combinations: some reapers
+                // close the immediate child's Java-side pipe as soon as that child exits, while
+                // others leave it open until the detached descriptor holder exits. Both outcomes
+                // are valid; the contract under test is that neither can block token() forever.
+                assertThat(supplier.token()).isEqualTo("token");
+            } catch (BearerTokenCommandException e) {
+                assertThat(e).hasMessageContaining("output streams did not close within");
+            }
             assertThat(Duration.ofNanos(System.nanoTime() - started))
                     .isLessThan(Duration.ofSeconds(5));
         } finally {


### PR DESCRIPTION
## Summary

- make the bearer-token cleanup regression portable across valid JDK pipe-reaper behavior while retaining its bounded-liveness contract
- keep the 1 KiB key fixture byte-exact across the six-digit index boundary
- give the merge stress fixture enough memory for one production encoder while retaining a forced multi-pass cascade

## Verification

- `./gradlew build -PnoIntegration`
- bearer-token regression repeated 20 times
- focused 1 KiB-key and merge-stress performance tests with `-Pperf -PonlyPerf`
- independent patch review: no blockers

Refs #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of merge stress handling and validation.
  * Corrected generation of long test keys, including large indices and consistent UTF-8 sizing.
  * Improved bearer-token cleanup behavior across supported platform conditions.

* **Tests**
  * Expanded regression coverage for large keys, multi-pass merges, and detached-process cleanup.
  * Kept cleanup checks bounded to prevent stalled operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->