### PR TITLE
Prepare the 0.3.2 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Notable changes per release. The full human summary for the current release is i
 
 ## Unreleased
 
+## 0.3.2 — 2026-09-03
+
 ### Fixed
 
 - The listing pipeline's shared channel no longer wakes every parked fetch worker for each page the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide gets from a Docker image to a small queryable Parquet inventory. The 
 example lists one historical day from NOAA's `noaa-gestofs-pds` bucket, so it is a quick
 functional check rather than the 39.6-million-object demonstration shown in the README.
 
-The commands below are written against swath **0.3.1**. Match your installed version with
+The commands below are written against swath **0.3.2**. Match your installed version with
 [step 1](#1-check-the-cli), and adjust the image tag if you are running a different
 release.
 
@@ -30,11 +30,11 @@ directly.
 ## 1. Check the CLI
 
 ```bash
-docker run --rm ghcr.io/varveio/swath:0.3.1 --version
+docker run --rm ghcr.io/varveio/swath:0.3.2 --version
 ```
 
 This prints the swath version and exits without contacting object storage. The examples
-below pin the `0.3.1` release tag; for reproducible automation, prefer the immutable
+below pin the `0.3.2` release tag; for reproducible automation, prefer the immutable
 digest published with that release instead of a mutable tag.
 
 ## 2. Stream a few public rows
@@ -43,7 +43,7 @@ The following command lists one historical NOAA day and stops after the downstre
 `head` process has read five rows:
 
 ```bash
-docker run --rm ghcr.io/varveio/swath:0.3.1 \
+docker run --rm ghcr.io/varveio/swath:0.3.2 \
   list s3://noaa-gestofs-pds/stofs_2d_glo.20230113/ \
   --no-sign-request --region us-east-1 \
   --format tsv |
@@ -74,7 +74,7 @@ Create a host directory, mount it into the container, and write the listing bene
 mkdir -p out
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
-  ghcr.io/varveio/swath:0.3.1 \
+  ghcr.io/varveio/swath:0.3.2 \
   list s3://noaa-gestofs-pds/stofs_2d_glo.20230113/ \
   --no-sign-request --region us-east-1 \
   --format parquet -o /out/stofs-20230113
@@ -137,7 +137,7 @@ The output directory is the public resume handle:
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
-  ghcr.io/varveio/swath:0.3.1 \
+  ghcr.io/varveio/swath:0.3.2 \
   resume /out/stofs-20230113
 ```
 
@@ -168,7 +168,7 @@ mkdir -p out
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/out:/out" \
   -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_REGION \
-  ghcr.io/varveio/swath:0.3.1 \
+  ghcr.io/varveio/swath:0.3.2 \
   list s3://my-bucket/prefix/ \
   --region us-east-1 \
   --format parquet -o /out/my-inventory

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,8 +17,8 @@ After installation, continue with [Getting started](getting-started.md).
 ## Docker
 
 ```bash
-docker pull ghcr.io/varveio/swath:0.3.1
-docker run --rm ghcr.io/varveio/swath:0.3.1 --version
+docker pull ghcr.io/varveio/swath:0.3.2
+docker run --rm ghcr.io/varveio/swath:0.3.2 --version
 ```
 
 `--version` prints the swath version and commit; use its output for support requests and
@@ -79,7 +79,7 @@ Docker-free contributor loop and opt-in test tiers, see
 
 `--version` prints the version, commit, and Java runtime without contacting object
 storage, using the invocation shown for your install path above: `docker run --rm
-ghcr.io/varveio/swath:0.3.1 --version`, `java -jar swath-X.Y.Z.jar --version`, or plain
+ghcr.io/varveio/swath:0.3.2 --version`, `java -jar swath-X.Y.Z.jar --version`, or plain
 `swath --version` once a launcher is on `PATH`. Include this output when filing a
 support request or reproduction report.
 

--- a/docs/ops/dev/RELEASE_NOTES.md
+++ b/docs/ops/dev/RELEASE_NOTES.md
@@ -1,70 +1,60 @@
-# swath 0.3.1
+# swath 0.3.2
 
 ## User-facing changes
 
-- **`swath-replay` answers wide `delimiter=/` rollups through the Parquet page index.** A
-  common-prefix successor hop that stayed inside one physical row group used to keep its
-  forward key cursor, so the server decoded every key in the subtree it was meant to skip;
-  wide directory probes over a skewed fixture became CPU-bound inside boundary row groups.
-  The skip-scan now reopens the cursor through the Parquet page index when the successor
-  provably lies beyond the current data page, and keeps the forward cursor when the page's
-  own maximum says the target can still occur on it — so a huge skipped subtree costs one
-  page landing while dense, tiny directories are not re-decoded page by page. Responses are
-  byte-identical to the previous walk; only the work changes. In the recorded local
-  isolation run over a 143,008,674-row fixture, the widest directory probe moved from
-  392.7 ms to 22.4 ms mean and its continuation request from 63.6 ms to 7.0 ms.
-- **New replay meters expose the skip-scan's work.**
-  `swath.replay.delimiter.skipscan.decoded_key_rows` and `.page_reseeks` record, per native
-  rollup, the key rows its cursors decoded and the same-row-group page reseeks it took —
-  distinguishing page-bounded landing work from a sequential subtree walk.
-  `swath.replay.delimiter.reader_pool.readers_opened` records how many reader handles a
-  file's lazy delimiter pool opened on first touch, isolating cold pool construction from
-  query time. `swath.replay.delimiter.skipscan.row_group_opens` now counts cursor opens as
-  operations: after a reseek the same physical row group can be opened more than once.
-- **Sorted-serving order checking has its scope stated where it is enforced.** Startup
-  eligibility proves the ascent of row-group first keys; request-time cursors additionally
-  check every row they decode and refuse with
-  `swath.replay.serving.refused{reason=row_group_disorder}` on an inversion. Page-index and
-  routing-index shortcuts deliberately leave other rows unread, so that refusal is a
-  fail-stop guard on the request path, not an exhaustive validation of a malformed fixture.
-  This was already the behavior; the reader javadoc, `docs/swath-replay.md`, and the
-  metrics reference now say it plainly, and tests pin the contract from both sides.
-- **The `swath` CLI is unchanged.** The only change under `swath-core` is a passive
-  decoded-row counter in the shared sorted-Parquet key cursor; listing, output, resume, and
-  sorted finalization behavior are identical to 0.3.0.
+- **The listing pipeline's shared channel no longer wakes every parked fetch worker per page.**
+  All fetch workers hand their pages to the single output stage through one bounded channel.
+  Releasing a page used to broadcast to every sender parked on the budget, so with 2,048 workers
+  behind the default 50,000-entry budget the consumer paid more per page for the resulting wakeup
+  storm than for the sink write itself, and every dataset, stdout and `--sort` run was capped at
+  roughly 2,600 pages per second whatever the writer count (#206). The channel now relays one
+  wakeup per released page and an admitted sender relays onward while budget remains; the 50 ms
+  bounded wait stays as the lost-wakeup backstop. The `--object-listing-queue-size` contract,
+  including admission of one over-budget page into an empty channel, is unchanged (#209).
+- **Per-page row tallies move off the consumer thread.** Object, common-prefix, delete-marker and
+  object-byte counts are now computed on the fetch worker that built the page and carried on the
+  page; the dataset, sort and discard stages merge four numbers per page instead of walking every
+  entry on the one consumer thread. The stdout formatter keeps its per-entry tally, whose
+  broken-pipe truncation semantics depend on it.
+- **`client_cost[]` gains a `channel_receive` span** (`swath.channel.receive.latency`): the
+  consumer stage's own wait to take each page off the shared channel, the complement of `emit` on
+  its timeline. `docs/performance.md` says how to read the two together.
+- **Measured effect, one public bucket.** sentinel-cogs (1.069 billion objects, `us-west-2`),
+  compressed TSV dataset output, `--concurrency 2048`, run from GCP `us-east1` one day apart on
+  0.3.1 and on this change: listing phase 5 m 12 s → 4 m 25 s at 32 vCPU with 16 writers, and
+  5 m 32 s → 3 m 11 s at 64 vCPU with 32 writers, where 0.3.1 had gained nothing from the extra
+  cores. Steady-state page rates rose from about 3.4 million keys per second to 4.5 and 6.8
+  million respectively.
+- **Explainer and site.** The explainer report renders run provenance as a collapsed run record
+  (#199); the website source now lives in this repository and deploys from CI (#196); runnable
+  documentation examples are pinned to a release (#201).
 
 ## Evidence
 
-- PR #194 carries the change, a one-row-group adversarial regression (16 prefixes ×
-  1,000 keys must answer from page landings, not subtree decodes), a dense-singleton-prefix
-  test proving the hybrid keeps its forward cursor on a shared page with zero reseeks, a
-  successor/resume-boundary parity test against an independent in-memory rollup — including
-  a bare object exactly equal to `successor(P)` — and a disorder-contract pair: an
-  inversion wholly inside a pruned page is skipped with a correct answer and no refusal,
-  while an inversion on a decoded landing page still refuses with `row_group_disorder`.
-- The recorded local isolation run (4-core/8-thread host, `-Xmx4g`, warm filesystem cache,
-  eight readers, eight requests in flight) over a four-part, 143,008,674-row,
-  2.96 GiB AWS Public Blockchain fixture measured 14 request shapes; every baseline and
-  candidate response was byte-identical by SHA-256, the three high-subtree shapes improved
-  7.1–21.8× in mean latency, and the full method and table are retained in
-  `docs/ops/dev/field-investigations.md` (2026-09-01 entry).
-- The full sorted-vs-DuckDB differential and conformance suites passed on the change, and
-  the repository `build -PnoIntegration` gate was run on the merged head.
+- PR #209 carries the change with `ChannelRelaySignalTest` (senders straddling the budget all
+  complete and none waits beyond the backstop; the receiver-drop and interrupt exits relay their
+  wakeup), `PageTallyTest` and `PageBatchTest` (a tally whose row count disagrees with its payload
+  is rejected), and the existing weighted-bound and pipeline-shutdown tests unchanged. The full
+  `build` gate, including the LocalStack integration tier, ran green on the merged head.
+- A standalone channel harness in the shape of the failing runs (2,048 virtual-thread senders,
+  1,000-entry pages, a 50,000-entry budget, one receiver, 20 s on an 8-CPU host) moved from 9,513
+  to 237,870 items per second, the receiver's per-item cost from 105 µs to 4 µs, and the worst
+  single send wait from 19.9 s to 1.0 s.
+- The run reports of the sentinel-cogs pairs above (kept as `_swath_summary.json` by the
+  benchmark harness) show the consumer's `channel_receive` and `emit` medians at about 1 µs per
+  page on this release, the AIMD permit wait falling from 531 to 26 workers on average, and the
+  remaining wait moving to the dataset writer lanes.
 
 ## Limits and known issues
 
-- The recorded latencies are a local warm-cache isolation run at one sample per
-  configuration on one host and one fixture — an implementation-path check, not a
-  production S3 latency model or a portable throughput claim. Small already-cheap shapes
-  moved by single-digit milliseconds in both directions at that sample size; the
-  dense-small-directory claim is carried by unit coverage rather than that run.
-- Sorted serving continues to require a correctly stamped, sorted fixture. Order checking
-  covers decoded rows only; a malformed fixture whose disorder sits entirely inside skipped
-  pages can serve answers those page bounds make correct rather than being detected.
-  Re-sort a suspect capture or serve it with DuckDB mode.
-- Cold first-request cost on a large fixture still includes synchronously opening the
-  lazy per-file delimiter reader pool and first-use page/index warming; this release does
-  not redesign pool initialization.
-- Everything in the 0.3.0 notes' limits — resume scope, sorted staging portability, the
-  report `sort`-block carve-out, supported backends, and live-listing consistency — is
-  unchanged.
+- The throughput figures are single runs on one live public bucket from one placement, one day
+  apart; live buckets grow and S3 latency varies between runs. They are an implementation-path
+  check, not a portable throughput claim.
+- With the channel out of the way, the dataset dispatcher now waits on its sticky writer lane
+  while other lanes idle (`head_of_line_blocked_ms` in the run report): lanes were about 60 %
+  busy at 32 vCPU and 42 % at 64 vCPU. A routing change that removes that wait was measured
+  slower at `--concurrency 2048` because the freed workers cost more client CPU per key than
+  they return; it is not in this release. The engine's latency-inflation freeze (#202) is the
+  next limiter at that ceiling.
+- Everything in the 0.3.1 notes' limits — resume scope, sorted staging portability, the report
+  `sort`-block carve-out, supported backends, and live-listing consistency — is unchanged.

--- a/site/data/channel.json
+++ b/site/data/channel.json
@@ -1,4 +1,4 @@
 {
   "channel": "release",
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/site/field-guide/index.html
+++ b/site/field-guide/index.html
@@ -2357,7 +2357,7 @@
     <span class="mono">contracts.md</span>, and <span class="mono">build-and-modules.md</span> —
     which are re-derived from the shipped code. Where this page and the source disagree, the
     source wins.<br>
-    This guide describes swath 0.3.1.
+    This guide describes swath 0.3.2.
     swath is pre-1.0: <span class="mono">list</span> and <span class="mono">resume</span> ship;
     current-object listing from general-purpose AWS S3 buckets is supported, and GCS through its
     XML API is experimental S3-compatible interoperability rather than a native backend.

--- a/site/index.html
+++ b/site/index.html
@@ -638,7 +638,7 @@ swath $ swath list s3://noaa-gestofs-pds/ \
 
   <!-- This line must track the release this site is published for; update it in the same
        change as any release that moves the documented version forward. -->
-  <p class="version-line">Documentation for swath 0.3.1.</p>
+  <p class="version-line">Documentation for swath 0.3.2.</p>
 
   <footer>
     <p>


### PR DESCRIPTION
Release notes and changelog for 0.3.2: the shared pipeline channel's relay signalling and the fetch-worker page tally (#209, fixes #206), the new `channel_receive` client-cost span, and the measured effect on sentinel-cogs at 32 and 64 vCPU. The explainer/site changes since 0.3.1 (#196, #199, #201) are listed. `verify-release-notes.sh 0.3.2` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation, installation instructions, site pages, and release notes for version 0.3.2.
  - Documented improved shared-channel wakeup behavior, more efficient page tallying, and a new channel-receive latency metric.
  - Added measured throughput improvements and updated operational limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->