### PR TITLE
Identify the two public NOAA captures and add canonical run facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,26 @@ requester-pays bucket, read the [request-cost guidance](docs/operating.md#reques
 
 ## See it at full scale
 
-[![swath demo: interrupt and resume a 39.6-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)](https://swath.varve.io/runs/noaa-gestofs-pds/)
+[![swath demo: interrupt and resume a 39.6-million-object S3 listing, then query the Parquet inventory with DuckDB](docs/assets/swath-demo-v0.2.1.gif)](docs/full-scale-demo.md)
 
-*The embedded recording was captured with swath v0.2.1 against the full public
-`noaa-gestofs-pds` bucket. That observed run listed 39,585,029 objects, made 41,582
-`ListObjectsV2` calls, wrote 790.8 MB of Parquet, and peaked at about 1.7 GB RSS.
-The bucket and the current release can produce different figures. Read the
-[full-scale demonstration](docs/full-scale-demo.md) before reproducing it, or
-[explore the run trace](https://swath.varve.io/runs/noaa-gestofs-pds/).*
+*Run `noaa-gestofs-pds-2026-08-03-505ae26`. The embedded recording was captured on
+2026-08-03 with swath v0.2.1 (`505ae26e6019`) against the full public
+`noaa-gestofs-pds` bucket, at `--concurrency 128`, and published 39,585,029 objects to a
+managed Parquet dataset. It is an interrupted `swath list` followed by the `swath resume`
+that finished it; that resume invocation reported 41,582 `ListObjectsV2` attempts, 22
+Parquet parts totaling 790.0 MB, a peak of about 1.7 GB RSS, and 1m36s elapsed for
+itself. swath prints an elapsed time per invocation, and no clock for the whole capture
+was recorded. The bucket and the current release can produce different figures; the
+[run facts](site/data/runs/noaa-gestofs-pds-2026-08-03-505ae26.json) record what is known
+about this capture and what is not. Read the
+[full-scale demonstration](docs/full-scale-demo.md) before reproducing it.*
+
+The [interactive run trace](https://swath.varve.io/runs/noaa-gestofs-pds/) visualizes a
+separate capture of the same bucket, not this recording: run
+`noaa-gestofs-pds-field-guide-trace` listed 39,651,850 objects, 66,821 more than the
+recording above, and its
+[run facts](site/data/runs/noaa-gestofs-pds-field-guide-trace.json) leave version,
+commit, date, and command unknown.
 
 The [visual field guide](https://swath.varve.io/field-guide/) explains why S3 listing is
 hard to parallelize and walks through the range model, safe splitting, work stealing,

--- a/docs/full-scale-demo.md
+++ b/docs/full-scale-demo.md
@@ -1,42 +1,77 @@
 # Full-scale public demonstration
 
 This page reproduces the large public listing shown in the README. It is evidence that
-swath can recover from severe key-distribution skew and resume a long run; it is not the
-recommended first command.
+swath can list a very large public bucket and resume it after an interruption; it is not
+the recommended first command.
 
 Start with [Getting started](getting-started.md) if you have not yet completed the small
 public example.
 
 ## What the recording shows
 
-The embedded README recording was captured with **swath v0.2.1** against the full public bucket
-`s3://noaa-gestofs-pds/` in `us-east-1`.
+The embedded README recording is run `noaa-gestofs-pds-2026-08-03-505ae26`, captured on
+2026-08-03 with **swath v0.2.1** (`505ae26e6019`) against the full public bucket
+`s3://noaa-gestofs-pds/`, with `--region us-east-1` and `--concurrency 128`.
 
-That observed run:
+It is two invocations: a `swath list` stopped by a signal, then the `swath resume` that
+finished the dataset. The completed dataset holds 39,585,029 objects, confirmed in the
+recording by a DuckDB count over its Parquet parts. The resume invocation reported:
 
-- listed 39,585,029 objects;
-- made 41,582 `ListObjectsV2` calls;
-- wrote 790.8 MB of Parquet;
-- peaked at about 1.7 GB of resident memory; and
-- began with 513 seed ranges, one of which contained 68% of the objects later found.
+- 41,582 `ListObjectsV2` attempts, including probes and retries;
+- 22 Parquet parts totaling 790.0 MB;
+- a peak of about 1.7 GB of resident memory; and
+- 1m36s elapsed for that invocation. swath prints an elapsed time per invocation, so this
+  is not a wall clock for the whole capture, and no such clock was recorded.
 
-swath discovered the imbalance while listing and split busy remaining ranges so idle
-workers could help. The [interactive run trace](https://swath.varve.io/runs/noaa-gestofs-pds/)
-shows the seed guesses, live ranges, split pivots, and long-tail behavior.
+The interrupted first attempt reported 573,741 objects and 635 attempts of its own. The
+recording does not say whether the resume invocation's totals already include them, so
+neither figure is a whole-capture request count.
 
-These figures describe one recorded run, not a portable benchmark or a promise for the
-current release. The bucket continues to change, object-store latency varies, and client
-CPU, memory, disk, region, and network path all affect the result.
+No run report or decision trace was retained for this capture, and the client machine,
+its provider, and its region are not recorded anywhere.
+[The run facts](../site/data/runs/noaa-gestofs-pds-2026-08-03-505ae26.json) list what is
+known and what is not.
+
+## The interactive trace is a separate capture
+
+The [interactive run trace](https://swath.varve.io/runs/noaa-gestofs-pds/) visualizes run
+`noaa-gestofs-pds-field-guide-trace`, a different capture of the same bucket. Read the two
+as separate runs:
+
+- it listed 39,651,850 objects, 66,821 more than the recording above;
+- it began with 513 initial ranges, one of which held 68.0% of the objects the run
+  returned;
+- it made 2,399 splits and completed all 2,912 ranges it claimed, with none failed; and
+- the report generated from its trace records a 68,592.2 ms span — about 1m 09s — between
+  the trace's first and last event. The trace file itself was not kept and no run summary
+  survives, so that span is the only listing duration available for this capture.
+
+That report counts 41,420 **committed listing pages** in the trace. It is a different
+metric from the 41,582 **`ListObjectsV2` attempts** the recording's resume invocation
+reported: committed pages exclude probes and retries, and the two counts belong to
+different runs in any case. This capture retains no API-attempt count, swath version,
+commit, capture date, or command; see
+[its run facts](../site/data/runs/noaa-gestofs-pds-field-guide-trace.json).
+
+That visualization is where the skew is visible: it shows the capture's seed guesses,
+live ranges, split pivots, and long tail as swath discovers the key-distribution
+imbalance while listing and splits the unscanned remainder of busy ranges so idle workers
+can help.
+
+Neither capture is a portable benchmark or a promise for the current release. The bucket
+continues to change, object-store latency varies, and client CPU, memory, disk, region,
+and network path all affect the result.
 
 ## Before you run it
 
 This command scans the entire public bucket. Review
-[request cost](operating.md#request-cost) first. The ideal page count is approximately
-one request per 1,000 returned keys, but probes, retries, sparse pages, and interrupted
-tails add overhead.
+[request cost](operating.md#request-cost) first. The floor is about one committed listing
+page per 1,000 returned keys, and each of those pages normally costs one successful
+request; probes, retries, sparse pages, and interrupted tails add further attempts.
 
-The command writes roughly a gigabyte of output for the recorded bucket state and uses
-more working memory than the small getting-started example. Keep the resulting
+The recording's resume invocation reported 790.0 MB written for the bucket state it
+captured; your run's output size will differ as the bucket changes. The command uses more
+working memory than the small getting-started example. Keep the resulting
 `_swath_summary.json`; it records the actual request count, duration, throughput, and
 resource evidence for your run.
 
@@ -119,7 +154,12 @@ work-supply starvation, output backpressure, and sorted-merge sizing.
 
 ## Related material
 
-- [Interactive trace for the recorded NOAA run](https://swath.varve.io/runs/noaa-gestofs-pds/)
+- [Interactive trace of run `noaa-gestofs-pds-field-guide-trace`](https://swath.varve.io/runs/noaa-gestofs-pds/)
+  — a separate capture of the same bucket
+- Run facts:
+  [`noaa-gestofs-pds-2026-08-03-505ae26`](../site/data/runs/noaa-gestofs-pds-2026-08-03-505ae26.json)
+  and
+  [`noaa-gestofs-pds-field-guide-trace`](../site/data/runs/noaa-gestofs-pds-field-guide-trace.json)
 - [Visual field guide](https://swath.varve.io/field-guide/)
 - [Getting started](getting-started.md)
 - [Operating swath and request cost](operating.md)

--- a/site/data/runs/noaa-gestofs-pds-2026-08-03-505ae26.json
+++ b/site/data/runs/noaa-gestofs-pds-2026-08-03-505ae26.json
@@ -1,0 +1,185 @@
+{
+  "schema_version": "swath-public-run-v1",
+  "run_id": "noaa-gestofs-pds-2026-08-03-505ae26",
+  "title": "README full-scale recording of s3://noaa-gestofs-pds/",
+  "provenance_status": "partial",
+  "swath": {
+    "version": "0.2.1",
+    "commit": "505ae26e6019",
+    "runtime": "25.0.3+9-LTS"
+  },
+  "captured_at": "2026-08-03",
+  "captured_at_precision": "date",
+  "captured_at_bounds": {
+    "earliest": "2026-08-03T12:29:20Z",
+    "latest": "2026-08-03T12:51:46Z",
+    "basis": "No timestamp was recorded for this capture. The date is derived from two bounds, not read from a clock. The recording's own DuckDB query over the produced dataset reports the newest listed object as last_modified 2026-08-03 12:29:20+00, so the listing was still running at or after that instant; the recording assets were committed to this repository at 2026-08-03T12:51:46Z, so it had finished by then. Both bounds fall on the same UTC date, which is why `captured_at` carries date precision and no time of day."
+  },
+  "target": {
+    "uri": "s3://noaa-gestofs-pds/",
+    "provider": "AWS S3",
+    "region": null,
+    "region_source": "Not recorded. The recorded command passed `--region us-east-1`, which is the client's configured region and is kept under `config.region`; no bucket-location response is retained, so the bucket's own region is not established by this capture."
+  },
+  "client": {
+    "provider": null,
+    "region": null,
+    "machine_type": null,
+    "cpu": null,
+    "memory_bytes": null,
+    "published_description": null
+  },
+  "command": {
+    "list": "swath list s3://noaa-gestofs-pds/ --no-sign-request --region us-east-1 --concurrency 128 --format parquet -o /out/noaa-gestofs-pds",
+    "resume": "swath resume /out/noaa-gestofs-pds"
+  },
+  "output": {
+    "format": "parquet",
+    "destination_kind": "managed Parquet dataset directory",
+    "destination_kind_source": "The recording's `ls -R` of the output directory shows `_SUCCESS`, `_swath_summary.json`, `manifest.json`, `symlink.txt`, and a `data/` directory of Parquet parts.",
+    "sorted": false,
+    "sorted_source": "The configured output mode, not a verified property of the published parts: the recorded command passes no `--sort` flag, and globally sorted output is opt-in."
+  },
+  "config": {
+    "concurrency_ceiling": 128,
+    "concurrency_ceiling_source": "The `--concurrency 128` flag is visible in the recorded command.",
+    "region": "us-east-1"
+  },
+  "clocks": {
+    "listing_wall": {
+      "ms": null,
+      "display": null,
+      "measures": "Not recorded. No single whole-capture listing clock exists in retained evidence; the capture is two invocations, each of which printed its own elapsed time under `invocations`."
+    },
+    "invocation_wall": {
+      "ms": null,
+      "display": null,
+      "measures": "Recorded per invocation rather than once for the capture. See `invocations[].elapsed_display`."
+    },
+    "trace_event_span": {
+      "ms": null,
+      "display": null,
+      "measures": "Not available. No `--trace` file was retained for this recording, and none is referenced by it."
+    },
+    "video_playback": {
+      "ms": null,
+      "display": null,
+      "measures": "Not recorded. The terminal screen capture's playback length is a property of the recording, not of the listing, and is stated nowhere in retained evidence."
+    }
+  },
+  "result": {
+    "objects": 39585029,
+    "objects_measures": "Objects in the published managed Parquet dataset, counted with DuckDB over `data/*.parquet` inside the recording itself. The resume invocation's summary printed the same total.",
+    "api_calls": null,
+    "api_calls_measures": "No whole-capture attempt count is established. The resume invocation printed 41,582 API calls and the interrupted first attempt printed 635; the recording does not say whether the larger figure already includes the smaller. Both are under `invocations`. swath's `cost.api_calls` counts `ListObjectsV2` attempts including probes and retries, per docs/operating.md.",
+    "api_calls_per_1k_objects": null,
+    "committed_pages": null,
+    "committed_pages_measures": "Not recorded. The recording reports API attempts, not committed listing pages.",
+    "pages_per_1k_objects": null,
+    "initial_ranges": null,
+    "empty_initial_ranges": null,
+    "splits": null,
+    "owner_splits": null,
+    "uniform_pivot_splits": null,
+    "claimed_ranges": null,
+    "completed_ranges": null,
+    "failed_ranges": null,
+    "listing_workers_observed": null,
+    "listing_workers_measures": "Not recorded. The recording shows the configured ceiling, not the number of workers that ran.",
+    "peak_live_ranges": null,
+    "heaviest_initial_range": null,
+    "median_initial_range_objects": null,
+    "parquet_parts": null,
+    "parquet_bytes": null,
+    "peak_rss_bytes": null,
+    "listed_object_bytes_display": "1.2 PiB",
+    "earliest_object_last_modified": "2021-01-05T20:24:05Z",
+    "latest_object_last_modified": "2026-08-03T12:29:20Z",
+    "listed_object_measures": "Properties of the objects the dataset describes, read from the recording's DuckDB query over the published parts: the summed `size` column and the range of the `last_modified` column. They describe bucket contents, not swath's own output or timing.",
+    "scope_note": "Output volume, memory, throughput, cost estimate, and fault counters are printed by an invocation's run summary. Whether each covers the whole capture or only that invocation is not stated in retained evidence, so they are kept under `invocations` rather than promoted here."
+  },
+  "invocations": [
+    {
+      "role": "initial",
+      "command": "swath list s3://noaa-gestofs-pds/ --no-sign-request --region us-east-1 --concurrency 128 --format parquet -o /out/noaa-gestofs-pds",
+      "outcome": "INCOMPLETE (signal)",
+      "elapsed_display": "3.6s",
+      "elapsed_measures": "Elapsed time printed by this invocation's run summary. Only the rounded terminal display is retained.",
+      "objects": 573741,
+      "api_calls": 635,
+      "api_calls_per_1k_objects_display": "1.11",
+      "keys_per_second": 161250,
+      "avg_in_flight_display": "19.16",
+      "peak_in_flight": 68,
+      "throttled": null,
+      "retried": null,
+      "errors": null,
+      "parquet_parts": null,
+      "parquet_bytes_display": null,
+      "peak_rss_display": "1.3 GB",
+      "estimated_list_cost_display": "~$0.003 (est. @ $0.005/1k LIST)",
+      "counter_scope": null,
+      "counter_scope_measures": "These are the values this invocation's run summary printed. swath may carry run figures forward across a resume, and the recording does not say which of these cover only this invocation."
+    },
+    {
+      "role": "resume",
+      "command": "swath resume /out/noaa-gestofs-pds",
+      "outcome": "complete",
+      "elapsed_display": "1m36s",
+      "elapsed_measures": "Elapsed time printed by this invocation's run summary, on the line that also reports the 39,585,029-object total. Only the rounded terminal display is retained.",
+      "objects": 39585029,
+      "api_calls": 41582,
+      "api_calls_per_1k_objects_display": "1.05",
+      "keys_per_second": 410223,
+      "avg_in_flight_display": "47.70",
+      "peak_in_flight": 64,
+      "throttled": 0,
+      "retried": 1,
+      "errors": 0,
+      "parquet_parts": 22,
+      "parquet_bytes_display": "790.0 MB",
+      "peak_rss_display": "1.7 GB",
+      "estimated_list_cost_display": "~$0.208 (est. @ $0.005/1k LIST)",
+      "counter_scope": null,
+      "counter_scope_measures": "These are the values this invocation's run summary printed. swath may carry run figures forward across a resume, and the recording does not say which of these cover only this invocation."
+    }
+  ],
+  "analysis": null,
+  "trace_model": null,
+  "artifacts": {
+    "summary": null,
+    "raw_trace": null,
+    "interactive_trace": null,
+    "video": [
+      {
+        "path": "docs/assets/swath-demo-v0.2.1.mp4",
+        "url": null,
+        "source": "This repository at commit e6447ff",
+        "sha256": "b0a0d1b5b0e97a6501a1ee36ae45d11d333f8b910cef124881f5c89d9bfaee8f",
+        "association": "The terminal recording of this capture."
+      },
+      {
+        "path": "docs/assets/swath-demo-v0.2.1.gif",
+        "url": null,
+        "source": "This repository at commit e6447ff",
+        "sha256": "9cf58c7e2a6a813aa2ca480da4aabd0b1b68dac1f5eb3965786bf2e5e51bd0a5",
+        "association": "The same recording as an animated image, embedded in README.md."
+      }
+    ]
+  },
+  "evidence": [
+    "Unless a field's own `_source` or `_measures` names another origin, every value above is read from the terminal recording committed as docs/assets/swath-demo-v0.2.1.gif and docs/assets/swath-demo-v0.2.1.mp4 (commit e6447ff, 2026-08-03).",
+    "The recording opens with `swath --version`, which prints `swath 0.2.1`, `Commit: 505ae26e6019`, and `Runtime: 25.0.3+9-LTS`. Repository tag v0.2.1 is 505ae26e6019dbf712e4d2ec9462521a53cee9d2, dated 2026-08-03.",
+    "The recording shows the full `swath list` command, an interruption, `swath resume`, both run summaries, an `ls -R` of the output directory listing 22 `part-*.parquet` files under `data/`, and a DuckDB count over the dataset."
+  ],
+  "notes": [
+    "Unknown fields were not present in retained evidence and must not be inferred.",
+    "Values are as a run summary printed them. Integer counters were printed in full; rates and ratios that swath rounds for display, and sizes and durations printed only in rounded units, are kept as `_display` strings so no precision is invented.",
+    "`clocks` is a map of named clocks. Each entry says what it measures, and carries a numeric `ms` only where the source recorded one; `display` is the value as it was shown.",
+    "This capture is not the capture behind the interactive run trace at https://swath.varve.io/runs/noaa-gestofs-pds/. See run noaa-gestofs-pds-field-guide-trace.",
+    "No `_swath_summary.json` or `--trace` file was retained for this capture, so exact byte counts, exact durations, range and split counts, and per-worker detail cannot be recovered.",
+    "The client machine, its provider, and its region are not recorded anywhere in retained evidence for this capture.",
+    "Documentation before this record stated `790.8 MB` of Parquet. The recording's own summary line reads `22 files · 790.0 MB written`; 790.8 is not supported by retained evidence.",
+    "Documentation before this record also attributed 513 initial ranges and a 68% heaviest range to this capture. Those figures come from the separate trace capture and are not stated anywhere in this recording."
+  ]
+}

--- a/site/data/runs/noaa-gestofs-pds-field-guide-trace.json
+++ b/site/data/runs/noaa-gestofs-pds-field-guide-trace.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": "swath-public-run-v1",
+  "run_id": "noaa-gestofs-pds-field-guide-trace",
+  "title": "Field-guide interactive trace of s3://noaa-gestofs-pds/",
+  "provenance_status": "partial",
+  "swath": {
+    "version": null,
+    "commit": null,
+    "runtime": null
+  },
+  "captured_at": null,
+  "captured_at_precision": null,
+  "captured_at_bounds": {
+    "earliest": null,
+    "latest": "2026-08-05T12:16:17Z",
+    "basis": "Nothing in retained evidence dates this capture. The upper bound is publication metadata: the generated report page was first committed to the project's website branch at that time (gh-pages commit db4c5fd), so the capture preceded it by an unknown interval."
+  },
+  "target": {
+    "uri": "s3://noaa-gestofs-pds/",
+    "provider": "AWS S3",
+    "region": null,
+    "region_source": "Not recorded. This capture retains no command, no region setting, and no bucket-location response. Other pages in this repository document `--region us-east-1` for this bucket, but that is not evidence about this run."
+  },
+  "client": {
+    "provider": null,
+    "region": null,
+    "machine_type": null,
+    "cpu": null,
+    "memory_bytes": null,
+    "published_description": "The published field guide describes this run as executed from a dedicated US-East cloud host on a different provider than the bucket's. That prose is the only retained description; it names neither provider, region, nor instance type."
+  },
+  "command": {
+    "list": null,
+    "resume": null
+  },
+  "output": {
+    "format": null,
+    "destination_kind": null,
+    "destination_kind_source": null,
+    "sorted": null,
+    "sorted_source": null
+  },
+  "config": {
+    "concurrency_ceiling": 128,
+    "concurrency_ceiling_source": "Stated as `--concurrency 128` on the published field guide. The trace independently shows 128 distinct listing workers, which is consistent with that ceiling but does not by itself record the configured value.",
+    "region": null
+  },
+  "clocks": {
+    "listing_wall": {
+      "ms": null,
+      "display": null,
+      "measures": "Not recorded. No run summary was retained for this capture, so no listing wall clock from swath itself is available."
+    },
+    "invocation_wall": {
+      "ms": null,
+      "display": null,
+      "measures": "Not recorded. No run summary was retained, and the retained evidence does not say how many invocations this capture took."
+    },
+    "trace_event_span": {
+      "ms": 68592.2,
+      "display": "1m 09s",
+      "measures": "Elapsed time between the first and the last event of the `--trace` JSONL this capture was generated from, computed by tools/explainer and rounded to 0.1 ms when the report was generated. The trace file itself was not retained; only this computed span survives. The published field guide and trace page present it as the run's wall clock."
+    },
+    "video_playback": {
+      "ms": null,
+      "display": "36-second replay",
+      "measures": "Playback length of the generated replay video, as labeled on the project homepage. It is a property of the visualization, not a listing clock, and no exact length is recorded."
+    }
+  },
+  "result": {
+    "objects": 39651850,
+    "objects_measures": "Sum of the `keys` field over the `page_committed` events of the trace, computed when the report was generated.",
+    "api_calls": null,
+    "api_calls_measures": "Not recorded. The trace does not carry the run's `ListObjectsV2` attempt count, and the generated report says so explicitly. Committed pages below are a different metric: they exclude probes and retries.",
+    "api_calls_per_1k_objects": null,
+    "committed_pages": 41420,
+    "committed_pages_measures": "Count of `page_committed` events in the trace.",
+    "pages_per_1k_objects": 1.045,
+    "initial_ranges": 513,
+    "empty_initial_ranges": 0,
+    "splits": 2399,
+    "owner_splits": 2204,
+    "uniform_pivot_splits": 23,
+    "claimed_ranges": 2912,
+    "completed_ranges": 2912,
+    "failed_ranges": 0,
+    "listing_workers_observed": 128,
+    "listing_workers_measures": "Distinct worker ids observed in the trace.",
+    "peak_live_ranges": 128,
+    "heaviest_initial_range": {
+      "objects": 26946179,
+      "share_percent": 68.0,
+      "splits_in_lineage": 2155,
+      "lower_bound": "_para3/",
+      "upper_bound": "_test/"
+    },
+    "median_initial_range_objects": 21024,
+    "parquet_parts": null,
+    "parquet_bytes": null,
+    "peak_rss_bytes": null,
+    "listed_object_bytes_display": null,
+    "earliest_object_last_modified": null,
+    "latest_object_last_modified": null,
+    "listed_object_measures": "Not recorded. A decision trace carries range and page events, not the size or age of the objects behind them.",
+    "scope_note": "Every figure here is derived from trace events. Nothing in retained evidence describes this capture's output, memory, or request cost."
+  },
+  "invocations": null,
+  "analysis": {
+    "busy_worker_seconds": 5030.0,
+    "ideal_seconds": 39.3,
+    "idle_worker_seconds": 3749.8,
+    "share_of_perfect_speedup_percent": 57.3,
+    "measures": "Busy worker-time is the sum of the durations of the trace's range-ownership segments. Ideal seconds is that total divided by the 128 observed workers. The percentage is ideal seconds over the trace event span. All four are generator-rounded for display. This is a diagnostic of this capture's own work accounting, not a portable efficiency score."
+  },
+  "trace_model": {
+    "events": 89230,
+    "unparsable_lines_skipped": 0,
+    "page_events_plotted": 10611,
+    "replay_downsample_keep_every": 5,
+    "cdf_points": 40561,
+    "anonymized": false,
+    "measures": "What the generator read and what the visualization draws. Trace events, committed listing pages, and plotted replay events are three different counts: the animation plots 10,611 of the 41,420 page events, while every figure in this record uses all of them."
+  },
+  "artifacts": {
+    "summary": null,
+    "raw_trace": null,
+    "interactive_trace": {
+      "url": "https://swath.varve.io/runs/noaa-gestofs-pds/",
+      "source": "gh-pages runs/noaa-gestofs-pds/index.html at commit ac66e15",
+      "sha256": "46c61d4bfa153feb6a5943e196a774e854579a46d16fc88029b186d8a6fc7bd4"
+    },
+    "video": [
+      {
+        "path": null,
+        "url": "https://swath.varve.io/assets/swath-noaa-gestofs.mp4",
+        "source": "gh-pages assets/swath-noaa-gestofs.mp4 at commit 2755ee3",
+        "sha256": "e707ea4f38a6a644e2b72d469fb529ce889bed88cf51781c80f40c885055d282",
+        "association": "A replay video of this capture. The trace report and a first version of this video were published together in gh-pages commit db4c5fd; the digest recorded here is the re-rendered video from commit 2755ee3, which replaced it. The project homepage labels it with this capture's figures. The frames were not re-derived from the trace file."
+      }
+    ]
+  },
+  "evidence": [
+    "Unless a field's own `_source` or `_measures` names another origin, every value above is read from the model embedded in the generated report page at https://swath.varve.io/runs/noaa-gestofs-pds/, which tools/explainer computed from the run's `--trace` JSONL at generation time.",
+    "The `--concurrency 128` value and the client description come from prose published on https://swath.varve.io/field-guide/.",
+    "The report page states its own limits: probe and retry requests are not in the committed-page figure, and the run summary's api_calls is the count of actual requests."
+  ],
+  "notes": [
+    "Unknown fields were not present in retained evidence and must not be inferred.",
+    "Values are as the report generator computed and rounded them for display; they carry that precision rather than exact underlying values.",
+    "`clocks` is a map of named clocks. Each entry says what it measures, and carries a numeric `ms` only where the source recorded one; `display` is the value as it was shown.",
+    "This capture is not the capture behind the README recording. See run noaa-gestofs-pds-2026-08-03-505ae26, which listed 39,585,029 objects; the two totals differ by 66,821 objects.",
+    "The trace JSONL itself was not retained anywhere. Only the generated report page, which embeds a reduced model of it, survives.",
+    "swath version, commit, capture date, command, output mode, and client machine are unknown for this capture.",
+    "Committed listing pages must never be compared with the other capture's `ListObjectsV2` attempt count as if they were the same metric."
+  ]
+}

--- a/swath-cli/build.gradle.kts
+++ b/swath-cli/build.gradle.kts
@@ -111,6 +111,11 @@ tasks.named<Test>("test") {
     // registry. Without this, Gradle only tracks compiled classes/resources as inputs, so a
     // docs-only edit leaves the task UP-TO-DATE and the doc/code parity check silently never runs.
     inputs.file(rootProject.file("docs/configuration.md")).withPathSensitivity(PathSensitivity.RELATIVE)
+    // PublicRunFactsTest compares the published run records with the prose that quotes them, for
+    // the same reason: an edit to either side has to be able to fail the check.
+    inputs.dir(rootProject.file("site/data/runs")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(rootProject.file("README.md")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(rootProject.file("docs/full-scale-demo.md")).withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {

--- a/swath-cli/src/test/java/io/varve/swath/cli/PublicRunFactsTest.java
+++ b/swath-cli/src/test/java/io/varve/swath/cli/PublicRunFactsTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2026 Varve Systems Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.varve.swath.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the canonical public run records and the prose that quotes them.
+ *
+ * <p>Two different captures of {@code s3://noaa-gestofs-pds/} are published: the README terminal
+ * recording and the interactive trace. They were once presented as one run, with figures from each
+ * attributed to the other. These checks keep every capture identified by its own run id, keep
+ * unknown provenance an explicit {@code null} rather than a missing or guessed field, keep the two
+ * records one interchangeable shape, and keep every headline number in the prose equal to the
+ * record it came from.
+ */
+final class PublicRunFactsTest {
+
+    private static final Path ROOT = Path.of("..").toAbsolutePath().normalize();
+    private static final Path RUNS = ROOT.resolve("site/data/runs");
+
+    private static final String RECORDING = "noaa-gestofs-pds-2026-08-03-505ae26";
+    private static final String TRACE = "noaa-gestofs-pds-field-guide-trace";
+
+    /** Objects whose key sets must be identical across every record, so one reader fits all. */
+    private static final List<String> SHARED_SHAPES =
+            List.of("", "/swath", "/captured_at_bounds", "/target", "/client", "/command",
+                    "/output", "/config", "/clocks", "/clocks/listing_wall",
+                    "/clocks/invocation_wall", "/clocks/trace_event_span",
+                    "/clocks/video_playback", "/result", "/artifacts");
+
+    /** Provenance this recording does not establish. Absent is not good enough; it must be null. */
+    private static final List<String> RECORDING_UNKNOWNS = List.of(
+            "/target/region",
+            "/client/provider", "/client/region", "/client/machine_type", "/client/cpu",
+            "/client/memory_bytes", "/client/published_description",
+            "/result/api_calls", "/result/api_calls_per_1k_objects", "/result/committed_pages",
+            "/result/pages_per_1k_objects", "/result/initial_ranges",
+            "/result/empty_initial_ranges", "/result/splits", "/result/owner_splits",
+            "/result/uniform_pivot_splits", "/result/claimed_ranges", "/result/completed_ranges",
+            "/result/failed_ranges", "/result/listing_workers_observed",
+            "/result/peak_live_ranges", "/result/heaviest_initial_range",
+            "/result/median_initial_range_objects",
+            "/result/parquet_parts", "/result/parquet_bytes", "/result/peak_rss_bytes",
+            "/analysis", "/trace_model",
+            "/artifacts/summary", "/artifacts/raw_trace", "/artifacts/interactive_trace",
+            "/clocks/listing_wall/ms", "/clocks/listing_wall/display",
+            "/clocks/invocation_wall/ms", "/clocks/invocation_wall/display",
+            "/clocks/trace_event_span/ms", "/clocks/trace_event_span/display",
+            "/clocks/video_playback/ms", "/clocks/video_playback/display");
+
+    /** Provenance the trace does not establish. */
+    private static final List<String> TRACE_UNKNOWNS = List.of(
+            "/swath/version", "/swath/commit", "/swath/runtime",
+            "/captured_at", "/captured_at_precision", "/captured_at_bounds/earliest",
+            "/target/region",
+            "/client/provider", "/client/region", "/client/machine_type", "/client/cpu",
+            "/client/memory_bytes",
+            "/command/list", "/command/resume",
+            "/output/format", "/output/destination_kind", "/output/destination_kind_source",
+            "/output/sorted", "/output/sorted_source",
+            "/config/region",
+            "/result/api_calls", "/result/api_calls_per_1k_objects", "/result/parquet_parts",
+            "/result/parquet_bytes", "/result/peak_rss_bytes",
+            "/result/listed_object_bytes_display", "/result/earliest_object_last_modified",
+            "/result/latest_object_last_modified",
+            "/invocations",
+            "/artifacts/summary", "/artifacts/raw_trace",
+            "/clocks/listing_wall/ms", "/clocks/listing_wall/display",
+            "/clocks/invocation_wall/ms", "/clocks/invocation_wall/display",
+            "/clocks/video_playback/ms");
+
+    /** Fields a consumer will do arithmetic on: never a string that merely looks numeric. */
+    private static final List<String> NUMERIC = List.of(
+            "/result/objects", "/result/api_calls", "/result/committed_pages",
+            "/result/initial_ranges", "/result/splits", "/result/claimed_ranges",
+            "/result/completed_ranges", "/result/failed_ranges",
+            "/result/listing_workers_observed", "/result/heaviest_initial_range/objects",
+            "/result/heaviest_initial_range/share_percent",
+            "/config/concurrency_ceiling",
+            "/clocks/listing_wall/ms", "/clocks/invocation_wall/ms",
+            "/clocks/trace_event_span/ms", "/clocks/video_playback/ms");
+
+    /** The image link that must never point at the other capture's trace page again. */
+    private static final Pattern RECORDING_IMAGE_LINK = Pattern.compile(
+            "\\[!\\[[^\\]]*]\\(docs/assets/swath-demo-v0\\.2\\.1\\.gif\\)]\\(([^)\\s]+)\\)");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void everyRecordIsIdentifiedByItsOwnRunId() throws Exception {
+        List<Path> records = records();
+        List<String> ids = new ArrayList<>();
+        for (Path record : records) {
+            JsonNode facts = MAPPER.readTree(record.toFile());
+            String stem = stem(record);
+            assertThat(facts.path("schema_version").asText())
+                    .as(stem + " schema version")
+                    .isEqualTo("swath-public-run-v1");
+            assertThat(facts.path("run_id").asText())
+                    .as(stem + " run id matches its file name")
+                    .isEqualTo(stem);
+            assertThat(facts.path("notes").isArray()).as(stem + " notes").isTrue();
+            assertThat(facts.path("evidence").isArray()).as(stem + " evidence").isTrue();
+            facts.path("clocks").properties().forEach(clock ->
+                    assertThat(clock.getValue().path("measures").asText(""))
+                            .as(stem + " clock " + clock.getKey() + " says what it measures")
+                            .isNotBlank());
+            ids.add(stem);
+        }
+        assertThat(ids).contains(RECORDING, TRACE);
+    }
+
+    @Test
+    void everyRecordHasTheSameShape() throws Exception {
+        JsonNode reference = read(RECORDING);
+        for (Path record : records()) {
+            JsonNode facts = MAPPER.readTree(record.toFile());
+            for (String pointer : SHARED_SHAPES) {
+                assertThat(keys(facts.at(pointer)))
+                        .as(stem(record) + " keys at '" + pointer + "'")
+                        .isEqualTo(keys(reference.at(pointer)));
+            }
+        }
+    }
+
+    @Test
+    void unknownProvenanceStaysExplicitlyNull() throws Exception {
+        assertExplicitNulls(read(TRACE), TRACE, TRACE_UNKNOWNS);
+        assertExplicitNulls(read(RECORDING), RECORDING, RECORDING_UNKNOWNS);
+
+        JsonNode recording = read(RECORDING);
+        assertThat(recording.at("/swath/version").asText()).isEqualTo("0.2.1");
+        assertThat(recording.at("/swath/commit").asText()).isEqualTo("505ae26e6019");
+        assertThat(recording.at("/command/list").asText()).contains("s3://noaa-gestofs-pds/");
+
+        for (Path record : records()) {
+            JsonNode facts = MAPPER.readTree(record.toFile());
+            for (String pointer : NUMERIC) {
+                JsonNode value = facts.at(pointer);
+                String parent = pointer.substring(0, pointer.lastIndexOf('/'));
+                if (value.isMissingNode() && facts.at(parent).isNull()) {
+                    continue; // the whole block is one explicit null
+                }
+                assertThat(value.isNull() || value.isNumber())
+                        .as(stem(record) + " " + pointer + " is a number or an explicit null")
+                        .isTrue();
+            }
+        }
+    }
+
+    @Test
+    void everyReferencedArtifactCarriesADigest() throws Exception {
+        for (Path record : records()) {
+            JsonNode artifacts = read(stem(record)).at("/artifacts");
+            List<JsonNode> referenced = new ArrayList<>();
+            artifacts.path("video").forEach(referenced::add);
+            if (artifacts.path("interactive_trace").isObject()) {
+                referenced.add(artifacts.path("interactive_trace"));
+            }
+            for (JsonNode artifact : referenced) {
+                String where = stem(record) + " artifact " + artifact.path("source").asText("?");
+                assertThat(artifact.path("sha256").asText(""))
+                        .as(where + " digest")
+                        .matches("[0-9a-f]{64}");
+                assertThat(artifact.path("source").asText("")).as(where + " origin").isNotBlank();
+                if (artifact.path("path").isNull() || artifact.path("path").isMissingNode()) {
+                    continue;
+                }
+                Path asset = ROOT.resolve(artifact.path("path").asText());
+                assertThat(asset).as(where + " file").isRegularFile();
+                assertThat(sha256(asset)).as(where + " still hashes to its recorded digest")
+                        .isEqualTo(artifact.path("sha256").asText());
+            }
+        }
+    }
+
+    @Test
+    void eachCaptureQuotesOnlyItsOwnFactsWhereItIsDescribed() throws Exception {
+        JsonNode recording = read(RECORDING);
+        JsonNode trace = read(TRACE);
+        JsonNode resume = recording.at("/invocations/1");
+        JsonNode initial = recording.at("/invocations/0");
+
+        List<String> recordingFacts = List.of(
+                RECORDING,
+                recording.at("/swath/version").asText(),
+                recording.at("/swath/commit").asText(),
+                recording.at("/captured_at").asText(),
+                grouped(recording.at("/result/objects").asLong()),
+                String.valueOf(recording.at("/config/concurrency_ceiling").asInt()),
+                grouped(resume.path("api_calls").asLong()),
+                String.valueOf(resume.path("parquet_parts").asInt()),
+                resume.path("parquet_bytes_display").asText(),
+                resume.path("peak_rss_display").asText(),
+                resume.path("elapsed_display").asText());
+
+        // Figures that belong to the trace alone. Attributing any of them to the recording is the
+        // exact defect this record set exists to prevent, so they must not appear where the
+        // recording is described.
+        List<String> traceOnlyFacts = List.of(
+                grouped(trace.at("/result/objects").asLong()),
+                grouped(trace.at("/result/committed_pages").asLong()),
+                grouped(trace.at("/result/initial_ranges").asLong()),
+                grouped(trace.at("/result/splits").asLong()),
+                grouped(trace.at("/result/completed_ranges").asLong()),
+                decimal(trace.at("/result/heaviest_initial_range/share_percent").asDouble()) + "%",
+                grouped(trace.at("/clocks/trace_event_span/ms").asDouble()));
+
+        String readme = text("README.md");
+        String demo = text("docs/full-scale-demo.md");
+        String readmeSection = between(readme, "## See it at full scale", "\n## ");
+        String readmeRecording = between(readmeSection, "*Run `", "The [interactive run trace]");
+        String readmeTrace = from(readmeSection, "The [interactive run trace]");
+        String demoRecording = between(demo, "## What the recording shows",
+                "## The interactive trace is a separate capture");
+        String demoTrace = between(demo, "## The interactive trace is a separate capture",
+                "## Before you run it");
+
+        quotes(readmeRecording, "README recording caption", recordingFacts);
+        quotes(demoRecording, "full-scale-demo recording section", recordingFacts);
+        quotes(demoRecording, "full-scale-demo recording section", List.of(
+                grouped(initial.path("objects").asLong()),
+                grouped(initial.path("api_calls").asLong())));
+        absent(readmeRecording, "README recording caption", traceOnlyFacts);
+        absent(demoRecording, "full-scale-demo recording section", traceOnlyFacts);
+
+        quotes(readmeTrace, "README trace paragraph", List.of(TRACE, "separate capture",
+                grouped(trace.at("/result/objects").asLong())));
+        quotes(demoTrace, "full-scale-demo trace section", traceOnlyFacts);
+        quotes(demoTrace, "full-scale-demo trace section", List.of(TRACE));
+        quotes(demo, "docs/full-scale-demo.md", List.of("separate capture"));
+
+        // The difference between the two captures is the whole point; keep it stated.
+        long gap = trace.at("/result/objects").asLong() - recording.at("/result/objects").asLong();
+        assertThat(gap).isNotZero();
+        quotes(readmeTrace, "README trace paragraph", List.of(grouped(gap)));
+        quotes(demoTrace, "full-scale-demo trace section", List.of(grouped(gap)));
+    }
+
+    @Test
+    void noRecordingImageLinksToTheOtherCapture() throws Exception {
+        String readme = text("README.md");
+        Matcher link = RECORDING_IMAGE_LINK.matcher(readme);
+        int found = 0;
+        while (link.find()) {
+            found++;
+            assertThat(link.group(1))
+                    .as("README image link " + found + " destination")
+                    .isEqualTo("docs/full-scale-demo.md");
+        }
+        assertThat(found).as("README embeds the recording as an inline linked image").isOne();
+        assertThat(readme.split("swath-demo-v0\\.2\\.1\\.gif", -1))
+                .as("the recording image appears exactly once")
+                .hasSize(2);
+    }
+
+    private static String between(String page, String start, String end) {
+        int from = page.indexOf(start);
+        assertThat(from).as("section start '" + start + "'").isNotNegative();
+        int to = page.indexOf(end, from + start.length());
+        return to < 0 ? page.substring(from) : page.substring(from, to);
+    }
+
+    private static String from(String page, String start) {
+        int at = page.indexOf(start);
+        assertThat(at).as("section start '" + start + "'").isNotNegative();
+        return page.substring(at);
+    }
+
+    private static void quotes(String page, String name, List<String> facts) {
+        for (String fact : facts) {
+            assertThat(page).as(name + " must quote '" + fact + "' from the run records")
+                    .contains(fact);
+        }
+    }
+
+    private static void absent(String page, String name, List<String> facts) {
+        for (String fact : facts) {
+            assertThat(page).as(name + " must not carry '" + fact + "', which belongs to the "
+                    + "other capture").doesNotContain(fact);
+        }
+    }
+
+    private static void assertExplicitNulls(JsonNode facts, String runId, List<String> pointers) {
+        for (String pointer : pointers) {
+            assertThat(facts.at(pointer).isNull())
+                    .as(runId + " must record " + pointer + " as an explicit null")
+                    .isTrue();
+        }
+    }
+
+    private static Set<String> keys(JsonNode node) {
+        Set<String> names = new LinkedHashSet<>();
+        for (Map.Entry<String, JsonNode> field : node.properties()) {
+            names.add(field.getKey());
+        }
+        return names;
+    }
+
+    private static List<Path> records() throws IOException {
+        try (Stream<Path> files = Files.list(RUNS)) {
+            return files.filter(p -> p.toString().endsWith(".json")).sorted().toList();
+        }
+    }
+
+    private static String stem(Path record) {
+        return record.getFileName().toString().replace(".json", "");
+    }
+
+    private static String grouped(long value) {
+        return String.format(Locale.ROOT, "%,d", value);
+    }
+
+    private static String grouped(double value) {
+        return String.format(Locale.ROOT, "%,.1f", value);
+    }
+
+    private static String decimal(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
+    }
+
+    private static String sha256(Path file) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(file)));
+    }
+
+    private static JsonNode read(String runId) throws IOException {
+        return MAPPER.readTree(RUNS.resolve(runId + ".json").toFile());
+    }
+
+    private static String text(String relative) throws IOException {
+        return Files.readString(ROOT.resolve(relative));
+    }
+}


### PR DESCRIPTION
## What this changes

`s3://noaa-gestofs-pds/` has been listed publicly twice, and the two captures were
presented as one run.

| | README recording | Interactive trace |
| --- | --- | --- |
| Run ID | `noaa-gestofs-pds-2026-08-03-505ae26` | `noaa-gestofs-pds-field-guide-trace` |
| Objects | 39,585,029 | 39,651,850 |
| swath version | 0.2.1 (`505ae26e6019`) | unknown |
| Captured | 2026-08-03 (bounded) | unknown |
| Command | recorded in full | unknown |
| Request count | 41,582 `ListObjectsV2` attempts printed by one invocation | not carried by a trace |
| Pages | not reported | 41,420 committed listing pages |

They differ by 66,821 objects. Before this change the README image linked straight to the
trace page, `docs/full-scale-demo.md` called the trace "the trace for the recorded NOAA
run", and the trace's 513 initial ranges and 68% heaviest range were listed as facts of the
v0.2.1 recording. Git history shows where that came from: the two sets of figures were
merged into one caption in #116 and split back out onto the recording in #141.

This PR keeps both artifacts, gives each a stable run ID, and adds one machine-readable
record per capture under `site/data/runs/` using the `swath-public-run-v1` schema from the
documentation review.

## Where the provenance came from

The recording's provenance is recoverable from the recording itself. Its frames show:

- `swath --version` printing `swath 0.2.1`, `Commit: 505ae26e6019`, `Runtime: 25.0.3+9-LTS`;
- the full `swath list` command, including `--region us-east-1` and `--concurrency 128`;
- an interrupted first attempt (`INCOMPLETE (signal)`, 573,741 objects, 635 API calls) and
  the `swath resume` that finished the dataset;
- `ls -R` of the output directory, with 22 `part-*.parquet` files under `data/`;
- a DuckDB count over the published parts returning 39,585,029 objects, and the newest
  listed object at `2026-08-03 12:29:20+00`.

That last timestamp plus the assets' commit time (2026-08-03T12:51:46Z) bound the capture
to a single UTC date, which is what `captured_at` records — as a derived bound, stated as
such, not as a read clock.

Two corrections fall out of the same evidence:

- the recording reports **790.0 MB** written, not the 790.8 MB the docs carried;
- **41,582 API attempts is what one invocation printed.** The recording does not say
  whether it includes the first attempt's 635, so the record leaves the whole-capture count
  null and keeps both figures under `invocations`.

The trace capture retains only its generated report page on `gh-pages`, which embeds the
model `tools/explainer` computed from the run's `--trace` JSONL. The trace file itself, and
any `_swath_summary.json`, are gone.

## What stays null

| Field | Recording | Trace |
| --- | --- | --- |
| swath version / commit / runtime | recorded | **null** |
| Capture date | derived bound, 2026-08-03 | **null** (upper bound 2026-08-05 publication only) |
| Command | recorded | **null** |
| Output mode | recorded | **null** |
| Client provider / region / machine / CPU / memory | **null** | **null** (only the field guide's "dedicated US-East cloud host" prose) |
| Target bucket region | **null** — the command's `--region` is client configuration, kept under `config.region` | **null** |
| API attempts (whole capture) | **null** | **null** — a trace does not carry them |
| Committed pages, ranges, splits | **null** | recorded |
| Output bytes, parts, peak RSS | per invocation only | **null** |
| Retained summary / raw trace | **null** | **null** |

Each null carries a `_measures` or `_source` string saying why, and every clock says what it
measures: the recording has a per-invocation elapsed time and no whole-capture clock; the
trace has a first-event-to-last-event span, and the video has a playback length that is not
a listing clock at all.

## Documentation changes

- `README.md` — the recording is identified by run ID with its version, commit, date, and
  command context; its image now links to the full-scale page instead of the other capture's
  trace; a following paragraph labels the trace as a separate capture with its own facts.
  The field-guide links were already neutral in wording, so they are untouched.
- `docs/full-scale-demo.md` — the recording section and a new "The interactive trace is a
  separate capture" section state each capture's own figures. Committed listing pages and
  `ListObjectsV2` attempts are labeled as different metrics wherever both appear.
- `docs/README.md` — unchanged; its only run cross-reference already matches the recording.

## Regression guard

`PublicRunFactsTest` holds the two records to one interchangeable shape, requires unknown
provenance to be an explicit `null` rather than a missing key, verifies the retained
recording assets still hash to their recorded digests, and — the check that maps to the
original defect — asserts each capture's figures appear only in the section that describes
that capture, so the trace's ranges and splits cannot drift back onto the recording.

Reviewed adversarially with `codex exec` over two passes; the findings on counter scope,
target region, "retained trace" wording, schema symmetry, and test strength are addressed
above.

refs #143
