### PR TITLE
explainer: render provenance as a collapsed run record

### DIFF
--- a/tools/explainer/src/swath_explainer/templates/report.html
+++ b/tools/explainer/src/swath_explainer/templates/report.html
@@ -59,6 +59,9 @@
 
   .card { background:var(--panel); border:1px solid var(--rule); border-radius:2px;
           padding:1rem 1.15rem; margin:1.1rem 0; overflow-x:auto; }
+  details.card > summary { font-family:var(--mono); font-size:.68rem; letter-spacing:.13em;
+             text-transform:uppercase; color:var(--ink3); font-weight:600; cursor:pointer; }
+  details.card[open] > summary { margin-bottom:.6rem; }
   .card h3 { font-family:var(--mono); font-size:.68rem; letter-spacing:.13em;
              text-transform:uppercase; color:var(--ink3); margin:0 0 .6rem; font-weight:600; }
   canvas { display:block; width:100%; }
@@ -107,13 +110,7 @@
   <noscript><!--__STATIC_SUMMARY__--></noscript>
   <script type="application/json" id="swath-run-facts">/*__FACTS__*/null</script>
 
-  <div class="card" id="provenance-panel">
-    <h3>Provenance</h3>
-    <table><tbody id="run-facts-table"></tbody></table>
-    <p class="cap">Fields absent from the retained run-facts record read "unknown in retained
-    evidence" rather than being inferred. The machine-readable copy is in
-    <code>#swath-run-facts</code>.</p>
-  </div>
+  <p class="sub" id="run-id-line" hidden>Run <code id="run-id"></code></p>
 
   <dl class="tiles" id="tiles"></dl>
   <div id="findings"></div>
@@ -218,6 +215,17 @@
     <div class="col"><p id="ledger-lede"></p></div>
   </div>
 
+  <div class="sec" id="run-record-sec" hidden>
+    <div class="sec-head"><span class="eyebrow">&sect;7</span><h2>Run record</h2></div>
+  </div>
+  <details class="card" id="provenance-panel" hidden>
+    <summary>Provenance</summary>
+    <table><tbody id="run-facts-table"></tbody></table>
+    <p class="cap">Fields absent from the retained run-facts record read "unknown in retained
+    evidence" rather than being inferred. The machine-readable copy is in
+    <code>#swath-run-facts</code>.</p>
+  </details>
+
   <footer id="provenance"></footer>
 </div>
 
@@ -275,6 +283,14 @@
       n=n[parts[i]]; }
     return n; }
   var factsTable=document.getElementById("run-facts-table");
+  if (FACTS){
+    document.getElementById("run-record-sec").hidden=false;
+    document.getElementById("provenance-panel").hidden=false;
+    if (FACTS.run_id){
+      document.getElementById("run-id").textContent=String(FACTS.run_id);
+      document.getElementById("run-id-line").hidden=false;
+    }
+  }
   FACTS_FIELDS.forEach(function(f){
     var v=dig(FACTS, f[1]), tr=el("tr");
     tr.appendChild(el("td","k",f[0]));

--- a/tools/explainer/uv.lock
+++ b/tools/explainer/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "swath-explainer"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
Mirrors the deployed trace page's layout (gh-pages #198): the provenance table moves from a top card to a collapsed details block in a Run record section before the footer, with a one-line run-ID strip up top; both stay hidden without a run-facts record. Self-test passes. refs #143