### PR TITLE
Release v0.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.3.1
+version=0.3.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.3.1-SNAPSHOT
+version=0.3.1


### PR DESCRIPTION
The two commits produced by `just release 0.3.1`: the v0.3.1 version commit (which the pushed v0.3.1 tag points at) and the 0.3.2-SNAPSHOT reopen. Merge with a merge commit — not squash or rebase — so the tagged commit becomes an ancestor of main and the release workflow's source guard passes.