### PR TITLE
Add current-format benchmark corpus records

### DIFF
--- a/docs/ops/dev/TESTING.md
+++ b/docs/ops/dev/TESTING.md
@@ -148,6 +148,28 @@ the retained tree remains byte-identical after each arm.
   -Dswath.bench.staging-dir=/path/to/_staging
 ```
 
+Register a retained corpus after its first validated benchmark run when later measurements need to
+prove that they used the same bytes and logical rows. Point `--evidence` at that run's JUnit XML,
+which contains its single `BENCH_CORPUS` and `BENCH_INPUT_ORACLE` records:
+
+```bash
+scripts/perf/corpus-record.sh register --corpus /path/to/_staging \
+  --evidence swath-core/build/test-results/test/TEST-io.varve.swath.sort.ParallelMergeBenchmark.xml
+scripts/perf/corpus-record.sh validate --corpus /path/to/_staging
+
+./gradlew :swath-core:test \
+  --tests 'io.varve.swath.sort.ParallelMergeBenchmark' \
+  -Dswath.bench=on -Pperf \
+  -Dswath.bench.staging-dir=/path/to/_staging \
+  -Dswath.bench.corpus-record=/path/to/CORPUS.varve
+```
+
+Corpus records are intentionally current-format-only: `swath-page-run-corpus-v4`. The shell helper
+checks path, segment count, and bytes; the benchmark then opens every segment through
+`PageRunSegmentIo`, checks the registered corpus identity and full-row multiset, and validates the
+sorted output against the same oracle. Regenerate and register a corpus after a page-run format
+change; there is no legacy conversion path.
+
 The encoder list must contain distinct values in `1..16` and begin with `1`. The harness
 materializes each arm with same-filesystem hard links and refuses a physical-copy fallback. Before
 timing, it fully reads and CRC-validates the source into a constant-memory row-count and multiset

--- a/scripts/perf/corpus-record.sh
+++ b/scripts/perf/corpus-record.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Registers cheap immutable metadata for one v4 page-run benchmark corpus.
+# The benchmark JVM remains the authority for decoding and validating segment contents.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  corpus-record.sh register --corpus DIR --evidence FILE [--record FILE]
+  corpus-record.sh validate --corpus DIR [--record FILE]
+EOF
+  exit 2
+}
+
+die() {
+  echo "corpus-record: $*" >&2
+  exit 1
+}
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  die "bash 4 or newer is required"
+fi
+
+record_value() {
+  local key=$1
+  local value
+  value=$(awk -v key="${key}" '
+    index($0, key "=") == 1 {
+      count++
+      value = substr($0, length(key) + 2)
+    }
+    END {
+      if (count == 1) print value
+      else exit 1
+    }
+  ' "${record}") || die "record must contain exactly one ${key}= entry: ${record}"
+  printf '%s\n' "${value}"
+}
+
+validate_record_schema() {
+  local line
+  local key
+  local expected
+  local -A seen=()
+  while IFS= read -r line || [[ -n ${line} ]]; do
+    [[ ${line} == *=* && ${line%%=*} != "" ]] \
+      || die "record has an invalid field: ${record}"
+    key=${line%%=*}
+    case ${key} in
+      format|corpus|rows|segments|bytes|corpus_id|multiset|created_by_head) ;;
+      *) die "record has an unknown field ${key}: ${record}" ;;
+    esac
+    [[ -z ${seen["${key}"]+present} ]] \
+      || die "record has a duplicate field ${key}: ${record}"
+    seen["${key}"]=1
+  done < "${record}"
+  for expected in format corpus rows segments bytes corpus_id multiset created_by_head; do
+    [[ -n ${seen["${expected}"]+present} ]] \
+      || die "record is missing field ${expected}: ${record}"
+  done
+}
+
+line_value() {
+  local line=$1
+  local key=$2
+  local token
+  local -a tokens
+  read -r -a tokens <<< "${line}"
+  for token in "${tokens[@]}"; do
+    case ${token} in
+      "${key}"=*) printf '%s\n' "${token#*=}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+validate_positive_integer() {
+  local label=$1
+  local value=$2
+  [[ ${value} =~ ^[0-9]+$ ]] && (( value > 0 )) \
+    || die "${label} must be an integer > 0"
+}
+
+validate_digest() {
+  local label=$1
+  local value=$2
+  local length=$3
+  [[ ${value} =~ ^[0-9a-f]+$ ]] && (( ${#value} == length )) \
+    || die "${label} must contain exactly ${length} lowercase hexadecimal characters"
+}
+
+[[ $# -ge 1 ]] || usage
+mode=$1
+shift
+[[ ${mode} == register || ${mode} == validate ]] || usage
+
+corpus=
+evidence=
+record=
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --corpus) [[ $# -ge 2 ]] || usage; corpus=$2; shift 2 ;;
+    --evidence) [[ $# -ge 2 ]] || usage; evidence=$2; shift 2 ;;
+    --record) [[ $# -ge 2 ]] || usage; record=$2; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n ${corpus} ]] || usage
+[[ -d ${corpus} ]] || die "corpus is not a directory: ${corpus}"
+corpus=$(realpath "${corpus}")
+if [[ -z ${record} ]]; then
+  record=$(dirname "${corpus}")/CORPUS.varve
+else
+  record=$(realpath -m "${record}")
+fi
+
+segments=$(find "${corpus}" -maxdepth 1 -type f -name '*.pageseg' -printf '.\n' | wc -l)
+bytes=$(find "${corpus}" -maxdepth 1 -type f -name '*.pageseg' -printf '%s\n' \
+  | awk '{ total += $1 } END { printf "%.0f\n", total }')
+validate_positive_integer segments "${segments}"
+validate_positive_integer bytes "${bytes}"
+
+if [[ ${mode} == register ]]; then
+  [[ -n ${evidence} ]] || usage
+  evidence=$(realpath "${evidence}")
+  [[ -f ${evidence} ]] || die "benchmark evidence is not a regular file: ${evidence}"
+  mapfile -t corpus_lines < <(grep -o 'BENCH_CORPUS [^<]*' "${evidence}" || true)
+  mapfile -t oracle_lines < <(grep -o 'BENCH_INPUT_ORACLE [^<]*' "${evidence}" || true)
+  (( ${#corpus_lines[@]} == 1 && ${#oracle_lines[@]} == 1 )) \
+    || die "evidence must contain exactly one BENCH_CORPUS and BENCH_INPUT_ORACLE line"
+
+  corpus_id=$(line_value "${corpus_lines[0]}" corpus_id) \
+    || die "BENCH_CORPUS has no corpus_id"
+  oracle_corpus_id=$(line_value "${oracle_lines[0]}" corpus_id) \
+    || die "BENCH_INPUT_ORACLE has no corpus_id"
+  measured_rows=$(line_value "${oracle_lines[0]}" rows) \
+    || die "BENCH_INPUT_ORACLE has no rows"
+  measured_segments=$(line_value "${corpus_lines[0]}" segments) \
+    || die "BENCH_CORPUS has no segments"
+  measured_bytes=$(line_value "${corpus_lines[0]}" bytes) \
+    || die "BENCH_CORPUS has no bytes"
+  multiset=$(line_value "${oracle_lines[0]}" multiset_digest) \
+    || die "BENCH_INPUT_ORACLE has no multiset_digest"
+  validate_positive_integer rows "${measured_rows}"
+  validate_digest corpus_id "${corpus_id}" 64
+  validate_digest multiset "${multiset}" 128
+  [[ ${oracle_corpus_id} == "${corpus_id}" ]] || die "evidence corpus IDs disagree"
+  [[ ${measured_segments} == "${segments}" ]] || die "evidence segment count disagrees"
+  [[ ${measured_bytes} == "${bytes}" ]] || die "evidence byte count disagrees"
+  [[ ! -e ${record} ]] || die "record already exists: ${record}"
+
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  repo_root=$(cd "${script_dir}/../.." && pwd)
+  created_by_head=$(git -C "${repo_root}" rev-parse HEAD)
+  temporary=$(mktemp "${record}.tmp.XXXXXX")
+  trap 'rm -f "${temporary}"' EXIT
+  {
+    echo 'format=swath-page-run-corpus-v4'
+    echo "corpus=${corpus}"
+    echo "rows=${measured_rows}"
+    echo "segments=${segments}"
+    echo "bytes=${bytes}"
+    echo "corpus_id=${corpus_id}"
+    echo "multiset=${multiset}"
+    echo "created_by_head=${created_by_head}"
+  } > "${temporary}"
+  chmod 0644 "${temporary}"
+  mv "${temporary}" "${record}"
+  trap - EXIT
+  echo "registered ${record}"
+else
+  [[ -z ${evidence} ]] || usage
+  [[ -f ${record} ]] || die "corpus record is absent: ${record}"
+  validate_record_schema
+  [[ $(record_value format) == swath-page-run-corpus-v4 ]] \
+    || die "record is not for the current v4 page-run format: ${record}"
+  [[ $(record_value corpus) == "${corpus}" ]] || die "record corpus path disagrees"
+  [[ $(record_value segments) == "${segments}" ]] || die "record segment count disagrees"
+  [[ $(record_value bytes) == "${bytes}" ]] || die "record byte count disagrees"
+  rows=$(record_value rows)
+  corpus_id=$(record_value corpus_id)
+  multiset=$(record_value multiset)
+  created_by_head=$(record_value created_by_head)
+  validate_positive_integer rows "${rows}"
+  validate_digest corpus_id "${corpus_id}" 64
+  validate_digest multiset "${multiset}" 128
+  validate_digest created_by_head "${created_by_head}" 40
+  echo "validated ${record}"
+  echo "rows=${rows} segments=${segments} bytes=${bytes}"
+  echo "corpus_id=${corpus_id} multiset=${multiset}"
+fi

--- a/swath-core/src/test/java/io/varve/swath/sort/BenchmarkCorpusRecord.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/BenchmarkCorpusRecord.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.sort;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** Verifies the immutable current-format corpus metadata registered by the shell helper. */
+final class BenchmarkCorpusRecord {
+
+    static final String FORMAT =
+            "swath-page-run-corpus-v" + PageRunFormat.CURRENT_FORMAT_VERSION;
+    private static final Set<String> FIELDS = Set.of(
+            "format", "corpus", "rows", "segments", "bytes", "corpus_id", "multiset",
+            "created_by_head");
+
+    private BenchmarkCorpusRecord() {
+    }
+
+    static void verify(String configuredPath, ParallelMergeBenchmark.CorpusCatalog corpus)
+            throws IOException {
+        if (configuredPath == null) {
+            return;
+        }
+        if (configuredPath.isBlank()) {
+            throw new IllegalArgumentException("swath.bench.corpus-record must not be blank");
+        }
+        Path path = Path.of(configuredPath).toAbsolutePath().normalize();
+        Map<String, String> fields = read(path);
+        if (!fields.keySet().equals(FIELDS)) {
+            throw new IOException("benchmark corpus record fields disagree: expected="
+                    + FIELDS + " actual=" + fields.keySet() + " record=" + path);
+        }
+        require(fields, "format", FORMAT, path);
+        require(fields, "corpus",
+                corpus.stagingDir().toAbsolutePath().normalize().toString(), path);
+        require(fields, "rows", Long.toString(corpus.oracle().rows()), path);
+        require(fields, "segments", Integer.toString(corpus.inputs().size()), path);
+        long bytes = corpus.inputs().stream()
+                .mapToLong(ParallelMergeBenchmark.CorpusInput::size)
+                .sum();
+        require(fields, "bytes", Long.toString(bytes), path);
+        require(fields, "corpus_id", corpus.identity(), path);
+        require(fields, "multiset", corpus.oracle().multisetDigest(), path);
+        String createdByHead = fields.get("created_by_head");
+        if (createdByHead == null || !createdByHead.matches("[0-9a-f]{40}")) {
+            throw new IOException("benchmark corpus record has an invalid created_by_head: " + path);
+        }
+    }
+
+    private static Map<String, String> read(Path path) throws IOException {
+        if (!Files.isRegularFile(path)) {
+            throw new IOException("benchmark corpus record is not a regular file: " + path);
+        }
+        Map<String, String> fields = new LinkedHashMap<>();
+        for (String line : Files.readAllLines(path)) {
+            int separator = line.indexOf('=');
+            if (separator <= 0 || fields.putIfAbsent(
+                    line.substring(0, separator), line.substring(separator + 1)) != null) {
+                throw new IOException("benchmark corpus record has an invalid or duplicate field: "
+                        + path);
+            }
+        }
+        return Map.copyOf(fields);
+    }
+
+    private static void require(Map<String, String> fields, String key,
+                                String expected, Path path) throws IOException {
+        String actual = fields.get(key);
+        if (!expected.equals(actual)) {
+            throw new IOException("benchmark corpus record disagrees for " + key
+                    + ": expected=" + expected + " actual=" + actual + " record=" + path);
+        }
+    }
+}

--- a/swath-core/src/test/java/io/varve/swath/sort/ParallelMergeBenchmark.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/ParallelMergeBenchmark.java
@@ -65,6 +65,7 @@ class ParallelMergeBenchmark {
 
     private static final ListEntryComparator CMP = new ListEntryComparator();
     private static final String EXTERNAL_STAGING_PROPERTY = "swath.bench.staging-dir";
+    private static final String CORPUS_RECORD_PROPERTY = "swath.bench.corpus-record";
     static final String ARM = SortArm.MERGE_BENCH_PAGE_RUN.name();
     private static final String NO_FINGERPRINT = "not_applicable";
 
@@ -145,6 +146,7 @@ class ParallelMergeBenchmark {
                             + corpus.oracle().trailerEntries() + " trailer_records="
                             + corpus.oracle().trailerRecords() + " multiset_digest="
                             + corpus.oracle().multisetDigest());
+            BenchmarkCorpusRecord.verify(System.getProperty(CORPUS_RECORD_PROPERTY), corpus);
 
             List<Integer> candidates = ENCODERS.stream().filter(encoders -> encoders != 1).toList();
             WriterFactoryProvider writerProvider =

--- a/swath-core/src/test/java/io/varve/swath/sort/ParallelMergeBenchmarkTest.java
+++ b/swath-core/src/test/java/io/varve/swath/sort/ParallelMergeBenchmarkTest.java
@@ -370,6 +370,56 @@ class ParallelMergeBenchmarkTest {
     }
 
     @Test
+    void currentFormatCorpusRecordPinsCanonicalGeneratedCorpus(@TempDir Path parent)
+            throws Exception {
+        ParallelMergeBenchmark.PreparedGenerated prepared =
+                ParallelMergeBenchmark.prepareGenerated(parent, 2, 40, 10, 5);
+        try {
+            Path record = parent.resolve("CORPUS.varve");
+            Files.writeString(record, corpusRecord(prepared.catalog()));
+
+            BenchmarkCorpusRecord.verify(record.toString(), prepared.catalog());
+
+            Files.writeString(record, corpusRecord(prepared.catalog())
+                    .replace(BenchmarkCorpusRecord.FORMAT, "swath-page-run-corpus-v3"));
+            assertThatThrownBy(() -> BenchmarkCorpusRecord.verify(
+                    record.toString(), prepared.catalog()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("format")
+                    .hasMessageContaining(BenchmarkCorpusRecord.FORMAT);
+
+            Files.writeString(record, corpusRecord(prepared.catalog())
+                    + "legacy_page_run_format=v3\n");
+            assertThatThrownBy(() -> BenchmarkCorpusRecord.verify(
+                    record.toString(), prepared.catalog()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("fields disagree");
+        } finally {
+            SortBenchCorpus.deleteTree(prepared.root());
+        }
+    }
+
+    @Test
+    void corpusRecordRejectsGeometryAndIdentityDrift(@TempDir Path staging) throws Exception {
+        Path segment = writeSegment(staging, "seg-generated-0.pageseg");
+        ParallelMergeBenchmark.CorpusCatalog catalog =
+                ParallelMergeBenchmark.snapshotCatalog("generated", staging, List.of(segment));
+        Path record = staging.resolveSibling("CORPUS.varve");
+        Files.writeString(record, corpusRecord(catalog).replace(
+                "corpus_id=" + catalog.identity(), "corpus_id=" + "0".repeat(64)));
+
+        assertThatThrownBy(() -> BenchmarkCorpusRecord.verify(record.toString(), catalog))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("corpus_id");
+
+        Files.writeString(record, corpusRecord(catalog).replace(
+                "bytes=" + Files.size(segment), "bytes=" + (Files.size(segment) + 1)));
+        assertThatThrownBy(() -> BenchmarkCorpusRecord.verify(record.toString(), catalog))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("bytes");
+    }
+
+    @Test
     void everyBenchLineCarriesCompleteContext(@TempDir Path staging) throws Exception {
         Path segment = writeSegment(staging, "seg-generated-0.pageseg");
         ParallelMergeBenchmark.CorpusCatalog catalog =
@@ -524,6 +574,21 @@ class ParallelMergeBenchmarkTest {
         } else {
             System.setProperty(key, value);
         }
+    }
+
+    private static String corpusRecord(ParallelMergeBenchmark.CorpusCatalog catalog) {
+        long bytes = catalog.inputs().stream()
+                .mapToLong(ParallelMergeBenchmark.CorpusInput::size)
+                .sum();
+        return String.join("\n",
+                "format=" + BenchmarkCorpusRecord.FORMAT,
+                "corpus=" + catalog.stagingDir().toAbsolutePath().normalize(),
+                "rows=" + catalog.oracle().rows(),
+                "segments=" + catalog.inputs().size(),
+                "bytes=" + bytes,
+                "corpus_id=" + catalog.identity(),
+                "multiset=" + catalog.oracle().multisetDigest(),
+                "created_by_head=" + "a".repeat(40)) + "\n";
     }
 
     private static ParallelMergeBenchmark.ArmResult sample(long elapsedNanos) {


### PR DESCRIPTION
## Summary

- add a v4-only benchmark corpus record derived from the canonical page-run catalog and benchmark oracle
- verify corpus path, rows, segments, bytes, immutable corpus identity, and multiset before benchmark execution
- add a small register/validate shell workflow with the same exact eight-field schema as the JVM verifier
- document the current workflow and tamper/legacy rejection behavior

This extracts only the durable corpus-registration idea from the superseded harness. It does not carry forward legacy page-run readers/converters, finalization protocols, ranges/sizer/A-B arms, or production changes.

## Verification

- `./gradlew build` after rebasing onto PR #175 (87 tasks, including LocalStack integration)
- `ParallelMergeBenchmarkTest` (22 tests)
- register/validate functional cycle
- unknown, duplicate, malformed, missing, legacy-field, and tampered-record rejection
- `bash -n scripts/perf/corpus-record.sh`
- `git diff --check`
- independent scope/correctness review: approved with no remaining actionables

Delta: 363 additions across five tooling, test, and developer-documentation files; production code is unchanged.