### PR TITLE
Fix replay, metrics, and CLI documentation defects

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -202,3 +202,6 @@ swath list --tune help
 The stable exit-code table and output contracts are in
 [Using swath](usage.md#exit-codes). Progress, report, and metric fields are in
 [Metrics and observability](metrics-and-observability.md).
+
+If none of the above resolves it, see
+[Filing a support request](operating.md#filing-a-support-request) for what to include.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,10 @@ This guide gets from a Docker image to a small queryable Parquet inventory. The 
 example lists one historical day from NOAA's `noaa-gestofs-pds` bucket, so it is a quick
 functional check rather than the 39.6-million-object demonstration shown in the README.
 
+The commands below are written against swath **0.3.0**. Match your installed version with
+[step 1](#1-check-the-cli), and adjust the image tag if you are running a different
+release.
+
 swath reads object metadata only. It never downloads or modifies object contents. A run is
 a live listing, not a point-in-time snapshot of a bucket that changes while the scan is in
 progress.
@@ -26,13 +30,12 @@ directly.
 ## 1. Check the CLI
 
 ```bash
-docker run --rm ghcr.io/varveio/swath:latest --version
+docker run --rm ghcr.io/varveio/swath:0.3.0 --version
 ```
 
-This prints the swath version and exits without contacting object storage.
-
-For reproducible automation, replace `latest` with a release tag or the immutable digest
-published with that release.
+This prints the swath version and exits without contacting object storage. The examples
+below pin the `0.3.0` release tag; for reproducible automation, prefer the immutable
+digest published with that release instead of a mutable tag.
 
 ## 2. Stream a few public rows
 
@@ -40,7 +43,7 @@ The following command lists one historical NOAA day and stops after the downstre
 `head` process has read five rows:
 
 ```bash
-docker run --rm ghcr.io/varveio/swath:latest \
+docker run --rm ghcr.io/varveio/swath:0.3.0 \
   list s3://noaa-gestofs-pds/stofs_2d_glo.20230113/ \
   --no-sign-request --region us-east-1 \
   --format tsv |
@@ -49,6 +52,16 @@ docker run --rm ghcr.io/varveio/swath:latest \
 
 The command is anonymous and needs no AWS credentials. Closing the pipe is treated as a
 successful downstream stop, not as a failed listing.
+
+Output is tab-separated, one object per line: `key`, `size`, `last_modified`, `etag`,
+`storage_class`, and `row_type`. The shape looks like this (illustrative; your exact
+keys, sizes, and timestamps will differ):
+
+```text
+key	size	last_modified	etag	storage_class	row_type
+stofs_2d_glo.20230113/stofs_2d_glo.t00z.fields.cwl.nc	123456789	2023-01-13T02:00:00Z	a1b2c3d4e5f6	STANDARD	OBJECT
+stofs_2d_glo.20230113/stofs_2d_glo.t00z.points.cwl.nc	12345678	2023-01-13T02:05:00Z	f6e5d4c3b2a1	STANDARD	OBJECT
+```
 
 If this exact public command fails, follow the reported network, region, or Docker symptom
 in [Troubleshooting and FAQ](faq.md). Do not add credentials to the public example.
@@ -61,7 +74,7 @@ Create a host directory, mount it into the container, and write the listing bene
 mkdir -p out
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
-  ghcr.io/varveio/swath:latest \
+  ghcr.io/varveio/swath:0.3.0 \
   list s3://noaa-gestofs-pds/stofs_2d_glo.20230113/ \
   --no-sign-request --region us-east-1 \
   --format parquet -o /out/stofs-20230113
@@ -124,7 +137,7 @@ The output directory is the public resume handle:
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
-  ghcr.io/varveio/swath:latest \
+  ghcr.io/varveio/swath:0.3.0 \
   resume /out/stofs-20230113
 ```
 
@@ -133,8 +146,11 @@ successfully.
 
 To observe real recovery, use the optional
 [full-scale demonstration](full-scale-demo.md), stop it with Ctrl+C, and pass the same
-output directory to `resume`. swath retains finalized Parquet parts, discards an
-unfinished part, and continues after the last durable cursor.
+output directory to `resume`. That demonstration lists the entire `noaa-gestofs-pds`
+bucket and makes tens of thousands of `ListObjectsV2` requests; it is a capability
+demonstration, not an installation test, so do not run it just to confirm swath works.
+swath retains finalized Parquet parts, discards an unfinished part, and continues after
+the last durable cursor.
 
 Do not edit the checkpoint or move an interrupted managed dataset. To replace a completed
 dataset deliberately, start a new listing with `--overwrite`.
@@ -152,7 +168,7 @@ mkdir -p out
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
   -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION \
-  ghcr.io/varveio/swath:latest \
+  ghcr.io/varveio/swath:0.3.0 \
   list s3://my-bucket/prefix/ \
   --region us-east-1 \
   --format parquet -o /out/my-inventory

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,12 +17,15 @@ After installation, continue with [Getting started](getting-started.md).
 ## Docker
 
 ```bash
-docker pull ghcr.io/varveio/swath:latest
-docker run --rm ghcr.io/varveio/swath:latest --version
+docker pull ghcr.io/varveio/swath:0.3.0
+docker run --rm ghcr.io/varveio/swath:0.3.0 --version
 ```
 
-For reproducible automation, replace `latest` with a release tag or the immutable digest
-published with that release.
+`--version` prints the swath version and commit; use its output for support requests and
+reproduction reports. A stable tagged release also publishes a rolling `X.Y` tag and
+`latest`; prefer the exact `X.Y.Z` tag shown above for reproducible examples, and prefer
+the immutable digest over any tag for reproducible automation. See [Tags &
+versioning](packaging-and-docker.md#tags--versioning) for the full tag policy.
 
 The image supports `linux/amd64` and `linux/arm64` and runs as non-root UID 10001. The
 [getting-started guide](getting-started.md) shows writable output mounts for Linux, macOS,
@@ -71,6 +74,14 @@ swath --version
 `./gradlew build` is the integration gate and includes LocalStack tests. For the
 Docker-free contributor loop and opt-in test tiers, see
 [Testing](ops/dev/TESTING.md).
+
+## Check the install
+
+`--version` prints the version, commit, and Java runtime without contacting object
+storage, using the invocation shown for your install path above: `docker run --rm
+ghcr.io/varveio/swath:0.3.0 --version`, `java -jar swath-X.Y.Z.jar --version`, or plain
+`swath --version` once a launcher is on `PATH`. Include this output when filing a
+support request or reproduction report.
 
 <a id="verifying-a-download"></a>
 

--- a/docs/internals/build-and-modules.md
+++ b/docs/internals/build-and-modules.md
@@ -44,14 +44,14 @@ All edges point one way (no cross-module cycles). The `engine`↔`runtime` packa
 
 ## The modules
 
-| Module | Gradle type | Contains | Depends on | v0.1 release status |
+| Module | Gradle type | Contains | Depends on | Distribution/support status |
 |---|---|---|---|---|
 | **`swath-model`** | `java-library` | The `io.varve.swath.model` package — a true leaf (imports no other internal package): `KeyBytes`, sealed `ListEntry`, `PageBatch`, `ByteMidpoint`. testFixtures: `ScalarSafety`. | — | internal; not published or supported |
 | **`swath-core`** | `java-library` | The internal core implementation: `engine`, `runtime`, `output` (incl. `output.parquet`), `sort`, `checkpoint`, `filter`, `pipeline`, `observability`, `error`, `concurrent`, and the **store abstraction** (`store/*` except `store/s3`). **No AWS SDK, no picocli.** testFixtures: `testkit` (MockPageFetcher, Keyspaces, EngineHarness…). Owns the JMH bench source set. | `api` → swath-model | internal; not published or supported |
 | **`swath-s3`** | `java-library` | The S3 backend: `io.varve.swath.store.s3` (`S3PageFetcher`, `S3ClientFactory`, `S3Config`) + the AWS SDK. testFixtures: `LocalStackSupport`. Future `swath-gcs`/`swath-azure` sit beside it. | `api` → swath-core | internal; not published or supported |
 | **`swath-cli`** | `application` | The `swath` binary: the `io.varve.swath.cli` package (`App`, `ListCommand`, `ResumeCommand`, …). `mainClass = io.varve.swath.cli.App`, `applicationName = swath`. | `impl` → swath-core, swath-s3 | binary/dist |
 | **`swath-replay`** | `application` | The listing replay server + `sort-fixture` + conformance harness (`io.varve.swath.replay`). Serves swath Parquet fixtures as a fake S3 `ListObjectsV2` endpoint. testFixtures: `testkit` (`ObjectEntries`, `ParquetFixtures`, `FakeListingStore`). | `impl` → swath-core | separate dev-tool distribution and container image |
-| **`swath-sim`** | `java-library` | The policy simulator (`io.varve.swath.sim`): the ground-truth **store** (`sim.store` — fixture-backed implementations of the replay module's `ListingStore` seam), the discrete-event **kernel** (`sim.kernel` — virtual clock, event queue, scheduler, seeded draw streams), the **models** (`sim.model` — latency, client cost, engine budgets), a synthetic load **driver** (`sim.driver`), and the real-policy **executor** (`sim.executor` — seed, owner-split, thief, pacing, and the simulator's AIMD port). The driver exercises store/kernel arithmetic without split/steal policy; the executor runs those policies against the modelled store in virtual time. See [`swath-sim/README.md`](../../swath-sim/README.md). | `api` → swath-replay; `impl` → swath-core | ❌ (dev/analysis tool) |
+| **`swath-sim`** | `java-library` | The policy simulator (`io.varve.swath.sim`): the ground-truth **store** (`sim.store` — fixture-backed implementations of the replay module's `ListingStore` seam), the discrete-event **kernel** (`sim.kernel` — virtual clock, event queue, scheduler, seeded draw streams), the **models** (`sim.model` — latency, client cost, engine budgets), a synthetic load **driver** (`sim.driver`), and the real-policy **executor** (`sim.executor` — seed, owner-split, thief, pacing, and the simulator's AIMD port). The driver exercises store/kernel arithmetic without split/steal policy; the executor runs those policies against the modeled store in virtual time. See [`swath-sim/README.md`](../../swath-sim/README.md). | `api` → swath-replay; `impl` → swath-core | ❌ (dev/analysis tool) |
 
 Only `swath-cli` ships in the main `swath` artifacts. The uber-jar is `:swath-cli:shadowJar` over swath-cli's own
 `runtimeClasspath`, and the Docker image copies exactly that jar, so a module reaches a shipped
@@ -59,7 +59,7 @@ artifact **iff `swath-cli` depends on it**. `swath-replay` is published separate
 own install distribution and container image; `swath-sim` is not on either runtime path (and
 is a `java-library`, so it has no dist of its own).
 
-v0.1 is CLI-only. No Java module is published to Maven Central and no Java
+The distributed product is CLI-only. No Java module is published to Maven Central and no Java
 package, class, interface, SPI, source shape, or binary ABI is a supported API.
 The `java-library` plugin and Gradle `api` edges below describe only this
 repository's compile-classpath structure. `swath-cli` ships as a binary/dist;

--- a/docs/metrics-and-observability.md
+++ b/docs/metrics-and-observability.md
@@ -4,14 +4,23 @@ This is the operator reference for a run that needs monitoring or diagnosis. A f
 listing needs no telemetry setup; use [Getting started](getting-started.md) and keep the
 default terminal progress display.
 
-swath exposes the same run through four progressively deeper surfaces:
+swath exposes the same run through five progressively deeper surfaces:
 
 | Need | Use |
 | --- | --- |
 | Watch a terminal run | the progress display, or `-v` structured progress logs |
 | Compare completed runs | `_swath_summary.json` or `--report PATH` |
 | Feed dashboards and alerts | OTLP metrics via `--metrics-endpoint` |
-| Reproduce an engine decision | `--trace PATH`, then `swath-replay` |
+| Explain a specific engine decision | `--trace PATH` and the trace schema / decision-trace tooling |
+| Reproduce a bucket shape or listing workload | capture a Parquet fixture and serve it with `swath-replay` |
+
+A decision trace and a replay fixture are related but distinct artifacts from the same
+run: the trace is a JSON Lines record of why the engine split, stole, or pivoted at a
+specific moment, while a fixture is captured Parquet listing data that `swath-replay`
+serves back as an S3-shaped source for other tests. An investigation can retain both
+from one run — the trace to explain the decision, the Parquet capture to reproduce the
+bucket shape that triggered it. `swath-replay` does not consume a decision trace, and a
+trace does not carry object rows.
 
 Logs always go to stderr; listing data can therefore stream safely on stdout. Use `-v`,
 `-vv`, or `-vvv` for INFO, DEBUG, or TRACE logs. `-q` selects ERROR and `-qq` disables
@@ -124,7 +133,7 @@ listing, `MERGE_ONLY_PAGE_RUN` is a checkpoint-authorized zero-LIST merge re-ent
 `PUBLISHED_REENTRY` is a checkpoint-authorized no-op resume that found this run already published
 (so it ran neither listing nor merge). It is independent of the retained `merge_only_resume`
 compatibility marker. `sort-fixture` has no run summary artifact; its existing stdout result line
-is labelled `arm=SORT_FIXTURE` instead.
+is labeled `arm=SORT_FIXTURE` instead.
 
 The `sort` block decomposes terminal work into `finalize_ms`, `finalize_close_ms`,
 `local_publication_ms`, `finalize_parallelism`, and `manifest_*` fields. `finalize_ms` is wall
@@ -282,6 +291,20 @@ pivots, so handle them like bucket metadata.
 Use a trace when aggregate counters show *that* a path engaged but you need to know *where*
 or *why*. The format and event guarantees are specified in
 [metrics internals](internals/metrics-internals.md#7-run-trace-format).
+
+A single run can produce several related artifacts, each answering a different question:
+
+```text
+run
+├── _swath_summary.json   result/config/metrics
+├── --trace JSONL         decision events and pivots
+└── Parquet capture       rows that swath-replay can serve
+```
+
+The summary and trace describe the run itself; a Parquet capture from the same run
+becomes an input to [`swath-replay`](swath-replay.md) only after a separate capture step
+(`--format parquet`), and only the capture — not the trace — is something `swath-replay`
+serves back as a listing source.
 
 ## 8. Replay meters
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -211,3 +211,14 @@ or another snapshotting mechanism when point-in-time semantics are required.
 6. Retain `_swath_summary.json` with the result. It can contain target URIs, filters,
    slow-range bounds, and key samples, so redact it before sharing outside the bucket's
    trust boundary.
+
+## Filing a support request
+
+Include these four things so an issue or investigation does not stall on missing facts:
+
+- the output of `swath --version` (version, commit, and Java runtime);
+- `_swath_summary.json` from the run, with bucket names, keys, and other sensitive
+  fields redacted;
+- the target object-store provider and region; and
+- the output mode used (`--format`: `auto`, `table`, `tsv`, `jsonl`, `parquet`, or the
+  diagnostic `discard`, and whether `--sort` was set).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,6 +7,26 @@ one run per point—not a portable performance promise or a release-candidate be
 For a first listing, use [Getting started](getting-started.md). Return here after a
 representative run has produced `_swath_summary.json`.
 
+### Three diagnostic recipes
+
+1. **Listing-bound vs. output-bound.** Rerun with `--format discard --checkpoint none
+   --report discard.json` and compare `keys_per_sec` and `duration_ms` against the
+   original report. A similar rate with output removed points at the listing path; a
+   large gain points at the output sink. See [Find the limiting
+   stage](#find-the-limiting-stage).
+2. **Underfilled concurrency.** Compare `engine.avg_in_flight` against the configured
+   `--concurrency` ceiling, and check `engine.splits`, steal counts, and probe reasons.
+   Low in-flight utilization with idle splits/probes means another stage is limiting
+   throughput, not the concurrency ceiling. See [In-flight
+   utilization](#in-flight-utilization).
+3. **Sorted-finalization bound.** Compare `pipeline_router_wait_ms`,
+   `pipeline_plan_queue_wait_ms`, and `pipeline_encoder_read_wait_ms`, and check cascade
+   pass count and encoder clamp/floor reasons. High router wait points at segment
+   production (header scan or cascade passes) rather than the encoders; high plan-queue
+   wait means the encoders cannot drain plans as fast as the router produces them, so
+   more encoder parallelism (if heap and descriptors allow) is the lever. See [The
+   sorted merge](#the-sorted-merge).
+
 <a id="diagnosing-a-run"></a>
 
 ## Start with your own run
@@ -21,17 +41,17 @@ Bucket shape, client location, output disk, filters, CPU architecture, and servi
 all affect the result. Absolute numbers from another bucket are rarely useful; the
 relationships among your own report fields are.
 
-### In-flight utilisation
+### In-flight utilization
 
 `--concurrency N` is a ceiling. The achieved request concurrency is
 `engine.avg_in_flight`:
 
 ```text
-utilisation = engine.avg_in_flight / configured concurrency
+utilization = engine.avg_in_flight / configured concurrency
 ```
 
-Use the configured ceiling, not `peak_in_flight`. High utilisation means the ceiling may
-be the bottleneck. Low utilisation means useful ranges, CPU, or another stage could not
+Use the configured ceiling, not `peak_in_flight`. High utilization means the ceiling may
+be the bottleneck. Low utilization means useful ranges, CPU, or another stage could not
 keep it full; raising the ceiling usually adds overhead.
 
 For a sorted run, the report's whole-run average includes the post-listing merge, where
@@ -63,7 +83,7 @@ Across a concurrency sweep:
   `engine.splits`, steals, probe reasons, tail occupancy, and the shape block.
 - High `queue.wait`, Parquet latency, or checkpoint waits identify a local downstream stage
   rather than the object store.
-- The combination of falling utilisation, falling throughput, and rising CPU per key is a
+- The combination of falling utilization, falling throughput, and rising CPU per key is a
   sign of an overshot ceiling, regardless of which resource ran out first.
 
 Treat `shape.divergence_depth_histogram`, `mass_skew_gini`, and `delimiter_fanout` as clues,
@@ -172,7 +192,7 @@ counts. The public PERF-2 gate covers 100,000 keys and requires peak heap below 
 its default Parquet fixture; it does not establish a billion-object memory envelope.
 
 For production sizing, sweep realistic concurrency under an explicit `-Xmx`, watch peak
-heap/RSS and disk, and keep the setting below the point where utilisation collapses.
+heap/RSS and disk, and keep the setting below the point where utilization collapses.
 
 <a id="retain-a-jfr-cpu-profile"></a>
 
@@ -247,7 +267,7 @@ not local SSD.
 
 One unsorted Parquet sweep against `pds-css-archive` (96,022,559 objects) produced:
 
-| `--concurrency` | keys/s | avg in-flight (utilisation) | CPU-s/Mkey | peak heap | peak RSS |
+| `--concurrency` | keys/s | avg in-flight (utilization) | CPU-s/Mkey | peak heap | peak RSS |
 | ---: | ---: | ---: | ---: | ---: | ---: |
 | 32 | 165,831 | 29.9 (93%) | 7.42 | 0.92 GB | 1.27 GB |
 | 64 | 327,275 | 56.9 (89%) | 7.28 | 2.24 GB | 2.51 GB |
@@ -256,7 +276,7 @@ One unsorted Parquet sweep against `pds-css-archive` (96,022,559 objects) produc
 | 512 | 519,286 | 93.2 (18%) | 11.06 | 5.25 GB | 5.66 GB |
 
 The peak in this sweep was 655,346 keys/s at 256—not a global ceiling or recommended
-default. At 512, utilisation collapsed and CPU cost rose while request latency stayed near
+default. At 512, utilization collapsed and CPU cost rose while request latency stayed near
 175 ms. Split counts had plateaued around 4,900, so extra slots had little useful work.
 
 Across the measured buckets, API calls per 1,000 objects were 1.016–1.089 against the 1.0

--- a/docs/swath-replay.md
+++ b/docs/swath-replay.md
@@ -16,6 +16,41 @@ virtual-host routing, version listing, or API other than path-style `ListObjects
 
 For an investigation workflow, see [Replay troubleshooting](replay-troubleshooting.md).
 
+A `--trace` decision trace and a replay fixture are different artifacts: a trace explains
+why the engine made a specific split or pivot decision during a run, while a replay
+fixture is captured Parquet listing data that `swath-replay` serves back as an
+S3-shaped source. A trace is not something `swath-replay` consumes, and a fixture does
+not carry engine decisions. See [Metrics and observability](metrics-and-observability.md)
+for how the two artifacts relate.
+
+## Quick path
+
+Capture a fixture, sort it if needed, serve it, query it, and collect its metrics:
+
+```bash
+swath list s3://digitalcorpora --region us-west-2 --no-sign-request \
+  --format parquet -o /tmp/swath-replay-example/capture --restart --concurrency 16
+
+swath-replay sort-fixture \
+  --capture /tmp/swath-replay-example/capture/data \
+  --output /tmp/swath-replay-example/sorted
+
+swath-replay serve --fixture /tmp/swath-replay-example/sorted \
+  --bucket digitalcorpora --host 127.0.0.1 --port 19090 \
+  --serving-mode sorted --metrics-port 19192 &
+SERVER_PID=$!
+
+# Wait for the index build to finish before sending requests.
+until curl -sf http://127.0.0.1:19192/healthz >/dev/null; do sleep 0.5; done
+
+curl 'http://127.0.0.1:19090/digitalcorpora?list-type=2&max-keys=10&encoding-type=url'
+curl -s http://127.0.0.1:19192/metrics | jq .
+
+kill "$SERVER_PID"
+```
+
+Each step is explained in detail below.
+
 ## Build
 
 ```bash
@@ -138,10 +173,12 @@ Jetty's implicit 200-thread default. It defaults to 512 and is reported as
 `max_concurrent_requests=` at startup. Set it at or above the widest client fan-out so
 connector queueing is not mistaken for backend latency.
 
-`--parquet-connections 0` uses the selected store's own reader default:
-`max(8, min(32, cores))` for sorted serving and `min(4, cores)` for DuckDB.
-Size this for concurrent decode work, not total requests: readers are returned before
-injected sleep. Each sorted slot holds an open reader and decoded footer per file, so
+`--parquet-connections N` controls the selected serving mode's backing-reader capacity.
+With `0`, sorted mode uses `max(8, min(32, available processors))`, while DuckDB mode
+uses `min(4, available processors)`. Size it for concurrent decode work rather than
+total HTTP requests; `--max-concurrent-requests` is the separate request-admission
+ceiling. Readers are returned before injected sleep. Each sorted slot holds an open
+reader and decoded footer per file, so
 very large pools can waste file descriptors and heap. Sorted mode eagerly opens the range-reader
 pool per file (`connections × files` readers). Its independent row-group pool opens lazily, one
 file at a time, only when a native `delimiter=/` skip-scan cannot answer from routing-index bounds;
@@ -266,9 +303,9 @@ group proves internally disordered, sorted mode returns `500 InternalError` and 
 `swath.replay.serving.refused{reason=row_group_disorder}`. It never guesses past disorder.
 Re-sort the capture or use DuckDB.
 
-`--parquet-connections N` controls the DuckDB pool; `0` chooses `min(4, CPUs)`. Connections
-divide available threads, so raising the pool trades per-query resources for request
-parallelism.
+See [Serving concurrency](#serving-concurrency---max-concurrent-requests) for
+`--parquet-connections` defaults and sizing guidance; it governs backing-reader capacity
+for both serving modes, not only DuckDB.
 
 ## Fault-latency injection (`--inject-latency`)
 

--- a/swath-cli/src/main/java/io/varve/swath/cli/App.java
+++ b/swath-cli/src/main/java/io/varve/swath/cli/App.java
@@ -33,7 +33,7 @@ import picocli.CommandLine.UnmatchedArgumentException;
         name = "swath",
         mixinStandardHelpOptions = true,
         versionProvider = App.VersionProvider.class,
-        description = "High-performance object-store lister.",
+        description = "Parallel, resumable S3 object lister.",
         footer = "Built by Varve: https://varve.io",
         subcommands = {
                 ListCommand.class,

--- a/swath-cli/src/test/resources/help/swath.txt
+++ b/swath-cli/src/test/resources/help/swath.txt
@@ -1,5 +1,5 @@
 Usage: swath [-hVqv] [--color=MODE] [COMMAND]
-High-performance object-store lister.
+Parallel, resumable S3 object lister.
       --color=MODE   Color the progress line and end-of-run summary: auto,
                        always, or never (default: auto).
   -h, --help         Show this help message and exit.


### PR DESCRIPTION
## Summary

Fixes a batch of mechanical documentation defects flagged by an external docs review
(P1.1, P1.2, P1.8-spelling, P2.4, and review sections 6/8/9/11/12/13/14):

- `docs/swath-replay.md`: removed the stale `--parquet-connections` paragraph that
  contradicted the earlier mode-specific defaults (sorted: `max(8, min(32, cores))`;
  DuckDB: `min(4, cores)`), consolidated the resource explanation into one canonical
  section with a link-back, added a 10-line "quick path" at the top, and noted that a
  decision trace is not a replay fixture.
- `docs/metrics-and-observability.md`: split the "reproduce an engine decision" table
  row into two (explain a decision vs. reproduce a bucket shape), added a bridge
  paragraph, and added a small artifact-relationship diagram.
- `docs/performance.md`: `utilisation` → `utilization` throughout, and added a compact
  "three diagnostic recipes" box near the top.
- `docs/internals/build-and-modules.md`: renamed the "v0.1 release status" table column
  to "Distribution/support status"; fixed "modelled" → "modeled".
- `swath-cli/src/main/java/io/varve/swath/cli/App.java`: root command description
  changed from "High-performance object-store lister." to "Parallel, resumable S3
  object lister."; updated the matching golden help text in
  `swath-cli/src/test/resources/help/swath.txt`.
- `docs/getting-started.md`: stated the documented binary version (0.3.0) near the top,
  pinned Docker examples to the `0.3.0` tag, added two illustrative sample TSV output
  rows after the first streaming command, and added a sentence warning that the
  full-scale demo makes tens of thousands of LIST requests and isn't an install test.
- `docs/install.md`: pinned the Docker example to `0.3.0` (a stable release publishes an
  exact `X.Y.Z` tag per `.github/workflows/release.yml`), and added a quick
  `swath --version` verification command/section.
- `docs/operating.md` / `docs/faq.md`: added a small "Filing a support request"
  section (version+commit, redacted `_swath_summary.json`, provider/region, output
  mode) with a cross-link from the FAQ.

Version references in these docs assume the 0.3.0 release and this PR should merge
after the release-prep PR.

## Test plan

- [x] `./gradlew build -PnoIntegration` (full build, all modules)
- [x] `HeadlineDocsCommandSmokeTest` and `DocumentationEntryPointTest` pass with the
      updated CLI description
- [x] Verified replay reader-capacity defaults against
      `SortedParquetStore.defaultConnectionCount()` and
      `DuckDbListingStore.defaultConnectionCount()`
- [x] Verified JDK 25 requirement against
      `build-logic/src/main/kotlin/swath.java-conventions.gradle.kts`
- [x] Verified TSV column layout against
      `swath-core/src/main/java/io/varve/swath/output/TsvFormatter.java`
- [x] Verified `--version` output (version/commit/runtime) against `App.java`
- [x] Verified Docker tag policy against `.github/workflows/release.yml`
