### PR TITLE
Gate image advisories by distro priority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Instrumentation-drift guard self-test (§5)
         run: ./scripts/ci/check-instrumentation-drift.sh --self-test
 
+      # The image policy parses an external tool's JSON and resolves Ubuntu USN groups to
+      # their member CVE priorities. Synthetic fixtures keep that fail-closed boundary under
+      # the per-commit gate without downloading a scanner database or building an image.
+      - name: OSV image-policy self-test
+        run: python3 ./scripts/ci/osv-image-policy.py --self-test
+
       - name: Set up JDK 25
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,8 +103,10 @@ jobs:
   # has not moved. That is also why it belongs beside the deep tier: both are backstops
   # against drift the per-commit gate cannot see.
   #
-  # config/osv/osv-scanner.toml carries the argued exceptions, each with an expiry; anything
-  # else fails the job. See scripts/ci/osv-scan.sh.
+  # config/osv/osv-scanner.toml carries only the argued Java exceptions, each with an expiry.
+  # The checked-in image policy fails every unexpected non-Ubuntu advisory and Ubuntu
+  # high/critical/unknown priority while reporting lower Canonical priorities. See
+  # scripts/ci/osv-scan.sh and scripts/ci/osv-image-policy.py.
   osv-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -155,4 +157,14 @@ jobs:
           cache-from: type=gha,scope=swath-replay
 
       - name: Scan the runtime images
+        env:
+          OSV_REPORT_DIR: build/reports/osv
         run: ./scripts/ci/osv-scan.sh image:swath:osv image:swath-replay:osv
+
+      - name: Upload raw OSV image reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: osv-image-reports
+          path: build/reports/osv/*.json
+          if-no-files-found: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@
 # multi-arch INDEX digest (not a per-arch manifest), so `--platform` selection still
 # resolves every target normally. The tag is kept alongside it for readability and
 # because Dependabot updates both (.github/dependabot.yml, `docker` ecosystem).
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble@sha256:3eb81ed94d8c1a34422f19f8188548bdf02cae69c91d0328afdbb7abed90f617 AS build
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble@sha256:534968c051301957beae735e7ba1db54d99ddecf08746d3b9d4f318cc132dbc3 AS build
 WORKDIR /src
 
 # The checked-in legal notices verifier runs its renderer during shadowJar.
@@ -85,7 +85,7 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :swath-cli:sha
 # Digest-pinned for the same reason as the build stage above; this is the one that
 # ships, so a mutable base here is what would put an unnoticed stale JRE in every
 # published image.
-FROM eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175 AS runtime
+FROM eclipse-temurin:25-jre-noble@sha256:b4c93a50fc67612798db73d68ca3b0ee4ebdd51736e59cca370e689b9797037e AS runtime
 
 COPY --from=build --chown=10001:10001 /src/swath-cli/build/libs/swath.jar /opt/swath/swath.jar
 COPY --from=build --chown=10001:10001 /src/LICENSE /opt/swath/LICENSE

--- a/Dockerfile.replay
+++ b/Dockerfile.replay
@@ -4,7 +4,7 @@
 # replace the `build` stage with the promotion payload produced from the already-tested
 # installDist tree, preserving the same build-once/promote-exact-bytes contract as the
 # main swath image. The distribution is architecture-neutral; only the JRE base varies.
-FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble@sha256:3eb81ed94d8c1a34422f19f8188548bdf02cae69c91d0328afdbb7abed90f617 AS build
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk-noble@sha256:534968c051301957beae735e7ba1db54d99ddecf08746d3b9d4f318cc132dbc3 AS build
 WORKDIR /src
 
 # The checked-in third-party notice is verified while Gradle assembles installDist.
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon :swath-replay:
 
 # RUN-free runtime stage keeps foreign-architecture builds free of emulation. The Gradle
 # launcher uses `exec`, so the JVM becomes PID 1 and receives container signals directly.
-FROM eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175 AS runtime
+FROM eclipse-temurin:25-jre-noble@sha256:b4c93a50fc67612798db73d68ca3b0ee4ebdd51736e59cca370e689b9797037e AS runtime
 
 COPY --from=build --chown=10001:10001 /src/swath-replay/build/install/swath-replay /opt/swath-replay
 

--- a/config/osv/osv-scanner.toml
+++ b/config/osv/osv-scanner.toml
@@ -1,9 +1,12 @@
-# Accepted findings for the nightly supply-chain scan (scripts/ci/osv-scan.sh).
+# Accepted Java findings for the nightly supply-chain scan (scripts/ci/osv-scan.sh).
 #
-# The scan fails on anything not listed here, so every entry is an argued exception with an
-# expiry rather than a mute: past `ignoreUntil` the finding comes back and has to be argued
-# again. Nothing is listed because it is inconvenient — everything reachable by a version
-# constraint is pinned in gradle/libs.versions.toml instead.
+# The jar-closure scan has zero tolerance for anything not listed here, so every entry is an
+# argued exception with an expiry rather than a mute: on `ignoreUntil` the finding comes
+# back and has to be argued again. The image policy recognizes these same Java exceptions
+# after retaining the scanner's unfiltered JSON, but it never applies them to Ubuntu
+# packages. OS-package results must never be added here. Nothing is listed because it is
+# inconvenient — everything reachable by a version constraint is pinned in
+# gradle/libs.versions.toml instead.
 #
 # ---------------------------------------------------------------------------------------
 # parquet-jackson 1.15.1 (9 advisories against jackson-core / jackson-databind 2.18.1)

--- a/docs/packaging-and-docker.md
+++ b/docs/packaging-and-docker.md
@@ -150,8 +150,20 @@ at most one version of each module (`verifyNoDuplicateModuleVersions`, part of
 conformance launcher into the same `lib/`, and before the floors were pinned it
 shipped two complete Jackson generations at once. And a nightly job scans both
 distributions and both runtime images against the OSV database
-(`scripts/ci/osv-scan.sh`); accepted findings live in
-`config/osv/osv-scanner.toml`, each with an argument and an expiry date.
+(`scripts/ci/osv-scan.sh`). The shipped Java closures are zero-tolerance except
+for the narrowly argued, expiring Java findings in
+`config/osv/osv-scanner.toml`.
+
+Image scans also cover the JRE base's Ubuntu packages. Their raw OSV JSON is
+retained as a workflow artifact and evaluated by
+`scripts/ci/osv-image-policy.py`: every non-Ubuntu finding outside the same
+expiring Java exceptions fails, as does Canonical priority high, critical,
+missing, or unknown. Canonical medium, low, and negligible priorities are
+reported with advisory-group and package-occurrence counts and whether the
+advisory lists a fixed version, but do not fail the nightly. A USN's
+classification comes from the worst Canonical
+priority among its member `UBUNTU-CVE` records, not its numeric CVSS maximum.
+Malformed or ambiguous scanner output fails closed.
 
 ## 5. Docker images
 
@@ -319,11 +331,12 @@ the `public-release` environment and requires the explicit
 `PUBLIC_RELEASE_ENABLED=true` repository variable, which acts as a publish
 kill-switch.
 
-The **CI image checks** have no scheduled run — they fire only on pull
-requests, pushes to `main`, and manual dispatch. (A separate `nightly` workflow
-runs the deep and perf test tiers on a daily schedule; it does not build or
-publish images.) Top-level workflow concurrency cancels superseded runs of the
-same PR; `main` and manual runs have unique top-level groups and are not
+The multi-arch **CI image build and smoke checks** have no scheduled run — they
+fire only on pull requests, pushes to `main`, and manual dispatch. A separate
+`nightly` workflow runs the deep and perf tiers and builds builder-native copies
+of both runtime images solely for OSV scanning; it never publishes those
+images. Top-level workflow concurrency cancels superseded runs of the same PR;
+`main` and manual runs have unique top-level groups and are not
 serialized there. The `docker-publish` job has its own global concurrency group,
 which queues publishes so shared tags cannot race. The `push` trigger is scoped
 to `main`, so

--- a/scripts/ci/osv-image-policy.py
+++ b/scripts/ci/osv-image-policy.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Apply swath's fail-closed policy to an OSV-Scanner image JSON report.
+
+The scanner's numeric CVSS score is deliberately not the Ubuntu gate. Canonical's
+Ubuntu priority includes distro-specific reachability and exposure, so Ubuntu findings
+are gated on the ``Ubuntu`` severity carried by the member ``UBUNTU-CVE`` records.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import datetime
+import io
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+import sys
+import tempfile
+import tomllib
+import unittest
+
+
+PRIORITY_ORDER = {
+    "negligible": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+UBUNTU_ECOSYSTEM = re.compile(
+    r"^Ubuntu(?::Pro)?:([0-9]+\.[0-9]+)(?::LTS)?$"
+)
+
+
+class SchemaError(ValueError):
+    """The scanner report cannot be interpreted without guessing."""
+
+
+@dataclass
+class Occurrence:
+    key: tuple[str, ...]
+    display_id: str
+    disposition: str
+    priority: str
+    package: str
+    fixed_versions: set[str] = field(default_factory=set)
+
+
+def require_dict(value: object, where: str) -> dict:
+    if not isinstance(value, dict):
+        raise SchemaError(f"{where} must be an object")
+    return value
+
+
+def require_list(value: object, where: str) -> list:
+    if not isinstance(value, list):
+        raise SchemaError(f"{where} must be an array")
+    return value
+
+
+def string_list(value: object, where: str) -> list[str]:
+    values = require_list(value, where)
+    if not all(isinstance(item, str) and item for item in values):
+        raise SchemaError(f"{where} must contain non-empty strings")
+    return values
+
+
+def ubuntu_release(ecosystem: str) -> str | None:
+    match = UBUNTU_ECOSYSTEM.fullmatch(ecosystem)
+    return match.group(1) if match else None
+
+
+def ubuntu_priority(vulnerability: dict, where: str) -> str:
+    severities = require_list(vulnerability.get("severity", []), f"{where}.severity")
+    priorities: list[str] = []
+    for index, severity_value in enumerate(severities):
+        severity = require_dict(severity_value, f"{where}.severity[{index}]")
+        if severity.get("type") == "Ubuntu":
+            score = severity.get("score")
+            if not isinstance(score, str) or not score:
+                raise SchemaError(f"{where}.severity[{index}].score must be a string")
+            priorities.append(score.lower())
+    if not priorities:
+        return "unknown"
+    if len(set(priorities)) != 1:
+        raise SchemaError(f"{where} has conflicting Ubuntu priorities: {priorities}")
+    priority = priorities[0]
+    return priority if priority in PRIORITY_ORDER else "unknown"
+
+
+def fixed_versions(vulnerability: dict, package: dict, where: str) -> set[str]:
+    release = ubuntu_release(package["ecosystem"])
+    fixes: set[str] = set()
+    affected_values = require_list(vulnerability.get("affected", []), f"{where}.affected")
+    for affected_index, affected_value in enumerate(affected_values):
+        affected = require_dict(
+            affected_value, f"{where}.affected[{affected_index}]"
+        )
+        affected_package = require_dict(
+            affected.get("package", {}),
+            f"{where}.affected[{affected_index}].package",
+        )
+        affected_ecosystem = affected_package.get("ecosystem")
+        if not isinstance(affected_ecosystem, str):
+            raise SchemaError(
+                f"{where}.affected[{affected_index}].package.ecosystem must be a string"
+            )
+        if affected_package.get("name") != package["name"]:
+            continue
+        if ubuntu_release(affected_ecosystem) != release:
+            continue
+        ranges = require_list(
+            affected.get("ranges", []), f"{where}.affected[{affected_index}].ranges"
+        )
+        for range_index, range_value in enumerate(ranges):
+            affected_range = require_dict(
+                range_value,
+                f"{where}.affected[{affected_index}].ranges[{range_index}]",
+            )
+            events = require_list(
+                affected_range.get("events", []),
+                f"{where}.affected[{affected_index}].ranges[{range_index}].events",
+            )
+            for event_index, event_value in enumerate(events):
+                event = require_dict(
+                    event_value,
+                    f"{where}.affected[{affected_index}].ranges[{range_index}]"
+                    f".events[{event_index}]",
+                )
+                if "fixed" in event:
+                    fixed = event["fixed"]
+                    if not isinstance(fixed, str) or not fixed:
+                        raise SchemaError(
+                            f"{where} contains a non-string fixed version"
+                        )
+                    fixes.add(fixed)
+    return fixes
+
+
+def group_member_ids(group: dict, vulnerabilities: dict[str, dict]) -> set[str]:
+    # `aliases` can name every CVE covered by a broad USN even when only a subset affects
+    # this binary/version. `ids` is OSV-Scanner's exact set for this occurrence.
+    identifiers = set(group["ids"])
+    members = {value for value in identifiers if value.startswith("UBUNTU-CVE-")}
+    # A USN is a group record whose related/upstream fields name its member CVEs.
+    # Follow both directions because OSV-Scanner has emitted both shapes over time.
+    changed = True
+    while changed:
+        changed = False
+        for vulnerability_id, vulnerability in vulnerabilities.items():
+            related: set[str] = set()
+            for field_name in ("aliases", "related", "upstream"):
+                if field_name in vulnerability:
+                    related.update(
+                        string_list(
+                            vulnerability[field_name],
+                            f"vulnerability {vulnerability_id}.{field_name}",
+                        )
+                    )
+            if vulnerability_id in identifiers or related & identifiers:
+                # Only vulnerability documents present in this package result are members;
+                # a USN document's broader `related` list can include unaffected CVEs.
+                expanded = ({vulnerability_id} | related) & vulnerabilities.keys()
+                if not expanded <= identifiers:
+                    identifiers.update(expanded)
+                    changed = True
+                members.update(
+                    value for value in expanded if value.startswith("UBUNTU-CVE-")
+                )
+    return members
+
+
+def parse_report(
+    document: object, java_exceptions: set[str] | None = None
+) -> list[Occurrence]:
+    java_exceptions = java_exceptions or set()
+    root = require_dict(document, "report")
+    results = require_list(root.get("results"), "report.results")
+    occurrences: list[Occurrence] = []
+    for result_index, result_value in enumerate(results):
+        result = require_dict(result_value, f"results[{result_index}]")
+        packages = require_list(
+            result.get("packages"), f"results[{result_index}].packages"
+        )
+        source = require_dict(result.get("source", {}), f"results[{result_index}].source")
+        source_path = source.get("path", "<image>")
+        if not isinstance(source_path, str):
+            raise SchemaError(f"results[{result_index}].source.path must be a string")
+        for package_index, package_value in enumerate(packages):
+            where = f"results[{result_index}].packages[{package_index}]"
+            entry = require_dict(package_value, where)
+            package = require_dict(entry.get("package"), f"{where}.package")
+            for field_name in ("name", "version", "ecosystem"):
+                if not isinstance(package.get(field_name), str) or not package[field_name]:
+                    raise SchemaError(f"{where}.package.{field_name} must be a string")
+            groups = require_list(entry.get("groups"), f"{where}.groups")
+            vulnerability_values = require_list(
+                entry.get("vulnerabilities"), f"{where}.vulnerabilities"
+            )
+            vulnerabilities: dict[str, dict] = {}
+            for vulnerability_index, vulnerability_value in enumerate(
+                vulnerability_values
+            ):
+                vulnerability = require_dict(
+                    vulnerability_value,
+                    f"{where}.vulnerabilities[{vulnerability_index}]",
+                )
+                vulnerability_id = vulnerability.get("id")
+                if not isinstance(vulnerability_id, str) or not vulnerability_id:
+                    raise SchemaError(
+                        f"{where}.vulnerabilities[{vulnerability_index}].id"
+                        " must be a string"
+                    )
+                if vulnerability_id in vulnerabilities:
+                    raise SchemaError(f"{where} repeats vulnerability {vulnerability_id}")
+                vulnerabilities[vulnerability_id] = vulnerability
+
+            normalized_groups: list[tuple[dict, list[str], str]] = []
+            grouped_ids: Counter[str] = Counter()
+            for group_index, group_value in enumerate(groups):
+                group_where = f"{where}.groups[{group_index}]"
+                group = require_dict(group_value, group_where)
+                ids = string_list(group.get("ids"), f"{group_where}.ids")
+                if not ids:
+                    raise SchemaError(f"{group_where}.ids must not be empty")
+                group["ids"] = ids
+                group["aliases"] = string_list(
+                    group.get("aliases", []), f"{group_where}.aliases"
+                )
+                normalized_groups.append((group, ids, group_where))
+                grouped_ids.update(ids)
+            missing_documents = sorted(grouped_ids.keys() - vulnerabilities.keys())
+            if missing_documents:
+                raise SchemaError(
+                    f"{where} groups reference missing vulnerability documents: "
+                    f"{missing_documents}"
+                )
+            ungrouped = sorted(vulnerabilities.keys() - grouped_ids.keys())
+            if ungrouped:
+                raise SchemaError(
+                    f"{where} has ungrouped vulnerability documents: {ungrouped}"
+                )
+            multiply_grouped = sorted(
+                vulnerability_id
+                for vulnerability_id, count in grouped_ids.items()
+                if count != 1
+            )
+            if multiply_grouped:
+                raise SchemaError(
+                    f"{where} groups vulnerability documents more than once: "
+                    f"{multiply_grouped}"
+                )
+
+            package_label = (
+                f"{package['name']}@{package['version']} ({package['ecosystem']}, "
+                f"{source_path})"
+            )
+            for group, ids, group_where in normalized_groups:
+                key = tuple(sorted(set(ids)))
+                display_id = next(
+                    (value for value in ids if value.startswith("USN-")), ids[0]
+                )
+                if ubuntu_release(package["ecosystem"]) is None:
+                    excepted = set(ids).issubset(java_exceptions)
+                    occurrences.append(
+                        Occurrence(
+                            key=key,
+                            display_id=display_id,
+                            disposition="EXCEPT" if excepted else "FAIL",
+                            priority="Java-exception" if excepted else "non-Ubuntu",
+                            package=package_label,
+                        )
+                    )
+                    continue
+
+                members = group_member_ids(group, vulnerabilities)
+                if not members:
+                    occurrences.append(
+                        Occurrence(
+                            key=key,
+                            display_id=display_id,
+                            disposition="FAIL",
+                            priority="unknown",
+                            package=package_label,
+                        )
+                    )
+                    continue
+                missing = sorted(members - vulnerabilities.keys())
+                if missing:
+                    raise SchemaError(
+                        f"{group_where} references missing Ubuntu members: {missing}"
+                    )
+                priorities: list[str] = []
+                fixes: set[str] = set()
+                for member in sorted(members):
+                    vulnerability = vulnerabilities[member]
+                    priorities.append(
+                        ubuntu_priority(vulnerability, f"vulnerability {member}")
+                    )
+                    fixes.update(
+                        fixed_versions(
+                            vulnerability, package, f"vulnerability {member}"
+                        )
+                    )
+                priority = (
+                    "unknown"
+                    if "unknown" in priorities
+                    else max(priorities, key=PRIORITY_ORDER.__getitem__)
+                )
+                disposition = (
+                    "REPORT"
+                    if priority in {"negligible", "low", "medium"}
+                    else "FAIL"
+                )
+                occurrences.append(
+                    Occurrence(
+                        key=key,
+                        display_id=display_id,
+                        disposition=disposition,
+                        priority=priority,
+                        package=package_label,
+                        fixed_versions=fixes,
+                    )
+                )
+    return occurrences
+
+
+def render(occurrences: list[Occurrence], output: io.TextIOBase) -> int:
+    grouped: dict[tuple[str, ...], list[Occurrence]] = {}
+    for occurrence in occurrences:
+        grouped.setdefault(occurrence.key, []).append(occurrence)
+    sorted_groups = sorted(grouped.values(), key=lambda items: items[0].display_id)
+    for values in sorted_groups:
+        dispositions = {value.disposition for value in values}
+        priorities = {value.priority for value in values}
+        if len(dispositions) != 1 or len(priorities) != 1:
+            raise SchemaError(
+                f"advisory group {values[0].display_id} has inconsistent classifications"
+            )
+
+    print(
+        f"OSV image policy: {len(grouped)} advisory group(s), "
+        f"{len(occurrences)} package occurrence(s)",
+        file=output,
+    )
+    rollup = {priority: [0, 0] for priority in (*PRIORITY_ORDER, "unknown")}
+    for values in sorted_groups:
+        priority = values[0].priority
+        if priority in rollup:
+            rollup[priority][0] += 1
+            rollup[priority][1] += len(values)
+    print(
+        "Ubuntu priority summary: "
+        + ", ".join(
+            f"{priority}={counts[0]} group(s)/{counts[1]} occurrence(s)"
+            for priority, counts in rollup.items()
+        ),
+        file=output,
+    )
+
+    failures = 0
+    for values in sorted_groups:
+        disposition = values[0].disposition
+        if disposition == "FAIL":
+            failures += 1
+        fixes = sorted(
+            {fixed for value in values for fixed in value.fixed_versions}
+        )
+        fix_summary = (
+            f"fixed version(s) listed: {', '.join(fixes)}"
+            if fixes
+            else "no fixed version listed"
+        )
+        packages = sorted({value.package for value in values})
+        print(
+            f"{disposition} {values[0].priority} {values[0].display_id}: "
+            f"{len(values)} occurrence(s); {fix_summary}; "
+            f"packages: {'; '.join(packages)}",
+            file=output,
+        )
+    if failures:
+        print(
+            f"OSV image policy rejected {failures} advisory group(s).", file=output
+        )
+        return 1
+    return 0
+
+
+def load_java_exceptions(path: Path, today: datetime.date | None = None) -> set[str]:
+    today = today or datetime.date.today()
+    try:
+        with path.open("rb") as config_file:
+            config = tomllib.load(config_file)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SchemaError(f"cannot read Java exception config: {error}") from error
+    entries = require_list(config.get("IgnoredVulns", []), "IgnoredVulns")
+    active: set[str] = set()
+    seen: set[str] = set()
+    for index, entry_value in enumerate(entries):
+        entry = require_dict(entry_value, f"IgnoredVulns[{index}]")
+        vulnerability_id = entry.get("id")
+        expiry = entry.get("ignoreUntil")
+        reason = entry.get("reason")
+        if not isinstance(vulnerability_id, str) or not vulnerability_id:
+            raise SchemaError(f"IgnoredVulns[{index}].id must be a string")
+        if vulnerability_id in seen:
+            raise SchemaError(f"duplicate Java exception {vulnerability_id}")
+        seen.add(vulnerability_id)
+        # datetime.datetime subclasses datetime.date; require a bare TOML local date so
+        # comparison cannot raise TypeError and silently turn a policy error into rc=1.
+        if type(expiry) is not datetime.date:
+            raise SchemaError(f"IgnoredVulns[{index}].ignoreUntil must be a TOML date")
+        if not isinstance(reason, str) or not reason.strip():
+            raise SchemaError(f"IgnoredVulns[{index}].reason must be a non-empty string")
+        # Match OSV-Scanner 2.5.1: ignoreUntil is active only while it is after today.
+        if expiry > today:
+            active.add(vulnerability_id)
+    return active
+
+
+def evaluate(
+    path: Path,
+    scanner_exit_code: int,
+    output: io.TextIOBase,
+    java_exceptions: set[str] | None = None,
+) -> int:
+    if scanner_exit_code not in (0, 1):
+        print(
+            f"OSV-Scanner failed with exit code {scanner_exit_code}; policy not evaluated.",
+            file=output,
+        )
+        return 2
+    try:
+        with path.open(encoding="utf-8") as report_file:
+            document = json.load(report_file)
+        occurrences = parse_report(document, java_exceptions)
+        if scanner_exit_code == 0 and occurrences:
+            raise SchemaError("scanner returned 0 but the report contains findings")
+        if scanner_exit_code == 1 and not occurrences:
+            raise SchemaError("scanner returned 1 but the report contains no findings")
+        return render(occurrences, output)
+    except (OSError, json.JSONDecodeError, SchemaError) as error:
+        print(f"OSV image policy could not safely interpret the report: {error}", file=output)
+        return 2
+
+
+def vulnerability(
+    vulnerability_id: str,
+    priority: str | None,
+    *,
+    related: list[str] | None = None,
+    fixed: str | None = None,
+) -> dict:
+    severity = (
+        [{"type": "Ubuntu", "score": priority}] if priority is not None else []
+    )
+    events = [{"introduced": "0"}]
+    if fixed is not None:
+        events.append({"fixed": fixed})
+    value = {
+        "id": vulnerability_id,
+        "severity": severity,
+        "affected": [
+            {
+                "package": {"name": "pkg", "ecosystem": "Ubuntu:24.04:LTS"},
+                "ranges": [{"type": "ECOSYSTEM", "events": events}],
+            }
+        ],
+    }
+    if related is not None:
+        value["related"] = related
+    return value
+
+
+def report(
+    groups: list[dict],
+    vulnerabilities: list[dict],
+    *,
+    ecosystem: str = "Ubuntu:24.04",
+    duplicate: bool = False,
+) -> dict:
+    package_entry = {
+        "package": {"name": "pkg", "version": "1", "ecosystem": ecosystem},
+        "groups": groups,
+        "vulnerabilities": vulnerabilities,
+    }
+    packages = [package_entry, package_entry] if duplicate else [package_entry]
+    return {
+        "results": [
+            {"source": {"path": "/image"}, "packages": packages}
+        ]
+    }
+
+
+class PolicySelfTest(unittest.TestCase):
+    def evaluate_document(
+        self,
+        document: object,
+        scanner_rc: int = 1,
+        java_exceptions: set[str] | None = None,
+    ) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            output = io.StringIO()
+            return (
+                evaluate(path, scanner_rc, output, java_exceptions),
+                output.getvalue(),
+            )
+
+    def test_cvss_high_but_ubuntu_medium_reports_and_passes(self) -> None:
+        member = vulnerability("UBUNTU-CVE-1", "medium", fixed="2")
+        member["severity"].insert(0, {"type": "CVSS_V3", "score": "9.8"})
+        code, output = self.evaluate_document(
+            report(
+                [{"ids": ["UBUNTU-CVE-1"], "aliases": [], "max_severity": "9.8"}],
+                [member],
+            )
+        )
+        self.assertEqual(0, code)
+        self.assertIn("REPORT medium", output)
+        self.assertIn("fixed version(s) listed: 2", output)
+
+    def test_ubuntu_high_fails(self) -> None:
+        code, output = self.evaluate_document(
+            report(
+                [{"ids": ["UBUNTU-CVE-1"], "aliases": []}],
+                [vulnerability("UBUNTU-CVE-1", "high")],
+            )
+        )
+        self.assertEqual(1, code)
+        self.assertIn("FAIL high", output)
+
+    def test_missing_or_unknown_priority_fails(self) -> None:
+        for priority in (None, "unknown"):
+            with self.subTest(priority=priority):
+                code, output = self.evaluate_document(
+                    report(
+                        [{"ids": ["UBUNTU-CVE-1"], "aliases": []}],
+                        [vulnerability("UBUNTU-CVE-1", priority)],
+                    )
+                )
+                self.assertEqual(1, code)
+                self.assertIn("FAIL unknown", output)
+
+    def test_usn_uses_worst_member_priority(self) -> None:
+        code, output = self.evaluate_document(
+            report(
+                [
+                    {
+                        "ids": ["USN-1", "UBUNTU-CVE-1", "UBUNTU-CVE-2"],
+                        "aliases": [],
+                    }
+                ],
+                [
+                    vulnerability(
+                        "USN-1",
+                        None,
+                        related=["UBUNTU-CVE-1", "UBUNTU-CVE-2"],
+                    ),
+                    vulnerability("UBUNTU-CVE-1", "low"),
+                    vulnerability("UBUNTU-CVE-2", "high"),
+                ],
+            )
+        )
+        self.assertEqual(1, code)
+        self.assertIn("FAIL high USN-1", output)
+
+    def test_non_ubuntu_fails(self) -> None:
+        code, output = self.evaluate_document(
+            report(
+                [{"ids": ["GHSA-1"], "aliases": []}],
+                [{"id": "GHSA-1", "affected": [], "severity": []}],
+                ecosystem="Maven",
+            )
+        )
+        self.assertEqual(1, code)
+        self.assertIn("FAIL non-Ubuntu GHSA-1", output)
+
+    def test_active_java_exception_is_the_only_non_ubuntu_allowance(self) -> None:
+        document = report(
+            [{"ids": ["GHSA-1"], "aliases": []}],
+            [{"id": "GHSA-1", "affected": [], "severity": []}],
+            ecosystem="Maven",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            output = io.StringIO()
+            code = evaluate(path, 1, output, {"GHSA-1"})
+        self.assertEqual(0, code)
+        self.assertIn("EXCEPT Java-exception GHSA-1", output.getvalue())
+
+        ubuntu_document = report(
+            [{"ids": ["GHSA-1"], "aliases": []}],
+            [{"id": "GHSA-1", "affected": [], "severity": []}],
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps(ubuntu_document), encoding="utf-8")
+            output = io.StringIO()
+            code = evaluate(path, 1, output, {"GHSA-1"})
+        self.assertEqual(1, code)
+        self.assertNotIn("EXCEPT", output.getvalue())
+
+    def test_expired_java_exception_is_inactive(self) -> None:
+        config = """
+[[IgnoredVulns]]
+id = "GHSA-active"
+ignoreUntil = 2026-09-01
+reason = "active fixture"
+
+[[IgnoredVulns]]
+id = "GHSA-expired"
+ignoreUntil = 2026-08-30
+reason = "expired fixture"
+
+[[IgnoredVulns]]
+id = "GHSA-today"
+ignoreUntil = 2026-08-31
+reason = "equal-date fixture"
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "osv-scanner.toml"
+            path.write_text(config, encoding="utf-8")
+            exceptions = load_java_exceptions(
+                path, today=datetime.date(2026, 8, 31)
+            )
+        self.assertEqual({"GHSA-active"}, exceptions)
+        document = report(
+            [{"ids": ["GHSA-expired"], "aliases": []}],
+            [{"id": "GHSA-expired", "affected": [], "severity": []}],
+            ecosystem="Maven",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            output = io.StringIO()
+            code = evaluate(path, 1, output, exceptions)
+        self.assertEqual(1, code)
+        self.assertIn("FAIL non-Ubuntu GHSA-expired", output.getvalue())
+
+    def test_datetime_exception_expiry_fails_closed(self) -> None:
+        config = """
+[[IgnoredVulns]]
+id = "GHSA-datetime"
+ignoreUntil = 2026-09-01T00:00:00Z
+reason = "datetime fixture"
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "osv-scanner.toml"
+            path.write_text(config, encoding="utf-8")
+            with self.assertRaisesRegex(SchemaError, "must be a TOML date"):
+                load_java_exceptions(path, today=datetime.date(2026, 8, 31))
+
+    def test_missing_ungrouped_and_duplicate_documents_fail_closed(self) -> None:
+        missing_group_document = report(
+            [{"ids": ["GHSA-1"], "aliases": []}],
+            [],
+            ecosystem="Maven",
+        )
+        code, output = self.evaluate_document(
+            missing_group_document, java_exceptions={"GHSA-1"}
+        )
+        self.assertEqual(2, code)
+        self.assertIn("missing vulnerability documents", output)
+
+        extra_ungrouped_document = report(
+            [{"ids": ["GHSA-1"], "aliases": []}],
+            [
+                {"id": "GHSA-1", "affected": [], "severity": []},
+                {"id": "GHSA-2", "affected": [], "severity": []},
+            ],
+            ecosystem="Maven",
+        )
+        code, output = self.evaluate_document(extra_ungrouped_document)
+        self.assertEqual(2, code)
+        self.assertIn("ungrouped vulnerability documents", output)
+
+        duplicate_grouping = report(
+            [
+                {"ids": ["GHSA-1"], "aliases": []},
+                {"ids": ["GHSA-1"], "aliases": []},
+            ],
+            [{"id": "GHSA-1", "affected": [], "severity": []}],
+            ecosystem="Maven",
+        )
+        code, output = self.evaluate_document(duplicate_grouping)
+        self.assertEqual(2, code)
+        self.assertIn("more than once", output)
+
+    def test_malformed_and_scanner_failure_return_script_error(self) -> None:
+        code, output = self.evaluate_document({"not_results": []})
+        self.assertEqual(2, code)
+        self.assertIn("could not safely interpret", output)
+        code, output = self.evaluate_document({}, scanner_rc=7)
+        self.assertEqual(2, code)
+        self.assertIn("failed with exit code 7", output)
+
+    def test_duplicate_occurrences_are_summarized(self) -> None:
+        code, output = self.evaluate_document(
+            report(
+                [{"ids": ["UBUNTU-CVE-1"], "aliases": []}],
+                [vulnerability("UBUNTU-CVE-1", "low")],
+                duplicate=True,
+            )
+        )
+        self.assertEqual(0, code)
+        self.assertIn("1 advisory group(s), 2 package occurrence(s)", output)
+        self.assertIn("low=1 group(s)/2 occurrence(s)", output)
+        self.assertIn("medium=0 group(s)/0 occurrence(s)", output)
+        self.assertEqual(1, output.count("REPORT low UBUNTU-CVE-1"))
+        self.assertIn("2 occurrence(s)", output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", nargs="?", type=Path)
+    parser.add_argument("--scanner-exit-code", type=int)
+    parser.add_argument("--java-exceptions", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    arguments = parser.parse_args()
+    if arguments.self_test:
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(PolicySelfTest)
+        return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+    if arguments.report is None or arguments.scanner_exit_code is None:
+        parser.error("report and --scanner-exit-code are required unless --self-test is used")
+    try:
+        java_exceptions = (
+            load_java_exceptions(arguments.java_exceptions)
+            if arguments.java_exceptions is not None
+            else set()
+        )
+    except SchemaError as error:
+        print(f"OSV image policy could not safely interpret the config: {error}")
+        return 2
+    return evaluate(
+        arguments.report,
+        arguments.scanner_exit_code,
+        sys.stdout,
+        java_exceptions,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/osv-image-policy.py
+++ b/scripts/ci/osv-image-policy.py
@@ -145,31 +145,23 @@ def group_member_ids(group: dict, vulnerabilities: dict[str, dict]) -> set[str]:
     # this binary/version. `ids` is OSV-Scanner's exact set for this occurrence.
     identifiers = set(group["ids"])
     members = {value for value in identifiers if value.startswith("UBUNTU-CVE-")}
-    # A USN is a group record whose related/upstream fields name its member CVEs.
-    # Follow both directions because OSV-Scanner has emitted both shapes over time.
-    changed = True
-    while changed:
-        changed = False
-        for vulnerability_id, vulnerability in vulnerabilities.items():
-            related: set[str] = set()
-            for field_name in ("aliases", "related", "upstream"):
-                if field_name in vulnerability:
-                    related.update(
-                        string_list(
-                            vulnerability[field_name],
-                            f"vulnerability {vulnerability_id}.{field_name}",
-                        )
-                    )
-            if vulnerability_id in identifiers or related & identifiers:
-                # Only vulnerability documents present in this package result are members;
-                # a USN document's broader `related` list can include unaffected CVEs.
-                expanded = ({vulnerability_id} | related) & vulnerabilities.keys()
-                if not expanded <= identifiers:
-                    identifiers.update(expanded)
-                    changed = True
-                members.update(
-                    value for value in expanded if value.startswith("UBUNTU-CVE-")
-                )
+    # The partition check assigns every vulnerability document to exactly one group. A USN
+    # can relate to CVEs owned by another group, so relation traversal must stay inside this
+    # group's IDs rather than importing every document named by `related` or `upstream`.
+    for vulnerability_id in identifiers:
+        vulnerability = vulnerabilities[vulnerability_id]
+        for field_name in ("aliases", "related", "upstream"):
+            if field_name not in vulnerability:
+                continue
+            related = string_list(
+                vulnerability[field_name],
+                f"vulnerability {vulnerability_id}.{field_name}",
+            )
+            members.update(
+                value
+                for value in related
+                if value in identifiers and value.startswith("UBUNTU-CVE-")
+            )
     return members
 
 
@@ -442,7 +434,7 @@ def evaluate(
         if scanner_exit_code == 1 and not occurrences:
             raise SchemaError("scanner returned 1 but the report contains no findings")
         return render(occurrences, output)
-    except (OSError, json.JSONDecodeError, SchemaError) as error:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, SchemaError) as error:
         print(f"OSV image policy could not safely interpret the report: {error}", file=output)
         return 2
 
@@ -568,6 +560,38 @@ class PolicySelfTest(unittest.TestCase):
         )
         self.assertEqual(1, code)
         self.assertIn("FAIL high USN-1", output)
+
+    def test_cross_group_relations_do_not_contaminate_priority(self) -> None:
+        code, output = self.evaluate_document(
+            report(
+                [
+                    {
+                        "ids": ["USN-1", "UBUNTU-CVE-1"],
+                        "aliases": [],
+                    },
+                    {
+                        "ids": ["USN-2", "UBUNTU-CVE-2"],
+                        "aliases": [],
+                    },
+                ],
+                [
+                    vulnerability(
+                        "USN-1",
+                        None,
+                        related=["UBUNTU-CVE-1", "UBUNTU-CVE-2"],
+                    ),
+                    vulnerability("UBUNTU-CVE-1", "low"),
+                    vulnerability(
+                        "USN-2", None, related=["UBUNTU-CVE-2"]
+                    ),
+                    vulnerability("UBUNTU-CVE-2", "high"),
+                ],
+            )
+        )
+        self.assertEqual(1, code)
+        self.assertIn("REPORT low USN-1", output)
+        self.assertIn("FAIL high USN-2", output)
+        self.assertNotIn("FAIL high USN-1", output)
 
     def test_non_ubuntu_fails(self) -> None:
         code, output = self.evaluate_document(
@@ -699,6 +723,15 @@ reason = "datetime fixture"
         code, output = self.evaluate_document({}, scanner_rc=7)
         self.assertEqual(2, code)
         self.assertIn("failed with exit code 7", output)
+
+    def test_invalid_utf8_report_returns_script_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_bytes(b'{"results": ["\xff"]}')
+            output = io.StringIO()
+            code = evaluate(path, 1, output)
+        self.assertEqual(2, code)
+        self.assertIn("could not safely interpret", output.getvalue())
 
     def test_duplicate_occurrences_are_summarized(self) -> None:
         code, output = self.evaluate_document(

--- a/scripts/ci/osv-scan.sh
+++ b/scripts/ci/osv-scan.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Supply-chain scan of what swath actually ships: the jars in each application distribution,
 # and the runtime container image (its JRE base carries OS packages no Gradle constraint
-# reaches). Findings are checked against config/osv/osv-scanner.toml, which holds the argued
-# exceptions; anything not listed there fails the run.
+# reaches). Jar findings are checked against the argued Java exceptions in
+# config/osv/osv-scanner.toml. Image findings are written as raw JSON and passed to the
+# checked-in Ubuntu-priority policy in osv-image-policy.py.
 #
 # The distributions are scanned rather than the source tree because the source tree has no
 # lockfile — the shipped `lib/` directory IS the resolved closure, and reading it means the
@@ -22,6 +23,8 @@ OSV_SCANNER_SHA256="f9f25499a2c8cc367b3af45df2ea7eeca7fbccceab9c35079968f4b36521
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONFIG="${REPO_ROOT}/config/osv/osv-scanner.toml"
+IMAGE_POLICY="${REPO_ROOT}/scripts/ci/osv-image-policy.py"
+REPORT_DIR="${OSV_REPORT_DIR:-${REPO_ROOT}/build/reports/osv}"
 
 if [ "$#" -eq 0 ]; then
     echo "usage: $0 <directory|image:NAME>..." >&2
@@ -44,18 +47,51 @@ for target in "$@"; do
         image:*)
             # `scan image` reads the image's OS package database and the language artifacts
             # inside it, which is the only way the JRE base layer gets looked at at all.
-            "$scanner" scan image --config "$CONFIG" "${target#image:}" || status=1
+            # Keep unfiltered scanner output as an audit artifact. The policy reads the
+            # Java-only exception file itself, so OS-package findings cannot be hidden in it.
+            mkdir -p "$REPORT_DIR"
+            image_name="${target#image:}"
+            report_name="${image_name//\//_}"
+            report_name="${report_name//:/_}"
+            report="${REPORT_DIR}/${report_name}.json"
+            scanner_status=0
+            "$scanner" scan image --format json \
+                --output-file "$report" "$image_name" || scanner_status=$?
+            if [ "$scanner_status" -gt 1 ]; then
+                echo "::error::OSV-Scanner failed for ${target} with exit code ${scanner_status}." >&2
+                exit 2
+            fi
+            policy_status=0
+            python3 "$IMAGE_POLICY" --scanner-exit-code "$scanner_status" \
+                --java-exceptions "$CONFIG" "$report" \
+                || policy_status=$?
+            if [ "$policy_status" -gt 1 ]; then
+                echo "::error::The OSV image report could not be evaluated safely." >&2
+                exit 2
+            fi
+            if [ "$policy_status" -eq 1 ]; then
+                status=1
+            fi
             ;;
         *)
             # The `artifact` plugin is what reads a bare .jar (Maven coordinates from the
             # embedded pom.properties); the default plugin set only understands lockfiles.
+            scanner_status=0
             "$scanner" scan source --config "$CONFIG" \
-                --experimental-plugins artifact --no-ignore --recursive "$target" || status=1
+                --experimental-plugins artifact --no-ignore --recursive "$target" \
+                || scanner_status=$?
+            if [ "$scanner_status" -gt 1 ]; then
+                echo "::error::OSV-Scanner failed for ${target} with exit code ${scanner_status}." >&2
+                exit 2
+            fi
+            if [ "$scanner_status" -eq 1 ]; then
+                status=1
+            fi
             ;;
     esac
 done
 
 if [ "$status" -ne 0 ]; then
-    echo "::error::OSV found advisories that config/osv/osv-scanner.toml does not except." >&2
+    echo "::error::OSV found a non-excepted Java advisory or an image advisory rejected by policy." >&2
 fi
 exit "$status"


### PR DESCRIPTION
## Summary

- refresh both runtime images to the audited Temurin 25.0.4+7 JDK/JRE digests
- retain raw OSV image reports and gate Ubuntu packages by Canonical priority, while preserving zero-tolerance Java scanning and the existing expiring Java-only exceptions
- fail closed on unknown/non-Ubuntu findings, malformed reports/config, scanner failures, and incomplete OSV grouping
- report per-advisory detail plus Ubuntu priority group/occurrence rollups

## Verification

- 11 fail-closed policy self-tests
- both Dockerfiles built; both containers smoke-tested as UID 10001
- live OSV Scanner 2.5.1 reports passed for both images
- independent security-policy review: clean after three fail-closed fixes
- Python compile, Bash syntax, YAML parse, and `git diff --check`

Latest live base result: 67 Ubuntu advisory groups / 122 package occurrences (56/104 medium, 10/15 low, 1/3 negligible; zero high, critical, or unknown). Replay also retains and explicitly classifies the nine current expiring shaded-Parquet Java exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added fail-closed policy checks for container image vulnerabilities, including Ubuntu advisory priorities and approved Java exceptions.
  - Image scan reports are retained as downloadable build artifacts for troubleshooting and review.
  - Improved error reporting distinguishes scanner failures from rejected security findings.

- **Maintenance**
  - Updated container build and runtime image security pins.

- **Documentation**
  - Expanded guidance for image scanning, vulnerability exceptions, Ubuntu advisory handling, and CI image workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->