### PR TITLE
Release v0.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.3.0
+version=0.3.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.2.5-SNAPSHOT
+version=0.3.0


### PR DESCRIPTION
The two commits produced by `just release 0.3.0`: the v0.3.0 version commit (which the pushed v0.3.0 tag points at) and the 0.3.1-SNAPSHOT reopen. Must be merged with a merge commit — not squashed or rebased — so the tagged commit becomes an ancestor of main and the release workflow's source guard passes.