### PR TITLE
Release v0.3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.3.2-SNAPSHOT
+version=0.3.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.caching=true
 
 # Single source of truth for every Gradle-produced artifact. Release automation
 # verifies that a vX.Y.Z tag exactly matches this value before publishing.
-version=0.3.2
+version=0.3.3-SNAPSHOT


### PR DESCRIPTION
Release commit `acf0d509f238832ffe2f0fb608951be33e99ae6f` sets `gradle.properties` to 0.3.2; the follow-up commit begins 0.3.3 development. Merge with a merge commit (as #200 for 0.3.1), then the `v0.3.2` tag goes on `acf0d509f238832ffe2f0fb608951be33e99ae6f` and the release workflow publishes.